### PR TITLE
Add message regarding no layouts available

### DIFF
--- a/application/modules/admin/views/admin/layouts/search.php
+++ b/application/modules/admin/views/admin/layouts/search.php
@@ -1,6 +1,12 @@
 <?php
 $json = url_get_contents('http://ilch2.de/downloads/layouts/list.php');
 $datas = json_decode($json);
+
+if (empty($datas)) {
+    echo $this->getTrans('noLayoutsAvailable');
+    return;
+}
+
 foreach ($datas as $data) : ?>
 
     <div class="row">


### PR DESCRIPTION
Add a message regarding no layouts found instead of failing with
"Invalid argument supplied for foreach()".

The translation for "noLayoutsAvailable" is missing in this pull-request. It ended up being part of a not yet send pull request for ticket 249.

http://redmine.ilch2.de/issues/249

