### PR TITLE
Fix/award 404 locale datetimepicker

### DIFF
--- a/application/modules/awards/views/admin/index/treat.php
+++ b/application/modules/awards/views/admin/index/treat.php
@@ -134,7 +134,9 @@ if ($awards != '') {
 </form>
 
 <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.js')?>" charset="UTF-8"></script>
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js')?>" charset="UTF-8"></script>
+<?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
+    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js')?>" charset="UTF-8"></script>
+<?php endif; ?>
 <script type="text/javascript">
 $(document).ready(function() {
     $(".form_datetime").datetimepicker({


### PR DESCRIPTION
Don't try to load bootstrap-datetimepicker.en.js as that file doesn't
exist. Only load the locale of the datetimepicker when locale != en.

TODO: There are still some other bugs.
http://www.ilch.de/forum-showposts-53353.html