### PR TITLE
Fixes Duplicate entry 'page_title'... in admin/settings

### DIFF
--- a/application/libraries/Ilch/Config/Database.php
+++ b/application/libraries/Ilch/Config/Database.php
@@ -71,7 +71,7 @@ class Database
             ->where(array('key' => $key))
             ->execute();
 
-        if ($oldValue != null) {
+        if ($oldValue !== null) {
             if ($value !== $oldValue) {
                 $this->_db->update('config')
                     ->fields(array(


### PR DESCRIPTION
Der Fehler tritt auf sobald man keinen page_title eingetragen hat und die Einstellungen erneut speichert. Das gleiche Problem wuerde logischerweise auch bei jedem anderen Schluessel mit leerem Wert passieren.

``` php
'' == null
# => true
```
