### PR TITLE
DB: Fixes Select::getTableSql() using the wrong table name when joini…

### DIFF
--- a/application/libraries/Ilch/Database/Mysql/Select.php
+++ b/application/libraries/Ilch/Database/Mysql/Select.php
@@ -387,7 +387,7 @@ class Select extends QueryBuilder
             $tableName = reset($table);
             $tableAlias = key($table);
         } else {
-            $tableName = $this->table;
+            $tableName = $table;
         }
 
         $sql = $this->db->quote('[prefix]_' . $tableName);


### PR DESCRIPTION
…ng tables without alias