### PR TITLE
Fix/module administrate link

### DIFF
--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -137,7 +137,7 @@ return
     'installModule' => 'Install',
     'modulesInstalled' => 'Installed Modules',
     'modulesNotInstalled' => 'Not installed Modules',
-    'noNotInstalledModules' => 'no Entries available',
+    'noNotInstalledModules' => 'No entries available',
     'media' => 'Media',
 
     'menuInfos' => 'Information',

--- a/application/modules/admin/views/admin/modules/index.php
+++ b/application/modules/admin/views/admin/modules/index.php
@@ -27,16 +27,9 @@
                             <br /><br />
                             <small><?=$this->getTrans('author')?>: <?=$module->getAuthor() ?></small>
                             <br />
-                            <a href="<?=$this->getUrl(array('module' => $module->getKey(), 'controller' => 'index', 'action' => 'index')) ?>">
-                                <?=$this->getTrans('administrate') ?>
-                            </a>
+                            <a href="<?=$this->getUrl(array('module' => $module->getKey(), 'controller' => 'index', 'action' => 'index')) ?>"><?=$this->getTrans('administrate') ?></a>
                             <?php if (!isset($config->isSystemModule)): ?>
-                                <small>
-                                    | 
-                                    <a class="delete_button" href="<?=$this->getUrl(array('action' => 'delete', 'key' => $module->getKey()), null, true) ?>">
-                                        <?=$this->getTrans('delete') ?>
-                                    </a>
-                                </small>
+                                <small>| <a class="delete_button" href="<?=$this->getUrl(array('action' => 'delete', 'key' => $module->getKey()), null, true) ?>"><?=$this->getTrans('delete') ?></a></small>
                             <?php endif; ?>
                         </td>
                         <td>


### PR DESCRIPTION
Avoid underline of a space in the administrate-link.

Fixed a typo in the translation.