### PR TITLE
Remoe server side sizecheck

### DIFF
--- a/application/modules/media/controllers/admin/Index.php
+++ b/application/modules/media/controllers/admin/Index.php
@@ -116,10 +116,9 @@ class Index extends \Ilch\Controller\Admin
             $upload->setFile($_FILES['upl']['name']);
             $upload->setTypes($this->getConfig()->get('media_ext_img'));
             $upload->setPath($this->getConfig()->get('media_uploadpath'));
-            // Early return if extension is not allowed or file is too big. Should normally already be done client-side.
-            // Doing this client-side is especially important for the "file too big"-case as early returning here is already too late.
+            // Early return if extension is not allowed. Should normally already be done client-side.
             $upload->setAllowedExtensions($allowedExtensions);
-            if (!$upload->isAllowedExtension() || filesize($_FILES['upl']['tmp_name']) > $upload->returnBytes(ini_get('upload_max_filesize'))) {
+            if (!file_exists($_FILES['upl']['tmp_name']) || !$upload->isAllowedExtension()) {
                 return;
             }
             $upload->upload();

--- a/application/modules/smilies/controllers/admin/Index.php
+++ b/application/modules/smilies/controllers/admin/Index.php
@@ -138,10 +138,9 @@ class Index extends \Ilch\Controller\Admin
             $upload->setFile($_FILES['upl']['name']);
             $upload->setTypes($this->getConfig()->get('smiley_filetypes'));
             $upload->setPath('application/modules/smilies/static/img/');
-            // Early return if extension is not allowed or file is too big. Should normally already be done client-side.
-            // Doing this client-side is especially important for the "file too big"-case as early returning here is already too late.
+            // Early return if extension is not allowed. Should normally already be done client-side.
             $upload->setAllowedExtensions($allowedExtensions);
-            if (!$upload->isAllowedExtension() || filesize($_FILES['upl']['tmp_name']) > $upload->returnBytes(ini_get('upload_max_filesize'))) {
+            if (!file_exists($_FILES['upl']['tmp_name']) || !$upload->isAllowedExtension()) {
                 return;
             }
             $upload->upload();

--- a/application/modules/user/controllers/Iframe.php
+++ b/application/modules/user/controllers/Iframe.php
@@ -59,10 +59,9 @@ class Iframe extends \Ilch\Controller\Frontend
             $upload->setFile($_FILES['upl']['name']);
             $upload->setTypes($this->getConfig()->get('usergallery_filetypes'));
             $upload->setPath($this->getConfig()->get('usergallery_uploadpath').$this->getUser()->getId().'/');
-            // Early return if extension is not allowed or file is too big. Should normally already be done client-side.
-            // Doing this client-side is especially important for the "file too big"-case as early returning here is already too late.
+            // Early return if extension is not allowed. Should normally already be done client-side.
             $upload->setAllowedExtensions($allowedExtensions);
-            if (!$upload->isAllowedExtension() || filesize($_FILES['upl']['tmp_name']) > $upload->returnBytes(ini_get('upload_max_filesize'))) {
+            if (!file_exists($_FILES['upl']['tmp_name']) || !$upload->isAllowedExtension()) {
                 return;
             }
             $upload->upload();


### PR DESCRIPTION
Turns out the server-side size check of the uploaded file is useless as
an file, which exceeds upload_max_filesize isn't even existing and
therefore filesize() always returns nothing.

In case of the filesize exceeds post_max_size the process gets aborted
way earlier.