### PR TITLE
Fix/media ext size

### DIFF
--- a/application/libraries/Ilch/Upload.php
+++ b/application/libraries/Ilch/Upload.php
@@ -316,7 +316,7 @@ class Upload extends \Ilch\Controller\Base
         return in_array($this->getEnding(), explode(' ', $this->getAllowedExtensions()));
     }
 
-    public function return_bytes($val) {
+    public function returnBytes($val) {
         $val = trim($val);
         $last = strtolower($val[strlen($val)-1]);
         switch($last) {

--- a/application/libraries/Ilch/Upload.php
+++ b/application/libraries/Ilch/Upload.php
@@ -47,6 +47,11 @@ class Upload extends \Ilch\Controller\Base
     protected $types;
 
     /**
+     * @var string $allowedExtensions
+     */
+    protected $allowedExtensions;
+
+    /**
      * @var string $path
      */
     protected $path;
@@ -208,6 +213,26 @@ class Upload extends \Ilch\Controller\Base
     }
 
     /**
+     * @param string $allowedExtensions
+     *
+     * @return string allowedExtensions
+     */
+    public function setAllowedExtensions($allowedExtensions)
+    {
+        $this->allowedExtensions = $allowedExtensions;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAllowedExtensions()
+    {
+        return $this->allowedExtensions;
+    }
+
+    /**
      * @param string $path
      *
      * @return string path
@@ -285,6 +310,26 @@ class Upload extends \Ilch\Controller\Base
                 $thumb -> Createthumb($this->path.$hash.'.'.$this->getEnding(),'file');
             }
         }
+    }
+
+    public function isAllowedExtension() {
+        return in_array($this->getEnding(), explode(' ', $this->getAllowedExtensions()));
+    }
+
+    public function return_bytes($val) {
+        $val = trim($val);
+        $last = strtolower($val[strlen($val)-1]);
+        switch($last) {
+            // The 'G' modifier is available since PHP 5.1.0
+            case 'g':
+                $val *= 1024;
+            case 'm':
+                $val *= 1024;
+            case 'k':
+                $val *= 1024;
+        }
+
+        return $val;
     }
 
     public function save()

--- a/application/modules/media/controllers/admin/Index.php
+++ b/application/modules/media/controllers/admin/Index.php
@@ -107,6 +107,10 @@ class Index extends \Ilch\Controller\Admin
                 ->add($this->getTranslator()->trans('media'), array('action' => 'index'))
                 ->add($this->getTranslator()->trans('mediaUpload'), array('action' => 'upload'));
 
+        $this->getView()->set('media_ext_img', $this->getConfig()->get('media_ext_img'));
+        $this->getView()->set('media_ext_file', $this->getConfig()->get('media_ext_file'));
+        $this->getView()->set('media_ext_video', $this->getConfig()->get('media_ext_video'));
+
         if (!is_writable(APPLICATION_PATH.'/../'.$this->getConfig()->get('media_uploadpath'))) {
             $this->addMessage('writableMedia', 'danger');
         }

--- a/application/modules/media/controllers/admin/Index.php
+++ b/application/modules/media/controllers/admin/Index.php
@@ -125,7 +125,7 @@ class Index extends \Ilch\Controller\Admin
             // Early return if extension is not allowed or file is too big. Should normally already be done client-side.
             // Doing this client-side is especially important for the "file too big"-case as early returning here is already too late.
             $upload->setAllowedExtensions($allowedExtensions);
-            if(!$upload->isAllowedExtension() || filesize($_FILES['upl']['name']) > $upload->return_bytes(ini_get('upload_max_filesize'))) {
+            if(!$upload->isAllowedExtension() || filesize($_FILES['upl']['name']) > $upload->returnBytes(ini_get('upload_max_filesize'))) {
                 return;
             }
             $upload->upload();

--- a/application/modules/media/static/js/script.js
+++ b/application/modules/media/static/js/script.js
@@ -21,15 +21,23 @@ $(function(){
             var tpl = $('<li class="working"><input type="text" value="0" data-width="48" data-height="48"'+
                 ' data-fgColor="#00AEFF" data-readOnly="1" data-bgColor="#3e4043" /><p></p><b class="suss-none">Finish</b><span class=""></span></li>');
 
-            // Append the file name and file size
-            tpl.find('p').text(data.files[0].name)
-                         .append('<i>' + formatFileSize(data.files[0].size) + '</i>');
-
+            if(data.files[0].size <= maxFileSize) {
+                // Append the file name and file size
+                tpl.find('p').text(data.files[0].name)
+                             .append('<i>' + formatFileSize(data.files[0].size) + '</i>');
+            } else {
+                tpl.find('p').text(messageFileTooBig);
+            }
+            
             // Add the HTML to the UL element
             data.context = tpl.appendTo(ul);
 
             // Initialize the knob plugin
             tpl.find('input').knob();
+
+            if(data.files[0].size > maxFileSize) {
+                return;
+            }
 
             // Listen for clicks on the cancel icon
             tpl.find('span').click(function(){

--- a/application/modules/media/static/js/script.js
+++ b/application/modules/media/static/js/script.js
@@ -21,21 +21,26 @@ $(function(){
             var tpl = $('<li class="working"><input type="text" value="0" data-width="48" data-height="48"'+
                 ' data-fgColor="#00AEFF" data-readOnly="1" data-bgColor="#3e4043" /><p></p><b class="suss-none">Finish</b><span class=""></span></li>');
 
-            if(data.files[0].size <= maxFileSize) {
+            var re = /(?:\.([^.]+))?$/;
+            var ext = re.exec(data.files[0].name)[1];
+
+            if(jQuery.inArray(ext,allowedExtensions) == -1) {
+               tpl.find('p').text(messageExtensionNotAllowed);
+            } else if(data.files[0].size <= maxFileSize) {
                 // Append the file name and file size
                 tpl.find('p').text(data.files[0].name)
                              .append('<i>' + formatFileSize(data.files[0].size) + '</i>');
             } else {
                 tpl.find('p').text(messageFileTooBig);
             }
-            
+
             // Add the HTML to the UL element
             data.context = tpl.appendTo(ul);
 
             // Initialize the knob plugin
             tpl.find('input').knob();
 
-            if(data.files[0].size > maxFileSize) {
+            if(data.files[0].size > maxFileSize || jQuery.inArray(ext,allowedExtensions) == -1) {
                 return;
             }
 

--- a/application/modules/media/static/js/script.js
+++ b/application/modules/media/static/js/script.js
@@ -21,17 +21,19 @@ $(function(){
             var tpl = $('<li class="working"><input type="text" value="0" data-width="48" data-height="48"'+
                 ' data-fgColor="#00AEFF" data-readOnly="1" data-bgColor="#3e4043" /><p></p><b class="suss-none">Finish</b><span class=""></span></li>');
 
+            // regular expression to get the file-extension
             var re = /(?:\.([^.]+))?$/;
             var ext = re.exec(data.files[0].name)[1];
 
             if(jQuery.inArray(ext,allowedExtensions) == -1) {
-               tpl.find('p').text(messageExtensionNotAllowed);
+                // File-extension is not one of the allowed ones
+                tpl.find('p').text(extensionNotAllowed);
             } else if(data.files[0].size <= maxFileSize) {
                 // Append the file name and file size
                 tpl.find('p').text(data.files[0].name)
                              .append('<i>' + formatFileSize(data.files[0].size) + '</i>');
             } else {
-                tpl.find('p').text(messageFileTooBig);
+                tpl.find('p').text(fileTooBig);
             }
 
             // Add the HTML to the UL element

--- a/application/modules/media/translations/de.php
+++ b/application/modules/media/translations/de.php
@@ -32,6 +32,7 @@ return array
     'browse' => 'Browse',
     'allowedMediaInfoText' => 'Hier kannst du die erlaubten Endungen einstellen. <br/> Schreibe die Endungen hinter einander und nur getrennt durch ein Leerzeichen.<br/> Sei dir im klaren das eine Endung wie z.B. "jpeg" nur bei erlaubte Bilder vorkommen darf und nicht bei erlaubte Videos oder erlaubte Files zu suchen hat!',
     'importInfoText' => 'Hier kannst du neue Dateien hinzufügen, die sich im Upload Ordner befinden, jedoch noch nicht in der Datenbank. Dies ist besonders hilfreich bei größeren Dateien, die ganz einfach per FTP in den Upload Ordner geladen werden können.',
+    'fileTooBig' => 'Die Datei ist zu groß.',
 
     'cats' => 'Kategorien',
     'cat' => 'Kategorie',

--- a/application/modules/media/translations/de.php
+++ b/application/modules/media/translations/de.php
@@ -33,6 +33,7 @@ return array
     'allowedMediaInfoText' => 'Hier kannst du die erlaubten Endungen einstellen. <br/> Schreibe die Endungen hinter einander und nur getrennt durch ein Leerzeichen.<br/> Sei dir im klaren das eine Endung wie z.B. "jpeg" nur bei erlaubte Bilder vorkommen darf und nicht bei erlaubte Videos oder erlaubte Files zu suchen hat!',
     'importInfoText' => 'Hier kannst du neue Dateien hinzufügen, die sich im Upload Ordner befinden, jedoch noch nicht in der Datenbank. Dies ist besonders hilfreich bei größeren Dateien, die ganz einfach per FTP in den Upload Ordner geladen werden können.',
     'fileTooBig' => 'Die Datei ist zu groß.',
+    'extensionNotAllowed' => 'Dateien mit dieser Dateiendung sind nicht erlaubt.',
 
     'cats' => 'Kategorien',
     'cat' => 'Kategorie',

--- a/application/modules/media/translations/en.php
+++ b/application/modules/media/translations/en.php
@@ -32,6 +32,7 @@ return array
     'browse' => 'Browse',
     'allowedMediaInfoText' => 'Here you can set the allowed extensions. Write <br/> the endings after another and only separated by a space <br/>. Be aware that you use an extension such as may "jpeg" only allowed images appear and has not allowed to look at videos or allowed Files!',
     'importInfoText' => 'Here you can add new files from the upload folder, but there are not in the database. This is particularly useful for large files, that can be easily uploaded via FTP to the upload folder.',
+    'FileTooBig' => 'The file is too big.',
 
     'cats' => 'Categories',
     'cat' => 'Categorie',

--- a/application/modules/media/translations/en.php
+++ b/application/modules/media/translations/en.php
@@ -33,6 +33,7 @@ return array
     'allowedMediaInfoText' => 'Here you can set the allowed extensions. Write <br/> the endings after another and only separated by a space <br/>. Be aware that you use an extension such as may "jpeg" only allowed images appear and has not allowed to look at videos or allowed Files!',
     'importInfoText' => 'Here you can add new files from the upload folder, but there are not in the database. This is particularly useful for large files, that can be easily uploaded via FTP to the upload folder.',
     'FileTooBig' => 'The file is too big.',
+    'extensionNotAllowed' => 'Files with this extension are not allowed.',
 
     'cats' => 'Categories',
     'cat' => 'Categorie',

--- a/application/modules/media/views/admin/index/upload.php
+++ b/application/modules/media/views/admin/index/upload.php
@@ -49,7 +49,7 @@ function toJavaScriptArray($array) {
 }
 ?>
 <script language="javascript">
-    const allowedExtensions = <?=toJavaScriptArray(explode(' ',$this->get('media_ext_img') . $this->get('media_ext_file') . $this->get('media_ext_video')));?>;
+    const allowedExtensions = <?=toJavaScriptArray(explode(' ',$this->get('allowedExtensions')));?>;
     var maxFileSize = <?=return_bytes(ini_get('upload_max_filesize'));?>;
     var fileTooBig = '<?=$this->getTrans('fileTooBig');?>';
     var extensionNotAllowed = '<?=$this->getTrans('extensionNotAllowed');?>';

--- a/application/modules/media/views/admin/index/upload.php
+++ b/application/modules/media/views/admin/index/upload.php
@@ -51,8 +51,8 @@ function toJavaScriptArray($array) {
 <script language="javascript">
     const allowedExtensions = <?=toJavaScriptArray(explode(' ',$this->get('media_ext_img') . $this->get('media_ext_file') . $this->get('media_ext_video')));?>;
     var maxFileSize = <?=return_bytes(ini_get('upload_max_filesize'));?>;
-    var messageFileTooBig = '<?=$this->getTrans('fileTooBig');?>';
-    var messageExtensionNotAllowed = '<?=$this->getTrans('extensionNotAllowed');?>';
+    var fileTooBig = '<?=$this->getTrans('fileTooBig');?>';
+    var extensionNotAllowed = '<?=$this->getTrans('extensionNotAllowed');?>';
    $(document).ready(function(){
 	$("[rel='tooltip']").tooltip();
     });

--- a/application/modules/media/views/admin/index/upload.php
+++ b/application/modules/media/views/admin/index/upload.php
@@ -19,21 +19,7 @@
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/script.js') ?>"></script>
 
 <?php
-function return_bytes($val) {
-    $val = trim($val);
-    $last = strtolower($val[strlen($val)-1]);
-    switch($last) {
-        // The 'G' modifier is available since PHP 5.1.0
-        case 'g':
-            $val *= 1024;
-        case 'm':
-            $val *= 1024;
-        case 'k':
-            $val *= 1024;
-    }
-
-    return $val;
-}
+$ilchUpload = new \Ilch\Upload();
 
 function toJavaScriptArray($array) {
     $arrayString = 'Array(';
@@ -50,7 +36,7 @@ function toJavaScriptArray($array) {
 ?>
 <script language="javascript">
     const allowedExtensions = <?=toJavaScriptArray(explode(' ',$this->get('allowedExtensions')));?>;
-    var maxFileSize = <?=return_bytes(ini_get('upload_max_filesize'));?>;
+    var maxFileSize = <?=$ilchUpload->returnBytes(ini_get('upload_max_filesize'));?>;
     var fileTooBig = <?=json_encode($this->getTrans('fileTooBig'));?>;
     var extensionNotAllowed = <?=json_encode($this->getTrans('extensionNotAllowed'));?>;
    $(document).ready(function(){

--- a/application/modules/media/views/admin/index/upload.php
+++ b/application/modules/media/views/admin/index/upload.php
@@ -17,7 +17,27 @@
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/jquery.iframe-transport.js') ?>"></script>
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/jquery.fileupload.js') ?>"></script>
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/script.js') ?>"></script>
+
+<?php
+function return_bytes($val) {
+    $val = trim($val);
+    $last = strtolower($val[strlen($val)-1]);
+    switch($last) {
+        // The 'G' modifier is available since PHP 5.1.0
+        case 'g':
+            $val *= 1024;
+        case 'm':
+            $val *= 1024;
+        case 'k':
+            $val *= 1024;
+    }
+
+    return $val;
+}
+?>
 <script language="javascript">
+    var maxFileSize = <?=return_bytes(ini_get('upload_max_filesize'));?>;
+    var messageFileTooBig = '<?=$this->getTrans('fileTooBig');?>';
    $(document).ready(function(){
 	$("[rel='tooltip']").tooltip();
     });

--- a/application/modules/media/views/admin/index/upload.php
+++ b/application/modules/media/views/admin/index/upload.php
@@ -51,8 +51,8 @@ function toJavaScriptArray($array) {
 <script language="javascript">
     const allowedExtensions = <?=toJavaScriptArray(explode(' ',$this->get('allowedExtensions')));?>;
     var maxFileSize = <?=return_bytes(ini_get('upload_max_filesize'));?>;
-    var fileTooBig = '<?=$this->getTrans('fileTooBig');?>';
-    var extensionNotAllowed = '<?=$this->getTrans('extensionNotAllowed');?>';
+    var fileTooBig = <?=json_encode($this->getTrans('fileTooBig'));?>;
+    var extensionNotAllowed = <?=json_encode($this->getTrans('extensionNotAllowed'));?>;
    $(document).ready(function(){
 	$("[rel='tooltip']").tooltip();
     });

--- a/application/modules/media/views/admin/index/upload.php
+++ b/application/modules/media/views/admin/index/upload.php
@@ -34,10 +34,25 @@ function return_bytes($val) {
 
     return $val;
 }
+
+function toJavaScriptArray($array) {
+    $arrayString = 'Array(';
+    for($i = 0; $i < count($array); ++$i) {
+        $arrayString = $arrayString . '\'' . $array[$i] . '\'';
+        if($i < count($array)-1) {
+            $arrayString = $arrayString . ',';
+        }
+    }
+
+    $arrayString = $arrayString . ')';
+    return $arrayString;
+}
 ?>
 <script language="javascript">
+    const allowedExtensions = <?=toJavaScriptArray(explode(' ',$this->get('media_ext_img') . $this->get('media_ext_file') . $this->get('media_ext_video')));?>;
     var maxFileSize = <?=return_bytes(ini_get('upload_max_filesize'));?>;
     var messageFileTooBig = '<?=$this->getTrans('fileTooBig');?>';
+    var messageExtensionNotAllowed = '<?=$this->getTrans('extensionNotAllowed');?>';
    $(document).ready(function(){
 	$("[rel='tooltip']").tooltip();
     });

--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -496,7 +496,7 @@ class Panel extends BaseController
             // Early return if extension is not allowed or file is too big. Should normally already be done client-side.
             // Doing this client-side is especially important for the "file too big"-case as early returning here is already too late.
             $upload->setAllowedExtensions($allowedExtensions);
-            if(!$upload->isAllowedExtension() || filesize($_FILES['upl']['name']) > $upload->return_bytes(ini_get('upload_max_filesize'))) {
+            if(!$upload->isAllowedExtension() || filesize($_FILES['upl']['name']) > $upload->returnBytes(ini_get('upload_max_filesize'))) {
                 return;
             }
             $upload->upload();

--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -477,6 +477,9 @@ class Panel extends BaseController
                 ->add($this->getTranslator()->trans('media'), array('action' => 'index'))
                 ->add($this->getTranslator()->trans('mediaUpload'), array('action' => 'upload'));
 
+        $allowedExtensions = $this->getConfig()->get('media_ext_img');
+        $this->getView()->set('allowedExtensions', $allowedExtensions);
+
         if (!is_writable(APPLICATION_PATH.'/../'.$this->getConfig()->get('usergallery_uploadpath'))) {
             $this->addMessage('writableMedia', 'danger');
         }
@@ -490,6 +493,12 @@ class Panel extends BaseController
             $upload->setFile($_FILES['upl']['name']);
             $upload->setTypes($this->getConfig()->get('usergallery_filetypes'));
             $upload->setPath($this->getConfig()->get('usergallery_uploadpath').$this->getUser()->getId().'/');
+            // Early return if extension is not allowed or file is too big. Should normally already be done client-side.
+            // Doing this client-side is especially important for the "file too big"-case as early returning here is already too late.
+            $upload->setAllowedExtensions($allowedExtensions);
+            if(!$upload->isAllowedExtension() || filesize($_FILES['upl']['name']) > $upload->return_bytes(ini_get('upload_max_filesize'))) {
+                return;
+            }
             $upload->upload();
 
             $model = new MediaModel();


### PR DESCRIPTION
This is a try to fix ticket 228 and 244.

Added basic checks on client-side to make sure the file is not too big and that it has one of the allowed file extensions. This avoids useless uploading of files with wrong file extension or which are too big.

Further added checks of the filesize and file-extension in php.

