### PR TITLE
Fix/thumbnail memory

### DIFF
--- a/application/libraries/Ilch/Upload.php
+++ b/application/libraries/Ilch/Upload.php
@@ -301,11 +301,16 @@ class Upload extends \Ilch\Controller\Base
 
         if (move_uploaded_file($_FILES['upl']['tmp_name'], $this->path.$hash.'.'.$this->getEnding())) {
             if (in_array($this->getEnding() , explode(' ', $this->types))) {
+                $imageInfo = getimagesize($this->path.$hash.'.'.$this->getEnding());
+                $requiredMemory = ($imageInfo[0] * $imageInfo[1] * ($imageInfo['bits'] / 8) * $imageInfo['channels'] * 2.5);
+                if (($this->returnBytes(ini_get('memory_limit')) - memory_get_usage(true)) < $requiredMemory) {
+                    return;
+                }
                 $thumb = new \Thumb\Thumbnail();
                 $thumb -> Thumbprefix = 'thumb_';
                 $thumb -> Thumblocation = $this->path;
                 $thumb -> Thumbsize = 300;
-                $thumb -> Square = 300;
+                $thumb -> Square = true;
                 $thumb -> Cropimage = [3,1,50,50,50,50];
                 $thumb -> Createthumb($this->path.$hash.'.'.$this->getEnding(),'file');
             }
@@ -340,11 +345,21 @@ class Upload extends \Ilch\Controller\Base
 
         rename($this->path.$this->getName().'.'.$this->getEnding(), $this->path.$hash.'.'.$this->getEnding());
         if (in_array($this->getEnding() , explode(' ', $this->types))) {
+            // Take an educated guess on how big the image is going to be in memory to decide if it should be tried to create a thumbnail.
+            $imageInfo = getimagesize($this->path.$hash.'.'.$this->getEnding());
+            // (width * height * bits / 8) * channels * tweak-factor
+            // channels will be 3 for RGB pictures and 4 for CMYK pictures
+            // bits is the number of bits for each color.
+            // The tweak-factor might be overly careful and could therefore be lowered if necessary.
+            $requiredMemory = ($imageInfo[0] * $imageInfo[1] * ($imageInfo['bits'] / 8) * $imageInfo['channels'] * 2.5);
+            if (($this->returnBytes(ini_get('memory_limit')) - memory_get_usage(true)) < $requiredMemory) {
+                return;
+            }
             $thumb = new \Thumb\Thumbnail();
             $thumb -> Thumbprefix = 'thumb_';
             $thumb -> Thumblocation = $this->path;
             $thumb -> Thumbsize = 300;
-            $thumb -> Square = 300;
+            $thumb -> Square = true;
             $thumb -> Cropimage = [3,1,50,50,50,50];
             $thumb -> Createthumb($this->path.$hash.'.'.$this->getEnding(),'file');
         }

--- a/application/modules/gallery/views/admin/gallery/treatgallery.php
+++ b/application/modules/gallery/views/admin/gallery/treatgallery.php
@@ -29,7 +29,11 @@
                             <td><input value="<?=$image->getId() ?>" type="checkbox" name="check_gallery[]" /></td>
                             <td><?=$this->getEditIcon(['controller' => 'image', 'action' => 'treatimage', 'gallery' => $image->getCat(), 'id' => $image->getId()]) ?></td>
                             <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $image->getId(), 'gallery' => $this->getRequest()->getParam('id')]) ?></td>
-                            <td><img class="image thumbnail img-responsive" src="<?=$this->getUrl().'/'.$image->getImageThumb() ?>"/></td>
+                            <?php if (file_exists($image->getImageThumb())): ?>
+                                <td><img class="image thumbnail img-responsive" src="<?=$this->getUrl().'/'.$image->getImageThumb() ?>"/></td>
+                            <?php else: ?>
+                                <td><img class="image thumbnail img-responsive" src="<?=$this->getBaseUrl('application/modules/media/static/img/nomedia.png') ?>"/></td>
+                            <?php endif; ?>
                             <td><?=$image->getImageTitle() ?></td>
                             <td><div class="table_text"><?=$image->getImageDesc() ?></div></td>
                         </tr>

--- a/application/modules/media/views/admin/iframe/index.php
+++ b/application/modules/media/views/admin/iframe/index.php
@@ -13,7 +13,11 @@
                     <div id="<?=$media->getId() ?>" class="col-lg-2 col-sm-3 col-xs-4 media_loader">
                         <img class="image thumbnail img-responsive"
                              data-url="<?=$media->getUrl() ?>"
-                             src="<?=$this->getBaseUrl($media->getUrlThumb()) ?>"
+                             <?php if (file_exists($media->getUrlThumb())): ?>
+                                src="<?=$this->getBaseUrl($media->getUrlThumb()) ?>"
+                             <?php else: ?>
+                                src="<?=$this->getBaseUrl('application/modules/media/static/img/nomedia.png') ?>"
+                             <?php endif; ?>
                              alt="<?=$media->getName() ?>">
                     </div>
                 <?php endif; ?>

--- a/application/modules/media/views/admin/iframe/multi.php
+++ b/application/modules/media/views/admin/iframe/multi.php
@@ -31,7 +31,11 @@
                             <div id="<?=$media->getId() ?>"  class="col-lg-2 col-md-2 col-sm-3 col-xs-4 co thumb media_loader">
                                 <img class="image thumbnail img-responsive"
                                      data-url="<?=$media->getUrl() ?>"
-                                     src="<?=$this->getBaseUrl($media->getUrlThumb()) ?>"
+                                     <?php if (file_exists($media->getUrlThumb())): ?>
+                                        src="<?=$this->getBaseUrl($media->getUrlThumb()) ?>"
+                                     <?php else: ?>
+                                        src="<?=$this->getBaseUrl('application/modules/media/static/img/nomedia.png') ?>"
+                                     <?php endif; ?>
                                      alt="<?=$media->getName() ?>">
                                 <input type="checkbox"
                                        id="<?=$media->getId() ?> test"

--- a/application/modules/media/views/admin/index/index.php
+++ b/application/modules/media/views/admin/index/index.php
@@ -97,7 +97,11 @@
                             <td>
                                 <?php if (in_array($media->getEnding(), explode(' ',$this->get('media_ext_img')))): ?>
                                     <a href="<?=$this->getBaseUrl($media->getUrl()) ?>" title="<?=$media->getName() ?>">
-                                        <img class="img-preview" src="<?=$this->getBaseUrl($media->getUrlThumb()) ?>" alt="<?=$media->getName() ?>">
+                                        <?php if (file_exists($media->getUrlThumb())): ?>
+                                            <img class="img-preview" src="<?=$this->getBaseUrl($media->getUrlThumb()) ?>" alt="<?=$media->getName() ?>">
+                                        <?php else: ?>
+                                            <img class="img-preview" src="<?=$this->getBaseUrl('application/modules/media/static/img/nomedia.png') ?>" alt="<?=$media->getName() ?>">
+                                        <?php endif; ?>
                                     </a>
                                 <?php else: ?>
                                     <img src="<?=$this->getBaseUrl('application/modules/media/static/img/nomedia.png') ?>"

--- a/application/modules/user/views/panel/treatgallery.php
+++ b/application/modules/user/views/panel/treatgallery.php
@@ -42,7 +42,11 @@
                                         <td><input value="<?=$image->getId() ?>" type="checkbox" name="check_gallery[]" /></td>
                                         <td><?=$this->getEditIcon(['action' => 'treatgalleryimage', 'gallery' => $this->getRequest()->getParam('id'), 'id' => $image->getId()]) ?></td>
                                         <td><?=$this->getDeleteIcon(['action' => 'delgalleryimage', 'gallery' => $this->getRequest()->getParam('id'), 'id' => $image->getImageId()]) ?></td>
-                                        <td><img class="image thumbnail img-responsive" src="<?=$this->getUrl().'/'.$image->getImageThumb() ?>"/></td>
+                                        <?php if (file_exists($image->getImageThumb())): ?>
+                                            <td><img class="image thumbnail img-responsive" src="<?=$this->getUrl().'/'.$image->getImageThumb() ?>"/></td>
+                                        <?php else: ?>
+                                            <td><img class="image thumbnail img-responsive" src="<?=$this->getBaseUrl('application/modules/media/static/img/nomedia.png') ?>"/></td>
+                                        <?php endif; ?>
                                         <td><?=$image->getImageTitle() ?></td>
                                         <td><?=$image->getImageDesc() ?></td>
                                     </tr>


### PR DESCRIPTION
Take an educated guess on how big the image is going to be in memory to decide if it should be tried to create a thumbnail.

Adjusted the views etc. for the case of a missing thumbnail and display the default image in that case.

The thumbnail may now be missing if creating a thumbnail would have probably needed too much memory.

The tweak-factor might be overly careful and could therefore be lowered if necessary.
See libraries/Ilch/Upload.

Before this change uploading a "bigger" image, which later was too big in memory to create a thumbnail, endet in the result that the image itself was orphaned in the upload folder.
In other words: uploaded, but not kept track of it in the database, because creating the thumbnail crashed with an error like this:

> PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 16000 bytes) in ...