### PR TITLE
Add support to resort profilefields.

### DIFF
--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -138,6 +138,7 @@ class Config extends \Ilch\Config\Install
                   `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
                   `name` VARCHAR(255) NOT NULL,
                   `type` INT(11) NOT NULL,
+                  `position` INT(11) UNSIGNED NOT NULL,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
 

--- a/application/modules/user/controllers/admin/ProfileFields.php
+++ b/application/modules/user/controllers/admin/ProfileFields.php
@@ -34,6 +34,15 @@ class ProfileFields extends BaseController
         $profileFieldsMapper = new ProfileFieldsMapper();
 
         $this->getView()->set('profileFields', $profileFieldsMapper->getProfileFields());
+        
+        if ($this->getRequest()->isPost()) {
+            $postData = $this->getRequest()->getPost();
+            $positions = explode(',', $postData['hiddenMenu']);
+            for($x = 0; $x < count($positions); $x++) {
+                $profileFieldsMapper->updatePositionById($positions[$x], $x);
+            }
+            $this->addMessage('success');
+        }
     }
 
     public function treatAction()

--- a/application/modules/user/mappers/ProfileFields.php
+++ b/application/modules/user/mappers/ProfileFields.php
@@ -19,6 +19,7 @@ class ProfileFields extends \Ilch\Mapper
     {
         $profileFieldRows = $this->db()->select('*')
             ->from('profile_fields')
+            ->order(['position' => 'ASC'])
             ->execute()
             ->fetchRows();
 
@@ -51,6 +52,19 @@ class ProfileFields extends \Ilch\Mapper
             return reset($profileFields);
         }
         return null;
+    }
+
+    /**
+     * Updates the position of a profile-field in the database.
+     *
+     * @param int $id, int $position
+     *
+     */
+    public function updatePositionById($id, $position) {
+        $this->db()->update('profile_fields')
+            ->values(['position' => $position])
+            ->where(['id' => $id])
+            ->execute();
     }
 
     /**
@@ -144,6 +158,10 @@ class ProfileFields extends \Ilch\Mapper
 
         if (isset($profileFieldRow['type'])) {
             $profileField->setType($profileFieldRow['type']);
+        }
+
+        if (isset($profileFieldRow['position'])) {
+            $profileField->setPosition($profileFieldRow['position']);
         }
 
         return $profileField;

--- a/application/modules/user/models/ProfileField.php
+++ b/application/modules/user/models/ProfileField.php
@@ -30,6 +30,13 @@ class ProfileField extends \Ilch\Model
     protected $type;
 
     /**
+     * The position of the profile-field.
+     *
+     * @var int
+     */
+    protected $position;
+
+    /**
      * Returns the id of the profile-field.
      *
      * @return int
@@ -94,6 +101,29 @@ class ProfileField extends \Ilch\Model
     public function setType($type)
     {
         $this->type = (int)$type;
+
+        return $this;
+    }
+
+    /**
+     * Returns the position of the profile-field.
+     *
+     * @return int
+     */
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    /**
+     * Sets the position.
+     *
+     * @param int $position
+     * @return ProfileField
+     */
+    public function setPosition($position)
+    {
+        $this->position = (int)$position;
 
         return $this;
     }

--- a/application/modules/user/views/admin/profilefields/index.php
+++ b/application/modules/user/views/admin/profilefields/index.php
@@ -1,36 +1,69 @@
-<table class="table table-hover table-striped">
-    <colgroup>
-        <col class="icon_width" />
-        <col class="icon_width" />
-        <col class="icon_width" />
-        <col />
-    </colgroup>
-    <thead>
-        <tr>
-            <th><?=$this->getCheckAllCheckbox('check_users') ?></th>
-            <th></th>
-            <th></th>
-            <th><?=$this->getTrans('profileFieldName') ?></th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php
-        $profileFields = $this->get('profileFields');
+<form class="form-horizontal" id="downloadsForm" method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]); ?>">
+    <?=$this->getTokenField(); ?>
+    <table class="table table-hover table-striped">
+        <colgroup>
+            <col class="icon_width" />
+            <col class="icon_width" />
+            <col class="icon_width" />
+            <col />
+        </colgroup>
+        <thead>
+            <tr>
+                <th><?=$this->getCheckAllCheckbox('check_users') ?></th>
+                <th></th>
+                <th></th>
+                <th><?=$this->getTrans('profileFieldName') ?></th>
+            </tr>
+        </thead>
+        <tbody id="sortable">
+            <?php
+            $profileFields = $this->get('profileFields');
 
-        foreach ($profileFields as $profileField) :
-        ?>
-        <tr>
-            <td>
-                <input value="<?=$profileField->getId()?>" type="checkbox" name="check_users[]" />
-            </td>
-            <td>
-                <?=$this->getEditIcon(['action' => 'treat', 'id' => $profileField->getId()]) ?>
-            </td>
-            <td>
-                <?=$this->getDeleteIcon(['action' => 'delete', 'id' => $profileField->getId()]) ?>
-            </td>
-            <td><?=$this->escape($profileField->getName()) ?></td>
-        </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
+            foreach ($profileFields as $profileField) :
+            ?>
+            <tr id="<?=$profileField->getId() ?>">
+                <td>
+                    <input value="<?=$profileField->getId()?>" type="checkbox" name="check_users[]" />
+                </td>
+                <td>
+                    <?=$this->getEditIcon(['action' => 'treat', 'id' => $profileField->getId()]) ?>
+                </td>
+                <td>
+                    <?=$this->getDeleteIcon(['action' => 'delete', 'id' => $profileField->getId()]) ?>
+                </td>
+                <?php if(!$profileField->getType()) : ?>
+                    <td><?=$this->escape($profileField->getName()) ?></td>
+                <?php else : ?>
+                    <td><b><?=$this->escape($profileField->getName()) ?></b></td>
+                <?php endif; ?>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <input type="hidden" id="hiddenMenu" name="hiddenMenu" value="" />
+    <?=$this->getSaveBar('saveButton')?>
+</form>
+
+<script>
+$(function() {
+$( "#sortable" ).sortable();
+$( "#sortable" ).disableSelection();
+});
+
+$('#downloadsForm').submit (
+    function () {
+        var items = $("#sortable tr");
+
+        var linkIDs = [items.size()];
+        var index = 0;
+
+        items.each(
+            function(intIndex) {
+                linkIDs[index] = $(this).attr("id");
+                index++;
+            });
+
+        $('#hiddenMenu').val(linkIDs.join(","));
+    }
+);
+</script>


### PR DESCRIPTION
Add support to resort profile-fields.
Now the administrator can resort the profile-fields by drag and drop.

Further display categories with a bold font in the admincenter so a category can be distinguished from a normal profile-field.