### PR TITLE
Fix/comment empty array

### DIFF
--- a/application/modules/article/views/index/show.php
+++ b/application/modules/article/views/index/show.php
@@ -226,87 +226,85 @@ function rec($id, $uid, $req, $obj)
                     </form>
                 </div>
             <?php endif; ?>
-            <?php if ($comments != ''): ?>
-                <?php foreach ($comments as $comment): ?>
-                    <?php $user = $userMapper->getUserById($comment->getUserId()); ?>
-                    <?php $commentDate = new \Ilch\Date($comment->getDateCreated()); ?>
-                    <section class="comment-list">
-                        <article class="row" id="comment_<?=$comment->getId() ?>">
-                            <?php if ($config->get('comment_avatar') == 1): ?>
-                                <div class="col-md-2 col-sm-2 hidden-xs">
-                                    <figure class="thumbnail" title="<?=$user->getName() ?>">
-                                        <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$user->getAvatar() ?>" alt="<?=$this->escape($user->getName()) ?>"></a>
-                                    </figure>
-                                </div>
-                            <?php endif; ?>
-                            <div class="col-md-<?=$col ?> col-sm-<?=$col ?>">
-                                <div class="panel panel-default">
-                                    <div class="panel-bodylist">
-                                        <header class="text-left">
-                                            <div class="comment-user">
-                                                <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId())) ?>"><?=$this->escape($user->getName()) ?></a>
-                                            </div>
-                                            <?php if ($config->get('comment_date') == 1): ?>
-                                                <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$commentDate->format("d.m.Y - H:i", true) ?></time>
-                                            <?php endif; ?>
-                                        </header>
-                                        <div class="comment-post"><p><?=nl2br($this->escape($comment->getText())) ?></p></div>
-                                        <?php if ($this->getUser() AND $config->get('comment_reply') == 1): ?>
-                                            <p class="text-right"><a href="javascript:slideReply('reply_<?=$comment->getId() ?>');" class="btn btn-default btn-sm"><i class="fa fa-reply"></i> <?=$this->getTrans('reply') ?></a></p>
-                                        <?php endif; ?>
-                                    </div>
-                                </div>
-                            </div>
-                        </article>
-
-                        <?php if($this->getUser()): ?>
-                            <div class="replyHidden" id="reply_<?=$comment->getId() ?>">
-                                <form action="" class="form-horizontal" method="POST">
-                                    <?=$this->getTokenField() ?>
-                                    <article class="row">
-                                        <?php if ($config->get('comment_avatar') == 1): ?>
-                                            <div class="col-md-2 col-sm-2 col-md-offset-1 col-sm-offset-1 hidden-xs">
-                                                <figure class="thumbnail" title="<?=$this->getUser()->getName() ?>">
-                                                    <a href="<?=$this->getUrl('user/profil/index/user/'.$this->getUser()->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$this->getUser()->getAvatar() ?>" alt="<?=$this->getUser()->getName() ?>"></a>
-                                                </figure>
-                                            </div>
-                                        <?php endif; ?>
-                                        <div class="col-md-<?=$col+-1 ?> col-sm-<?=$col-1 ?>">
-                                            <div class="panel panel-default">
-                                                <div class="panel-body">
-                                                    <div class="panel-heading right"><i class="fa fa-reply"></i> <?=$this->escape($user->getName()) ?></div>
-                                                    <header class="text-left">
-                                                        <div class="comment-user">
-                                                            <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $this->getUser()->getId())) ?>"><?=$this->getUser()->getName() ?></a>
-                                                        </div>
-                                                        <?php if ($config->get('comment_date') == 1): ?>
-                                                            <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$nowDate->format("d.m.Y - H:i", true) ?></time>
-                                                        <?php endif; ?>
-                                                    </header>
-                                                    <div class="comment-post">
-                                                        <p>
-                                                            <textarea class="form-control"
-                                                                      accesskey=""
-                                                                      name="article_comment_text"
-                                                                      style="resize: vertical"
-                                                                      required></textarea>
-                                                        </p>
-                                                    </div>
-                                                    <input type="hidden" name="fkId" value="<?=$comment->getId() ?>" />
-                                                    <p class="text-right submit">
-                                                        <?=$this->getSaveBar('submit', 'Comment') ?>
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </article>
-                                </form>
+            <?php foreach ($comments as $comment): ?>
+                <?php $user = $userMapper->getUserById($comment->getUserId()); ?>
+                <?php $commentDate = new \Ilch\Date($comment->getDateCreated()); ?>
+                <section class="comment-list">
+                    <article class="row" id="comment_<?=$comment->getId() ?>">
+                        <?php if ($config->get('comment_avatar') == 1): ?>
+                            <div class="col-md-2 col-sm-2 hidden-xs">
+                                <figure class="thumbnail" title="<?=$user->getName() ?>">
+                                    <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$user->getAvatar() ?>" alt="<?=$this->escape($user->getName()) ?>"></a>
+                                </figure>
                             </div>
                         <?php endif; ?>
-                        <?php rec($comment->getId(), $comment->getUserId(), 1, $this) ?>
-                    </section>
-                <?php endforeach; ?>
-            <?php endif; ?>
+                        <div class="col-md-<?=$col ?> col-sm-<?=$col ?>">
+                            <div class="panel panel-default">
+                                <div class="panel-bodylist">
+                                    <header class="text-left">
+                                        <div class="comment-user">
+                                            <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId())) ?>"><?=$this->escape($user->getName()) ?></a>
+                                        </div>
+                                        <?php if ($config->get('comment_date') == 1): ?>
+                                            <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$commentDate->format("d.m.Y - H:i", true) ?></time>
+                                        <?php endif; ?>
+                                    </header>
+                                    <div class="comment-post"><p><?=nl2br($this->escape($comment->getText())) ?></p></div>
+                                    <?php if ($this->getUser() AND $config->get('comment_reply') == 1): ?>
+                                        <p class="text-right"><a href="javascript:slideReply('reply_<?=$comment->getId() ?>');" class="btn btn-default btn-sm"><i class="fa fa-reply"></i> <?=$this->getTrans('reply') ?></a></p>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+
+                    <?php if($this->getUser()): ?>
+                        <div class="replyHidden" id="reply_<?=$comment->getId() ?>">
+                            <form action="" class="form-horizontal" method="POST">
+                                <?=$this->getTokenField() ?>
+                                <article class="row">
+                                    <?php if ($config->get('comment_avatar') == 1): ?>
+                                        <div class="col-md-2 col-sm-2 col-md-offset-1 col-sm-offset-1 hidden-xs">
+                                            <figure class="thumbnail" title="<?=$this->getUser()->getName() ?>">
+                                                <a href="<?=$this->getUrl('user/profil/index/user/'.$this->getUser()->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$this->getUser()->getAvatar() ?>" alt="<?=$this->getUser()->getName() ?>"></a>
+                                            </figure>
+                                        </div>
+                                    <?php endif; ?>
+                                    <div class="col-md-<?=$col+-1 ?> col-sm-<?=$col-1 ?>">
+                                        <div class="panel panel-default">
+                                            <div class="panel-body">
+                                                <div class="panel-heading right"><i class="fa fa-reply"></i> <?=$this->escape($user->getName()) ?></div>
+                                                <header class="text-left">
+                                                    <div class="comment-user">
+                                                        <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $this->getUser()->getId())) ?>"><?=$this->getUser()->getName() ?></a>
+                                                    </div>
+                                                    <?php if ($config->get('comment_date') == 1): ?>
+                                                        <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$nowDate->format("d.m.Y - H:i", true) ?></time>
+                                                    <?php endif; ?>
+                                                </header>
+                                                <div class="comment-post">
+                                                    <p>
+                                                        <textarea class="form-control"
+                                                                  accesskey=""
+                                                                  name="article_comment_text"
+                                                                  style="resize: vertical"
+                                                                  required></textarea>
+                                                    </p>
+                                                </div>
+                                                <input type="hidden" name="fkId" value="<?=$comment->getId() ?>" />
+                                                <p class="text-right submit">
+                                                    <?=$this->getSaveBar('submit', 'Comment') ?>
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </article>
+                            </form>
+                        </div>
+                    <?php endif; ?>
+                    <?php rec($comment->getId(), $comment->getUserId(), 1, $this) ?>
+                </section>
+            <?php endforeach; ?>
         </div>
     </div>
 <?php endif; ?>

--- a/application/modules/comment/mappers/Comment.php
+++ b/application/modules/comment/mappers/Comment.php
@@ -11,7 +11,7 @@ use Modules\Comment\Models\Comment as CommentModel;
 class Comment extends \Ilch\Mapper
 {
     /**
-     * @return CommentModel[]|null
+     * @return CommentModel[]
      */
     public function getCommentsByKey($key)
     {
@@ -21,10 +21,6 @@ class Comment extends \Ilch\Mapper
             ->order(array('id' => 'DESC'))
             ->execute()
             ->fetchRows();
-
-        if (empty($commentsArray)) {
-            return null;
-        }
 
         $comments = array();
 
@@ -68,7 +64,7 @@ class Comment extends \Ilch\Mapper
     }
 
     /**
-     * @return CommentModel[]|null
+     * @return CommentModel[]
      */
     public function getComments()
     {
@@ -77,10 +73,6 @@ class Comment extends \Ilch\Mapper
             ->order(array('id' => 'DESC'))
             ->execute()
             ->fetchRows();
-
-        if (empty($commentsArray)) {
-            return NULL;
-        }
 
         $comments = array();
 

--- a/application/modules/comment/views/admin/index/index.php
+++ b/application/modules/comment/views/admin/index/index.php
@@ -3,7 +3,7 @@ $locale = $this->get('locale');
 ?>
 
 <legend><?=$this->getTrans('menuComments') ?></legend>
-<?php if ($this->get('comments') != ''): ?>
+<?php if (!empty($this->get('comments'))): ?>
     <form class="form-horizontal" method="POST" action="">
         <?=$this->getTokenField() ?>
         <div class="table-responsive">

--- a/application/modules/gallery/views/index/showimage.php
+++ b/application/modules/gallery/views/index/showimage.php
@@ -197,87 +197,85 @@ function rec($id, $uid, $req, $obj)
                 </form>
             </div>
         <?php endif; ?>
-        <?php if ($comments != ''): ?>
-            <?php foreach ($comments as $comment): ?>
-                <?php $user = $userMapper->getUserById($comment->getUserId()); ?>
-                <?php $commentDate = new \Ilch\Date($comment->getDateCreated()); ?>
-                <section class="comment-list">
-                    <article class="row" id="comment_<?=$comment->getId() ?>">
-                        <?php if ($config->get('comment_avatar') == 1): ?>
-                            <div class="col-md-2 col-sm-2 hidden-xs">
-                                <figure class="thumbnail" title="<?=$user->getName() ?>">
-                                    <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$user->getAvatar() ?>" alt="<?=$this->escape($user->getName()) ?>"></a>
-                                </figure>
-                            </div>
-                        <?php endif; ?>
-                        <div class="col-md-<?=$col ?> col-sm-<?=$col ?>">
-                            <div class="panel panel-default">
-                                <div class="panel-bodylist">
-                                    <header class="text-left">
-                                        <div class="comment-user">
-                                            <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId())) ?>"><?=$this->escape($user->getName()) ?></a>
-                                        </div>
-                                        <?php if ($config->get('comment_date') == 1): ?>
-                                            <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$commentDate->format("d.m.Y - H:i", true) ?></time>
-                                        <?php endif; ?>
-                                    </header>
-                                    <div class="comment-post"><p><?=nl2br($this->escape($comment->getText())) ?></p></div>
-                                    <?php if ($this->getUser() AND $config->get('comment_reply') == 1): ?>
-                                        <p class="text-right"><a href="javascript:slideReply('reply_<?=$comment->getId() ?>');" class="btn btn-default btn-sm"><i class="fa fa-reply"></i> <?=$this->getTrans('reply') ?></a></p>
-                                    <?php endif; ?>
-                                </div>
-                            </div>
-                        </div>
-                    </article>
-
-                    <?php if($this->getUser()): ?>
-                        <div class="replyHidden" id="reply_<?=$comment->getId() ?>">
-                            <form action="" class="form-horizontal" method="POST">
-                                <?=$this->getTokenField() ?>
-                                <article class="row">
-                                    <?php if ($config->get('comment_avatar') == 1): ?>
-                                        <div class="col-md-2 col-sm-2 col-md-offset-1 col-sm-offset-1 hidden-xs">
-                                            <figure class="thumbnail" title="<?=$this->getUser()->getName() ?>">
-                                                <a href="<?=$this->getUrl('user/profil/index/user/'.$this->getUser()->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$this->getUser()->getAvatar() ?>" alt="<?=$this->getUser()->getName() ?>"></a>
-                                            </figure>
-                                        </div>
-                                    <?php endif; ?>
-                                    <div class="col-md-<?=$col+-1 ?> col-sm-<?=$col-1 ?>">
-                                        <div class="panel panel-default">
-                                            <div class="panel-body">
-                                                <div class="panel-heading right"><i class="fa fa-reply"></i> <?=$this->escape($user->getName()) ?></div>
-                                                <header class="text-left">
-                                                    <div class="comment-user">
-                                                        <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $this->getUser()->getId())) ?>"><?=$this->getUser()->getName() ?></a>
-                                                    </div>
-                                                    <?php if ($config->get('comment_date') == 1): ?>
-                                                        <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$nowDate->format("d.m.Y - H:i", true) ?></time>
-                                                    <?php endif; ?>
-                                                </header>
-                                                <div class="comment-post">
-                                                    <p>
-                                                        <textarea class="form-control"
-                                                                  accesskey=""
-                                                                  name="gallery_comment_text"
-                                                                  style="resize: vertical"
-                                                                  required></textarea>
-                                                    </p>
-                                                </div>
-                                                <input type="hidden" name="fkId" value="<?=$comment->getId() ?>" />
-                                                <p class="text-right submit">
-                                                    <?=$this->getSaveBar('submit', 'Comment') ?>
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </article>
-                            </form>
+        <?php foreach ($comments as $comment): ?>
+            <?php $user = $userMapper->getUserById($comment->getUserId()); ?>
+            <?php $commentDate = new \Ilch\Date($comment->getDateCreated()); ?>
+            <section class="comment-list">
+                <article class="row" id="comment_<?=$comment->getId() ?>">
+                    <?php if ($config->get('comment_avatar') == 1): ?>
+                        <div class="col-md-2 col-sm-2 hidden-xs">
+                            <figure class="thumbnail" title="<?=$user->getName() ?>">
+                                <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$user->getAvatar() ?>" alt="<?=$this->escape($user->getName()) ?>"></a>
+                            </figure>
                         </div>
                     <?php endif; ?>
-                    <?php rec($comment->getId(), $comment->getUserId(), 1, $this) ?>
-                </section>
-            <?php endforeach; ?>
-        <?php endif; ?>
+                    <div class="col-md-<?=$col ?> col-sm-<?=$col ?>">
+                        <div class="panel panel-default">
+                            <div class="panel-bodylist">
+                                <header class="text-left">
+                                    <div class="comment-user">
+                                        <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId())) ?>"><?=$this->escape($user->getName()) ?></a>
+                                    </div>
+                                    <?php if ($config->get('comment_date') == 1): ?>
+                                        <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$commentDate->format("d.m.Y - H:i", true) ?></time>
+                                    <?php endif; ?>
+                                </header>
+                                <div class="comment-post"><p><?=nl2br($this->escape($comment->getText())) ?></p></div>
+                                <?php if ($this->getUser() AND $config->get('comment_reply') == 1): ?>
+                                    <p class="text-right"><a href="javascript:slideReply('reply_<?=$comment->getId() ?>');" class="btn btn-default btn-sm"><i class="fa fa-reply"></i> <?=$this->getTrans('reply') ?></a></p>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+
+                <?php if($this->getUser()): ?>
+                    <div class="replyHidden" id="reply_<?=$comment->getId() ?>">
+                        <form action="" class="form-horizontal" method="POST">
+                            <?=$this->getTokenField() ?>
+                            <article class="row">
+                                <?php if ($config->get('comment_avatar') == 1): ?>
+                                    <div class="col-md-2 col-sm-2 col-md-offset-1 col-sm-offset-1 hidden-xs">
+                                        <figure class="thumbnail" title="<?=$this->getUser()->getName() ?>">
+                                            <a href="<?=$this->getUrl('user/profil/index/user/'.$this->getUser()->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$this->getUser()->getAvatar() ?>" alt="<?=$this->getUser()->getName() ?>"></a>
+                                        </figure>
+                                    </div>
+                                <?php endif; ?>
+                                <div class="col-md-<?=$col+-1 ?> col-sm-<?=$col-1 ?>">
+                                    <div class="panel panel-default">
+                                        <div class="panel-body">
+                                            <div class="panel-heading right"><i class="fa fa-reply"></i> <?=$this->escape($user->getName()) ?></div>
+                                            <header class="text-left">
+                                                <div class="comment-user">
+                                                    <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $this->getUser()->getId())) ?>"><?=$this->getUser()->getName() ?></a>
+                                                </div>
+                                                <?php if ($config->get('comment_date') == 1): ?>
+                                                    <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$nowDate->format("d.m.Y - H:i", true) ?></time>
+                                                <?php endif; ?>
+                                            </header>
+                                            <div class="comment-post">
+                                                <p>
+                                                    <textarea class="form-control"
+                                                              accesskey=""
+                                                              name="gallery_comment_text"
+                                                              style="resize: vertical"
+                                                              required></textarea>
+                                                </p>
+                                            </div>
+                                            <input type="hidden" name="fkId" value="<?=$comment->getId() ?>" />
+                                            <p class="text-right submit">
+                                                <?=$this->getSaveBar('submit', 'Comment') ?>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </article>
+                        </form>
+                    </div>
+                <?php endif; ?>
+                <?php rec($comment->getId(), $comment->getUserId(), 1, $this) ?>
+            </section>
+        <?php endforeach; ?>
     </div>
 </div>
 

--- a/application/modules/user/views/gallery/showimage.php
+++ b/application/modules/user/views/gallery/showimage.php
@@ -198,87 +198,85 @@ function rec($id, $uid, $req, $obj)
                 </form>
             </div>
         <?php endif; ?>
-        <?php if ($comments != ''): ?>
-            <?php foreach ($comments as $comment): ?>
-                <?php $user = $userMapper->getUserById($comment->getUserId()); ?>
-                <?php $commentDate = new \Ilch\Date($comment->getDateCreated()); ?>
-                <section class="comment-list">
-                    <article class="row" id="comment_<?=$comment->getId() ?>">
-                        <?php if ($config->get('comment_avatar') == 1): ?>
-                            <div class="col-md-2 col-sm-2 hidden-xs">
-                                <figure class="thumbnail" title="<?=$user->getName() ?>">
-                                    <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$user->getAvatar() ?>" alt="<?=$this->escape($user->getName()) ?>"></a>
-                                </figure>
-                            </div>
-                        <?php endif; ?>
-                        <div class="col-md-<?=$col ?> col-sm-<?=$col ?>">
-                            <div class="panel panel-default">
-                                <div class="panel-bodylist">
-                                    <header class="text-left">
-                                        <div class="comment-user">
-                                            <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId())) ?>"><?=$this->escape($user->getName()) ?></a>
-                                        </div>
-                                        <?php if ($config->get('comment_date') == 1): ?>
-                                            <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$commentDate->format("d.m.Y - H:i", true) ?></time>
-                                        <?php endif; ?>
-                                    </header>
-                                    <div class="comment-post"><p><?=nl2br($this->escape($comment->getText())) ?></p></div>
-                                    <?php if ($this->getUser() AND $config->get('comment_reply') == 1): ?>
-                                        <p class="text-right"><a href="javascript:slideReply('reply_<?=$comment->getId() ?>');" class="btn btn-default btn-sm"><i class="fa fa-reply"></i> <?=$this->getTrans('reply') ?></a></p>
-                                    <?php endif; ?>
-                                </div>
-                            </div>
-                        </div>
-                    </article>
-
-                    <?php if($this->getUser()): ?>
-                        <div class="replyHidden" id="reply_<?=$comment->getId() ?>">
-                            <form action="" class="form-horizontal" method="POST">
-                                <?=$this->getTokenField() ?>
-                                <article class="row">
-                                    <?php if ($config->get('comment_avatar') == 1): ?>
-                                        <div class="col-md-2 col-sm-2 col-md-offset-1 col-sm-offset-1 hidden-xs">
-                                            <figure class="thumbnail" title="<?=$this->getUser()->getName() ?>">
-                                                <a href="<?=$this->getUrl('user/profil/index/user/'.$this->getUser()->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$this->getUser()->getAvatar() ?>" alt="<?=$this->getUser()->getName() ?>"></a>
-                                            </figure>
-                                        </div>
-                                    <?php endif; ?>
-                                    <div class="col-md-<?=$col+-1 ?> col-sm-<?=$col-1 ?>">
-                                        <div class="panel panel-default">
-                                            <div class="panel-body">
-                                                <div class="panel-heading right"><i class="fa fa-reply"></i> <?=$this->escape($user->getName()) ?></div>
-                                                <header class="text-left">
-                                                    <div class="comment-user">
-                                                        <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $this->getUser()->getId())) ?>"><?=$this->getUser()->getName() ?></a>
-                                                    </div>
-                                                    <?php if ($config->get('comment_date') == 1): ?>
-                                                        <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$nowDate->format("d.m.Y - H:i", true) ?></time>
-                                                    <?php endif; ?>
-                                                </header>
-                                                <div class="comment-post">
-                                                    <p>
-                                                        <textarea class="form-control"
-                                                                  accesskey=""
-                                                                  name="gallery_comment_text"
-                                                                  style="resize: vertical"
-                                                                  required></textarea>
-                                                    </p>
-                                                </div>
-                                                <input type="hidden" name="fkId" value="<?=$comment->getId() ?>" />
-                                                <p class="text-right submit">
-                                                    <?=$this->getSaveBar('submit', 'Comment') ?>
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </article>
-                            </form>
+        <?php foreach ($comments as $comment): ?>
+            <?php $user = $userMapper->getUserById($comment->getUserId()); ?>
+            <?php $commentDate = new \Ilch\Date($comment->getDateCreated()); ?>
+            <section class="comment-list">
+                <article class="row" id="comment_<?=$comment->getId() ?>">
+                    <?php if ($config->get('comment_avatar') == 1): ?>
+                        <div class="col-md-2 col-sm-2 hidden-xs">
+                            <figure class="thumbnail" title="<?=$user->getName() ?>">
+                                <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$user->getAvatar() ?>" alt="<?=$this->escape($user->getName()) ?>"></a>
+                            </figure>
                         </div>
                     <?php endif; ?>
-                    <?php rec($comment->getId(), $comment->getUserId(), 1, $this) ?>
-                </section>
-            <?php endforeach; ?>
-        <?php endif; ?>
+                    <div class="col-md-<?=$col ?> col-sm-<?=$col ?>">
+                        <div class="panel panel-default">
+                            <div class="panel-bodylist">
+                                <header class="text-left">
+                                    <div class="comment-user">
+                                        <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId())) ?>"><?=$this->escape($user->getName()) ?></a>
+                                    </div>
+                                    <?php if ($config->get('comment_date') == 1): ?>
+                                        <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$commentDate->format("d.m.Y - H:i", true) ?></time>
+                                    <?php endif; ?>
+                                </header>
+                                <div class="comment-post"><p><?=nl2br($this->escape($comment->getText())) ?></p></div>
+                                <?php if ($this->getUser() AND $config->get('comment_reply') == 1): ?>
+                                    <p class="text-right"><a href="javascript:slideReply('reply_<?=$comment->getId() ?>');" class="btn btn-default btn-sm"><i class="fa fa-reply"></i> <?=$this->getTrans('reply') ?></a></p>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+
+                <?php if($this->getUser()): ?>
+                    <div class="replyHidden" id="reply_<?=$comment->getId() ?>">
+                        <form action="" class="form-horizontal" method="POST">
+                            <?=$this->getTokenField() ?>
+                            <article class="row">
+                                <?php if ($config->get('comment_avatar') == 1): ?>
+                                    <div class="col-md-2 col-sm-2 col-md-offset-1 col-sm-offset-1 hidden-xs">
+                                        <figure class="thumbnail" title="<?=$this->getUser()->getName() ?>">
+                                            <a href="<?=$this->getUrl('user/profil/index/user/'.$this->getUser()->getId()) ?>"><img class="img-responsive" src="<?=$this->getUrl().'/'.$this->getUser()->getAvatar() ?>" alt="<?=$this->getUser()->getName() ?>"></a>
+                                        </figure>
+                                    </div>
+                                <?php endif; ?>
+                                <div class="col-md-<?=$col+-1 ?> col-sm-<?=$col-1 ?>">
+                                    <div class="panel panel-default">
+                                        <div class="panel-body">
+                                            <div class="panel-heading right"><i class="fa fa-reply"></i> <?=$this->escape($user->getName()) ?></div>
+                                            <header class="text-left">
+                                                <div class="comment-user">
+                                                    <i class="fa fa-user" title="<?=$this->getTrans('commentUser') ?>"></i> <a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $this->getUser()->getId())) ?>"><?=$this->getUser()->getName() ?></a>
+                                                </div>
+                                                <?php if ($config->get('comment_date') == 1): ?>
+                                                    <time class="comment-date"><i class="fa fa-clock-o" title="<?=$this->getTrans('commentDateTime') ?>"></i> <?=$nowDate->format("d.m.Y - H:i", true) ?></time>
+                                                <?php endif; ?>
+                                            </header>
+                                            <div class="comment-post">
+                                                <p>
+                                                    <textarea class="form-control"
+                                                              accesskey=""
+                                                              name="gallery_comment_text"
+                                                              style="resize: vertical"
+                                                              required></textarea>
+                                                </p>
+                                            </div>
+                                            <input type="hidden" name="fkId" value="<?=$comment->getId() ?>" />
+                                            <p class="text-right submit">
+                                                <?=$this->getSaveBar('submit', 'Comment') ?>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </article>
+                        </form>
+                    </div>
+                <?php endif; ?>
+                <?php rec($comment->getId(), $comment->getUserId(), 1, $this) ?>
+            </section>
+        <?php endforeach; ?>
     </div>
 </div>
 


### PR DESCRIPTION
getCommentsByKey() and getComments() no longer return null. They now return an empty array.
Adjusted the callers of these functions accordingly. An example for such an adjustement is that checks for '' (for null) are removed.

When a foreach-iteration receives an empty array as argument it doesn't even run the code-block ones.

These changes fix the following bug, too:
http://www.ilch.de/forum-showposts-53325.html

> Warning: Invalid argument supplied for foreach() in ...\application\modules\downloads\views\index\showfile.php on line 54 