### PR TITLE
Fix/userpanel settings newsletter

### DIFF
--- a/application/modules/newsletter/translations/de.php
+++ b/application/modules/newsletter/translations/de.php
@@ -42,4 +42,9 @@ return
     'acceptNewsletter' => 'Newsletter erhalten?',
     'yes' => 'Ja',
     'no' => 'Nein',
+
+    'panel' => 'Panel',
+    'dialog' => 'Nachrichten',
+    'gallery' => 'Galerie',
+    'settingsSettings' => 'Einstellungen',
     ];

--- a/application/modules/newsletter/translations/en.php
+++ b/application/modules/newsletter/translations/en.php
@@ -42,4 +42,9 @@ return
     'acceptNewsletter' => 'Receive newsletter?',
     'yes' => 'Yes',
     'no' => 'No',
+
+    'panel' => 'Panel',
+    'dialog' => 'Messages',
+    'gallery' => 'Gallery',
+    'settingsSettings' => 'Settings',
     ];

--- a/application/modules/user/views/panel/navi.php
+++ b/application/modules/user/views/panel/navi.php
@@ -16,8 +16,6 @@ function getTransKey($usermenuId) {
 
 ?>
 
-<link href="<?=$this->getModuleUrl('static/css/user.css') ?>" rel="stylesheet">
-
 <img class="panel-profile-image" src="<?=$this->getStaticUrl().'../'.$this->escape($profil->getAvatar()) ?>" title="<?=$this->escape($profil->getName()) ?>">
 <ul class="nav">
     <?php foreach ($this->get('usermenu') as $usermenu): ?>


### PR DESCRIPTION
Add the missing translation for the navigation when navigating to
user-panel -> settings -> newsletter.

The "navi.php" mainly included in application\modules\user\views\panel\
with the exception of
application\modules\newsletter\views\index\settings.php added the
"user.css". In the case of the newsletter-settings this didn't worked
and resulted in a 404-error.

Further the "user.css" is already added in
application\modules\user\views\panel\ and
application\modules\newsletter\views\index\settings.php. Therefore it
was added twice.

By removing the addition of the "user.css" in "navi.php" the 404-error
and duplicated addition of it is fixed.