### PR TITLE
Adds support for multidimensional arrays in Request->getPost()

### DIFF
--- a/application/libraries/Ilch/Request.php
+++ b/application/libraries/Ilch/Request.php
@@ -201,19 +201,35 @@ class Request
 
     /**
      * Get post-value by key.
-     *
+     * Supports 'dot' notation for arrays
+     * e.g.
+     *      foo.bar     > foo['bar']
+     *      foo.bar.baz > foo['bar']['baz']
      * @param  string $key
+     * @param  string $default This gets returned if $key does not exist
      * @return mixed
      */
-    public function getPost($key = '')
+    public function getPost($key = null, $default = null)
     {
-        if ($key === '') {
-            return $_POST;
-        } elseif (isset($_POST[$key])) {
-            return $_POST[$key];
-        } else {
-            return null;
+        $array = $_POST;
+
+        if (null === $key) {
+            return $array;
         }
+
+        if (isset($array[$key])) {
+            return $array[$key];
+        }
+
+        foreach (explode('.', $key) as $seg) {
+            if (! is_array($array) || ! array_key_exists($seg, $array)) {
+                return $default;
+            }
+
+            $array = $array[$seg];
+        }
+
+        return $array;
     }
 
     /**


### PR DESCRIPTION
Wenn man jetzt im Formular ein Array sendet und direkt auf irgendetwas verschachteltes zugreifen möchte, kann man einfach `Request::getPost('foo.bar.baz')` machen und bekommt dann eben den Wert von `$_POST['foo']['bar']['baz']` zurück. Das ist denke ich angenehmer als ein `Request::getPost('foo')['bar']['baz']` oder so und deutlich hübscher.

Außerdem kann man jetzt direkt einen Standardwert übergeben, der zurückgegeben wird, wenn der der gewünschte `$key` nicht gefunden wird. Beispiel: `Request::getPost('foo.bar', 'Nichts gefunden, deshalb werde ich zurückgegeben :)')`

Das sollte jetzt auch problemlos abwärtskompatibel sein, es hat sich halt lediglich der Standardwert bei leerem `$key` von `''` zu `null` geändert. Alles andere sollte passen.
