### PR TITLE
Don't call isAdmin() if $this->getUser() is null

### DIFF
--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -116,7 +116,7 @@ class Showposts extends \Ilch\Controller\Frontend
         $cat = $forumMapper->getCatByParentId($forum->getParentId());
         $post = $topicMapper->getPostById($topicId);
 
-        if ($this->getUser() && $this->getUser()->getName() == $post->getAuthor() || $this->getUser()->isAdmin()) {
+        if ($this->getUser() && ($this->getUser()->getName() == $post->getAuthor() || $this->getUser()->isAdmin())) {
             $this->getLayout()->set('metaTitle', $this->getTranslator()->trans('forum') . ' - ' . $forum->getTitle());
 
             $this->getLayout()->getHmenu()
@@ -136,8 +136,7 @@ class Showposts extends \Ilch\Controller\Frontend
 
                 $this->redirect(['controller' => 'showposts', 'action' => 'index', 'topicid' => $topicId]);
             }
-
-            $this->getView()->set('post', $postMapper->getPostById($postId));
         }
+        $this->getView()->set('post', $postMapper->getPostById($postId));
     }
 }


### PR DESCRIPTION
Changed the expression by adding a pair of brackets.
Previously isAdmin() would be called even if $this->getUser() was null.

> Fatal error: Call to a member function isAdmin() on null.

Moved call of $this->getView()->set() out of the "true-block". That line needs to be called everytime. Otherwise the page is displayed wrong.

