### PR TITLE
Fix/translation admincenter

### DIFF
--- a/application/modules/admin/layouts/iframe.php
+++ b/application/modules/admin/layouts/iframe.php
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="de">
     <head>
-        <title>Ilch - Admincenter</title>
+        <title>Ilch - <?=$this->getTrans('admincenter') ?></title>
 
         <!-- META -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-        <meta name="description" content="Ilch - Admincenter">
+        <meta name="description" content="Ilch - <?=$this->getTrans('admincenter') ?>">
 
         <!-- FAVICON -->
         <link rel="shortcut icon" type="image/x-icon" href="<?=$this->getStaticUrl('img/favicon.ico') ?>">

--- a/application/modules/admin/layouts/index.php
+++ b/application/modules/admin/layouts/index.php
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="de">
     <head>
-        <title>Ilch - Admincenter</title>
+        <title>Ilch - <?=$this->getTrans('admincenter') ?></title>
 
         <!-- META -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-        <meta name="description" content="Ilch - Admincenter">
+        <meta name="description" content="Ilch - <?=$this->getTrans('admincenter') ?>">
 
         <!-- FAVICON -->
         <link rel="shortcut icon" type="image/x-icon" href="<?=$this->getStaticUrl('img/favicon.ico') ?>">

--- a/application/modules/user/boxes/views/login.php
+++ b/application/modules/user/boxes/views/login.php
@@ -8,7 +8,7 @@
     <div id="checknewmessage"></div>
     <?php if ($this->get('userAccesses') || $this->getUser()->isAdmin()): ?>
         <a target="_blank" href="<?=$this->getUrl(['module' => 'admin', 'controller' => 'admin', 'action' => 'index']) ?>">
-            <?=$this->getTrans('adminarea') ?>
+            <?=$this->getTrans('admincenter') ?>
         </a>
         <br />
     <?php endif; ?>

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -160,7 +160,7 @@ return
     'message' => 'Nachricht',
     'userPanel' => 'User Panel',
     'hello' => 'Hallo',
-    'adminarea' => 'Adminbereich',
+    'admincenter' => 'Admincenter',
 
     'register' => 'Registrieren',
     'menuLoginWith' => 'Login mit',

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -160,7 +160,7 @@ return
     'message' => 'Message',
     'userPanel' => 'User Panel',
     'hello' => 'Hello',
-    'adminarea' => 'Adminarea',
+    'admincenter' => 'Admincenter',
 
     'register' => 'Register',
     'menuLoginWith' => 'Login with',


### PR DESCRIPTION
Changed the text for the login-box to "Admincenter" from "Adminbereich"
or "Adminarea".