### PR TITLE
Fix typo in function-name

### DIFF
--- a/application/modules/forum/mappers/Post.php
+++ b/application/modules/forum/mappers/Post.php
@@ -46,7 +46,7 @@ class Post extends \Ilch\Mapper
         return $entryModel;
     }
 
-    public function getAllPostsByUderId($userId)
+    public function getAllPostsByUserId($userId)
     {
         $this->db()->select('id')
             ->from('forum_posts')


### PR DESCRIPTION
Just fixed a typo in application/modules/forum/mappers/Post.php in the name of getAllPostsByUserId() 