### PR TITLE
Feature/pagination settings ticket248

### DIFF
--- a/application/libraries/Ilch/Pagination.php
+++ b/application/libraries/Ilch/Pagination.php
@@ -23,6 +23,13 @@ class Pagination
      */
     protected $rows;
 
+    public function __construct($rowsPerPage = 20)
+    {
+        if(!empty($rowsPerPage)) {
+            $this->setRowsPerPage($rowsPerPage);
+        }
+    }
+
     /**
      * @param integer $page
      */

--- a/application/libraries/Ilch/Pagination.php
+++ b/application/libraries/Ilch/Pagination.php
@@ -23,13 +23,6 @@ class Pagination
      */
     protected $rows;
 
-    public function __construct($rowsPerPage = 20)
-    {
-        if(!empty($rowsPerPage)) {
-            $this->setRowsPerPage($rowsPerPage);
-        }
-    }
-
     /**
      * @param integer $page
      */

--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -24,6 +24,7 @@ class Config extends \Ilch\Config\Install
         $databaseConfig->set('start_page', 'module_article');
         $databaseConfig->set('page_title', 'ilch - Content Manage System');
         $databaseConfig->set('standardMail', $_SESSION['install']['adminEmail']);
+        $databaseConfig->set('defaultPaginationObjects', 20);
         $databaseConfig->set('admin_layout_top_nav', '');
         $databaseConfig->set('maintenance_mode', '0');
         $databaseConfig->set('maintenance_status', '0');

--- a/application/modules/admin/controllers/admin/Settings.php
+++ b/application/modules/admin/controllers/admin/Settings.php
@@ -71,6 +71,7 @@ class Settings extends \Ilch\Controller\Admin
             $this->getConfig()->set('standardMail', $this->getRequest()->getPost('standardMail'));
             $this->getConfig()->set('timezone', $this->getRequest()->getPost('timezone'));
             $this->getConfig()->set('locale', $this->getRequest()->getPost('locale'));
+            $this->getConfig()->set('defaultPaginationObjects', $this->getRequest()->getPost('defaultPaginationObjects'));
             if ($this->getRequest()->getPost('navbarFixed') === '1') {
                 $this->getConfig()->set('admin_layout_top_nav', 'navbar-fixed-top');
             }
@@ -111,6 +112,7 @@ HTACCESS;
         $this->getView()->set('modules', $moduleMapper->getModules());
         $this->getView()->set('pages', $pageMapper->getPageList());
         $this->getView()->set('navbarFixed', $this->getConfig()->get('admin_layout_top_nav'));
+        $this->getView()->set('defaultPaginationObjects', $this->getConfig()->get('defaultPaginationObjects'));
     }
 
     public function maintenanceAction()

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -44,6 +44,7 @@ return
     'noUserEmailGiven' => 'Es wurde kein(e) Benutzername/E-Mail angegeben.',
     'contentLanguage' => 'Sprache des Inhaltes',
     'standardMail' => 'Standard E-Mail Absender',
+    'defaultPaginationObjects' => 'Standardanzahl Objekte pro Seite',
     'timezone' => 'Zeitzone',
     'home' => 'Startseite',
     'navigation' => 'Menüs',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -44,6 +44,7 @@ return
     'noUserEmailGiven' => 'No username/email was provided.',
     'contentLanguage' => 'Contentlanguage',
     'standardMail' => 'Standard E-Mail sender',
+    'defaultPaginationObjects' => 'default count of objects per page',
     'timezone' => 'timezone',
     'home' => 'Start',
     'navigation' => 'Navigation',

--- a/application/modules/admin/views/admin/settings/index.php
+++ b/application/modules/admin/views/admin/settings/index.php
@@ -129,6 +129,19 @@
                    value="<?=$this->escape($this->get('standardMail')) ?>" />
         </div>
     </div>
+    <div class="form-group">
+        <label for="defaultPaginationObjectsInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('defaultPaginationObjects') ?>:
+        </label>
+        <div class="col-lg-8">
+            <input class="form-control"
+                   id="defaultPaginationObjectsInput"
+                   name="defaultPaginationObjects"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('defaultPaginationObjects')) ?>" />
+        </div>
+    </div>
 
     <legend><?=$this->getTrans('seo') ?></legend>
     <div class="form-group">

--- a/application/modules/article/controllers/Archive.php
+++ b/application/modules/article/controllers/Archive.php
@@ -41,6 +41,7 @@ class Archive extends \Ilch\Controller\Frontend
                 ->add($this->getTranslator()->trans('menuArticle'), ['controller' => 'index', 'action' => 'index'])
                 ->add($this->getTranslator()->trans('menuArchives'), ['action' => 'index']);
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('article_articlesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('categoryMapper', $categoryMapper);

--- a/application/modules/article/controllers/Cats.php
+++ b/application/modules/article/controllers/Cats.php
@@ -54,6 +54,7 @@ class Cats extends \Ilch\Controller\Frontend
                 ->add($this->getTranslator()->trans('menuCats'), ['action' => 'index'])
                 ->add($articlesCats->getName(), ['action' => 'show', 'id' => $articlesCats->getId()]);
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('article_articlesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('categoryMapper', $categoryMapper);

--- a/application/modules/article/controllers/Index.php
+++ b/application/modules/article/controllers/Index.php
@@ -39,6 +39,7 @@ class Index extends \Ilch\Controller\Frontend
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('menuArticle'), ['action' => 'index']);
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('article_articlesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('categoryMapper', $categoryMapper);

--- a/application/modules/article/controllers/admin/Cats.php
+++ b/application/modules/article/controllers/admin/Cats.php
@@ -32,6 +32,12 @@ class Cats extends \Ilch\Controller\Admin
                 'active' => false,
                 'icon' => 'fa fa-plus-circle',
                 'url' => $this->getLayout()->getUrl(['controller' => 'cats', 'action' => 'treat'])
+            ],
+            [
+                'name' => 'menuSettings',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
             ]
         ];
 
@@ -39,6 +45,8 @@ class Cats extends \Ilch\Controller\Admin
             $items[1]['active'] = true;
         } elseif ($this->getRequest()->getControllerName() == 'cats' AND $this->getRequest()->getActionName() == 'treat') {
             $items[2]['active'] = true;
+        } elseif ($this->getRequest()->getControllerName() == 'settings' AND $this->getRequest()->getActionName() == 'index') {
+            $items[3]['active'] = true;
         } else {
             $items[0]['active'] = true;
         }

--- a/application/modules/article/controllers/admin/Index.php
+++ b/application/modules/article/controllers/admin/Index.php
@@ -32,6 +32,12 @@ class Index extends \Ilch\Controller\Admin
                 'active' => false,
                 'icon' => 'fa fa-plus-circle',
                 'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'treat'])
+            ],
+            [
+                'name' => 'menuSettings',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
             ]
         ];
 
@@ -39,6 +45,8 @@ class Index extends \Ilch\Controller\Admin
             $items[1]['active'] = true;
         } elseif ($this->getRequest()->getControllerName() == 'index' AND $this->getRequest()->getActionName() == 'treat') {
             $items[2]['active'] = true;
+        } elseif ($this->getRequest()->getControllerName() == 'settings' AND $this->getRequest()->getActionName() == 'index') {
+            $items[3]['active'] = true;
         } else {
             $items[0]['active'] = true;
         }

--- a/application/modules/article/controllers/admin/Settings.php
+++ b/application/modules/article/controllers/admin/Settings.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\Article\Controllers\Admin;
+
+class Settings extends \Ilch\Controller\Admin
+{
+    public function init()
+    {
+        $items = [
+            [
+                'name' => 'manage',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+            ],
+            [
+                'name' => 'menuCats',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'cats', 'action' => 'index'])
+            ],
+            [
+                'name' => 'add',
+                'active' => false,
+                'icon' => 'fa fa-plus-circle',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'treat'])
+            ],
+            [
+                'name' => 'menuSettings',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
+            ]
+        ];
+
+        if ($this->getRequest()->getControllerName() == 'cats' AND $this->getRequest()->getActionName() == 'index') {
+            $items[1]['active'] = true;
+        } elseif ($this->getRequest()->getControllerName() == 'index' AND $this->getRequest()->getActionName() == 'treat') {
+            $items[2]['active'] = true;
+        } elseif ($this->getRequest()->getControllerName() == 'settings' AND $this->getRequest()->getActionName() == 'index') {
+            $items[3]['active'] = true;
+        } else {
+            $items[0]['active'] = true;
+        }
+
+        $this->getLayout()->addMenu
+        (
+            'menuArticle',
+            $items
+        );
+    }
+
+    public function indexAction()
+    {
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('menuArticle'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('settings'), ['action' => 'index']);
+
+        if ($this->getRequest()->isPost()) {
+            $this->getConfig()->set('article_articlesPerPage', $this->getRequest()->getPost('articlesPerPage'));
+            $this->addMessage('saveSuccess');
+        }
+
+        $this->getView()->set('articlesPerPage', $this->getConfig()->get('article_articlesPerPage'));
+    }
+}

--- a/application/modules/article/translations/de.php
+++ b/application/modules/article/translations/de.php
@@ -36,4 +36,5 @@ return [
     'commentDateTime' => 'Datum/Uhrzeit',
     'missingName' => 'Es wurde kein Name für die Kategorie eingegeben.',
     'categoryInUse' => 'Diese Kategorie kann nicht gelöscht werden, da sie noch Artikeln zugewiesen ist.',
+    'articlePerPage' => 'Artikel pro Seite',
 ];

--- a/application/modules/article/translations/en.php
+++ b/application/modules/article/translations/en.php
@@ -36,4 +36,5 @@ return [
     'commentDateTime' => 'Date/Time',
     'missingName' => 'No name for the category entered.',
     'categoryInUse' => 'This category cannot be deleted as it is still assigned with articles.',
+    'articlePerPage' => 'Article per page',
 ];

--- a/application/modules/article/views/admin/settings/index.php
+++ b/application/modules/article/views/admin/settings/index.php
@@ -1,0 +1,18 @@
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <legend><?=$this->getTrans('settings') ?></legend>
+    <div class="form-group">
+        <label for="articlesPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('articlePerPage') ?>:
+        </label>
+        <div class="col-lg-8">
+            <input class="form-control"
+                   id="articlesPerPageInput"
+                   name="articlesPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('articlesPerPage')) ?>" />
+        </div>
+    </div>
+    <?=$this->getSaveBar() ?>
+</form>

--- a/application/modules/article/views/admin/settings/index.php
+++ b/application/modules/article/views/admin/settings/index.php
@@ -5,7 +5,7 @@
         <label for="articlesPerPageInput" class="col-lg-2 control-label">
             <?=$this->getTrans('articlePerPage') ?>:
         </label>
-        <div class="col-lg-8">
+        <div class="col-lg-2">
             <input class="form-control"
                    id="articlesPerPageInput"
                    name="articlesPerPage"

--- a/application/modules/downloads/controllers/Index.php
+++ b/application/modules/downloads/controllers/Index.php
@@ -46,7 +46,8 @@ class Index extends \Ilch\Controller\Frontend
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('menuDownloadsOverview'), ['action' => 'index'])
                 ->add($downloads->getTitle(), ['action' => 'show', 'id' => $id]);
-        
+
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('downloads_downloadsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         
         $this->getView()->set('file', $fileMapper->getFileByDownloadsId($id, $pagination));

--- a/application/modules/downloads/controllers/admin/Downloads.php
+++ b/application/modules/downloads/controllers/admin/Downloads.php
@@ -56,6 +56,7 @@ class Downloads extends BaseController
             }
         }
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('downloads_downloadsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $this->getView()->set('file', $fileMapper->getFileByDownloadsId($id, $pagination));
         $this->getView()->set('pagination', $pagination);

--- a/application/modules/downloads/controllers/admin/Index.php
+++ b/application/modules/downloads/controllers/admin/Index.php
@@ -12,6 +12,36 @@ use Modules\Downloads\Mappers\File as FileMapper;
 
 class Index extends BaseController
 {
+    public function init()
+    {
+        $items = [
+            [
+                'name' => 'menuDownloads',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+            ],
+            [
+                'name' => 'menuSettings',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
+            ]
+        ];
+
+        if ($this->getRequest()->getControllerName() == 'settings' AND $this->getRequest()->getActionName() == 'index') {
+            $items[1]['active'] = true;
+        } else {
+            $items[0]['active'] = true;
+        }
+
+        $this->getLayout()->addMenu
+        (
+            'menuDownloads',
+            $items
+        );
+    }
+
     public function indexAction() 
     {
         $this->getLayout()->getAdminHmenu()

--- a/application/modules/downloads/controllers/admin/Settings.php
+++ b/application/modules/downloads/controllers/admin/Settings.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\Downloads\Controllers\Admin;
+
+class Settings extends \Ilch\Controller\Admin
+{
+    public function init()
+    {
+        $items = [
+            [
+                'name' => 'menuDownloads',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+            ],
+            [
+                'name' => 'menuSettings',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
+            ]
+        ];
+
+        if ($this->getRequest()->getControllerName() == 'settings' AND $this->getRequest()->getActionName() == 'index') {
+            $items[1]['active'] = true;
+        } else {
+            $items[0]['active'] = true;
+        }
+
+        $this->getLayout()->addMenu
+        (
+            'menuDownloads',
+            $items
+        );
+    }
+
+    public function indexAction()
+    {
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('downloads'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('settings'), ['action' => 'index']);
+
+        if ($this->getRequest()->isPost()) {
+            $this->getConfig()->set('downloads_downloadsPerPage', $this->getRequest()->getPost('downloadsPerPage'));
+            $this->addMessage('saveSuccess');
+        }
+
+        $this->getView()->set('downloadsPerPage', $this->getConfig()->get('downloads_downloadsPerPage'));
+    }
+}

--- a/application/modules/downloads/translations/de.php
+++ b/application/modules/downloads/translations/de.php
@@ -42,4 +42,5 @@ return [
     'commentDateTime' => 'Datum/Uhrzeit',
     'missingTitle' => 'Es muss ein Titel angegeben werden.',
     'missingCat' => 'Es muss zuerst eine Kategorie hinzugefügt werden.',
+    'downloadsPerPage' => 'Downloads pro Seite',
 ];

--- a/application/modules/downloads/translations/en.php
+++ b/application/modules/downloads/translations/en.php
@@ -42,4 +42,5 @@ return [
     'commentDateTime' => 'Date/Time',
     'missingTitle' => 'It is required to add a title.',
     'missingCat' => 'It is required to first add a category.',
+    'downloadsPerPage' => 'Downloads per page',
 ];

--- a/application/modules/downloads/views/admin/settings/index.php
+++ b/application/modules/downloads/views/admin/settings/index.php
@@ -5,7 +5,7 @@
         <label for="downloadsPerPageInput" class="col-lg-2 control-label">
             <?=$this->getTrans('downloadsPerPage') ?>:
         </label>
-        <div class="col-lg-8">
+        <div class="col-lg-2">
             <input class="form-control"
                    id="downloadsPerPageInput"
                    name="downloadsPerPage"

--- a/application/modules/downloads/views/admin/settings/index.php
+++ b/application/modules/downloads/views/admin/settings/index.php
@@ -1,0 +1,18 @@
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <legend><?=$this->getTrans('settings') ?></legend>
+    <div class="form-group">
+        <label for="downloadsPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('downloadsPerPage') ?>:
+        </label>
+        <div class="col-lg-8">
+            <input class="form-control"
+                   id="downloadsPerPageInput"
+                   name="downloadsPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('downloadsPerPage')) ?>" />
+        </div>
+    </div>
+    <?=$this->getSaveBar() ?>
+</form>

--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -23,6 +23,8 @@ class Showposts extends \Ilch\Controller\Frontend
         $forumMapper = new ForumMapper();
         $topicModel = new ForumTopicModel;
         $pagination = new \Ilch\Pagination();
+
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('forum_postsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $topicId = (int)$this->getRequest()->getParam('topicid');

--- a/application/modules/forum/controllers/Showtopics.php
+++ b/application/modules/forum/controllers/Showtopics.php
@@ -51,6 +51,7 @@ class Showtopics extends \Ilch\Controller\Frontend
                 ->add($cat->getTitle(), ['controller' => 'showcat','action' => 'index', 'id' => $cat->getId()])
                 ->add($forum->getTitle(), ['action' => 'index', 'forumid' => $forumId]);
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('forum_threadsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_threadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('forum', $forum);

--- a/application/modules/forum/controllers/Showunread.php
+++ b/application/modules/forum/controllers/Showunread.php
@@ -20,9 +20,6 @@ class Showunread extends \Ilch\Controller\Frontend
             $pagination = new \Ilch\Pagination();
             $userMapper = new UserMapper();
 
-            
-            
-
             $userId = null;
             $groupIds = [3];
 
@@ -36,6 +33,7 @@ class Showunread extends \Ilch\Controller\Frontend
 
             $groupIdsArray = explode(',',implode(',', $groupIds));
 
+            $pagination->setRowsPerPage(empty($this->getConfig()->get('forum_postsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
             $pagination->setPage($this->getRequest()->getParam('page'));
 
             $this->getLayout()->getHmenu()

--- a/application/modules/forum/controllers/admin/Base.php
+++ b/application/modules/forum/controllers/admin/Base.php
@@ -34,6 +34,12 @@ class Base extends \Ilch\Controller\Admin
                     'active' => $active['index'],
                     'icon' => 'fa fa-th',
                     'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+                ],
+                [
+                    'name' => 'menuSettings',
+                    'active' => false,
+                    'icon' => 'fa fa-th-list',
+                    'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
                 ]
             ]
         );

--- a/application/modules/forum/controllers/admin/Base.php
+++ b/application/modules/forum/controllers/admin/Base.php
@@ -21,7 +21,7 @@ class Base extends \Ilch\Controller\Admin
     {
         $active = [];
 
-        foreach (['index'] as $controllerName) {
+        foreach (['index', 'settings'] as $controllerName) {
             $active[$controllerName] = (boolean)($this->getRequest()->getControllerName() == $controllerName);
         }
 
@@ -37,7 +37,7 @@ class Base extends \Ilch\Controller\Admin
                 ],
                 [
                     'name' => 'menuSettings',
-                    'active' => false,
+                    'active' => $active['settings'],
                     'icon' => 'fa fa-th-list',
                     'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
                 ]

--- a/application/modules/forum/controllers/admin/Settings.php
+++ b/application/modules/forum/controllers/admin/Settings.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\Forum\Controllers\Admin;
+
+use Modules\Forum\Controllers\Admin\Base as BaseController;
+
+class Settings extends BaseController
+{
+    public function indexAction()
+    {
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('forum'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('settings'), ['action' => 'index']);
+
+        if ($this->getRequest()->isPost()) {
+            $this->getConfig()->set('forum_threadsPerPage', $this->getRequest()->getPost('threadsPerPage'));
+            $this->getConfig()->set('forum_postsPerPage', $this->getRequest()->getPost('postsPerPage'));
+            $this->addMessage('saveSuccess');
+        }
+
+        $this->getView()->set('threadsPerPage', $this->getConfig()->get('forum_threadsPerPage'));
+        $this->getView()->set('postsPerPage', $this->getConfig()->get('forum_postsPerPage'));
+    }
+}

--- a/application/modules/forum/translations/de.php
+++ b/application/modules/forum/translations/de.php
@@ -65,4 +65,6 @@ return [
     'edit' => 'Editieren',
     'cancel' => 'Abbrechen',
     'missingTitle' => 'Es muss ein Titel angegeben werden.',
+    'threadsPerPage' => 'Themen pro Seite',
+    'postsPerPage' => 'Beiträge pro Seite',
 ];

--- a/application/modules/forum/translations/en.php
+++ b/application/modules/forum/translations/en.php
@@ -65,4 +65,6 @@ return [
     'edit' => 'Edit',
     'cancel' => 'Cancel',
     'missingTitle' => 'It is required to add a title.',
+    'threadsPerPage' => 'Threads per page',
+    'postsPerPage' => 'Posts per page',
 ];

--- a/application/modules/forum/views/admin/settings/index.php
+++ b/application/modules/forum/views/admin/settings/index.php
@@ -5,7 +5,7 @@
         <label for="threadsPerPageInput" class="col-lg-2 control-label">
             <?=$this->getTrans('threadsPerPage') ?>:
         </label>
-        <div class="col-lg-8">
+        <div class="col-lg-2">
             <input class="form-control"
                    id="threadsPerPageInput"
                    name="threadsPerPage"
@@ -18,7 +18,7 @@
         <label for="postsPerPageInput" class="col-lg-2 control-label">
             <?=$this->getTrans('postsPerPage') ?>:
         </label>
-        <div class="col-lg-8">
+        <div class="col-lg-2">
             <input class="form-control"
                    id="postsPerPageInput"
                    name="postsPerPage"

--- a/application/modules/forum/views/admin/settings/index.php
+++ b/application/modules/forum/views/admin/settings/index.php
@@ -1,0 +1,31 @@
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <legend><?=$this->getTrans('settings') ?></legend>
+    <div class="form-group">
+        <label for="threadsPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('threadsPerPage') ?>:
+        </label>
+        <div class="col-lg-8">
+            <input class="form-control"
+                   id="threadsPerPageInput"
+                   name="threadsPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('threadsPerPage')) ?>" />
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="postsPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('postsPerPage') ?>:
+        </label>
+        <div class="col-lg-8">
+            <input class="form-control"
+                   id="postsPerPageInput"
+                   name="postsPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('postsPerPage')) ?>" />
+        </div>
+    </div>
+    <?=$this->getSaveBar() ?>
+</form>

--- a/application/modules/gallery/controllers/Index.php
+++ b/application/modules/gallery/controllers/Index.php
@@ -38,6 +38,7 @@ class Index extends \Ilch\Controller\Frontend
 
         $id = $this->getRequest()->getParam('id');
         $gallery = $galleryMapper->getGalleryById($id);
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('gallery_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('gallery_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getLayout()->set('metaTitle', $this->getTranslator()->trans('gallery').' - '.$gallery->getTitle());

--- a/application/modules/gallery/controllers/admin/Base.php
+++ b/application/modules/gallery/controllers/admin/Base.php
@@ -21,7 +21,7 @@ class Base extends \Ilch\Controller\Admin
     {
         $active = [];
 
-        foreach (['index', 'gallery', 'image'] as $controllerName) {
+        foreach (['index', 'gallery', 'image', 'settings'] as $controllerName) {
             $active[$controllerName] = (boolean)($this->getRequest()->getControllerName() == $controllerName);
         }
 
@@ -34,6 +34,12 @@ class Base extends \Ilch\Controller\Admin
                     'active' => $active['index'] or $active['gallery'] or $active['image'],
                     'icon' => 'fa fa-th',
                     'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+                ],
+                [
+                    'name' => 'menuSettings',
+                    'active' => $active['settings'],
+                    'icon' => 'fa fa-th-list',
+                    'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
                 ]
             ]
         );

--- a/application/modules/gallery/controllers/admin/Gallery.php
+++ b/application/modules/gallery/controllers/admin/Gallery.php
@@ -61,6 +61,7 @@ class Gallery extends BaseController
             }
         }
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('gallery_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('gallery_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $this->getView()->set('image', $imageMapper->getImageByGalleryId($id, $pagination));
         $this->getView()->set('pagination', $pagination);

--- a/application/modules/gallery/controllers/admin/Settings.php
+++ b/application/modules/gallery/controllers/admin/Settings.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\Gallery\Controllers\Admin;
+
+use Modules\Gallery\Controllers\Admin\Base as BaseController;
+
+class Settings extends BaseController
+{
+    public function indexAction()
+    {
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('gallery'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('settings'), ['action' => 'index']);
+
+        if ($this->getRequest()->isPost()) {
+            $this->getConfig()->set('gallery_picturesPerPage', $this->getRequest()->getPost('picturesPerPage'));
+            $this->addMessage('saveSuccess');
+        }
+
+        $this->getView()->set('picturesPerPage', $this->getConfig()->get('gallery_picturesPerPage'));
+    }
+}

--- a/application/modules/gallery/translations/de.php
+++ b/application/modules/gallery/translations/de.php
@@ -40,4 +40,5 @@ return [
     'commentUser' => 'Benutzer',
     'commentDateTime' => 'Datum/Uhrzeit',
     'media' => 'Medien',
+    'picturesPerPage' => 'Bilder pro Seite',
 ];

--- a/application/modules/gallery/translations/en.php
+++ b/application/modules/gallery/translations/en.php
@@ -40,4 +40,5 @@ return [
     'commentUser' => 'User',
     'commentDateTime' => 'Date/Time',
     'media' => 'Media',
+    'picturesPerPage' => 'Pictures per page',
 ];

--- a/application/modules/gallery/views/admin/settings/index.php
+++ b/application/modules/gallery/views/admin/settings/index.php
@@ -5,7 +5,7 @@
         <label for="picturesPerPageInput" class="col-lg-2 control-label">
             <?=$this->getTrans('picturesPerPage') ?>:
         </label>
-        <div class="col-lg-8">
+        <div class="col-lg-2">
             <input class="form-control"
                    id="picturesPerPageInput"
                    name="picturesPerPage"

--- a/application/modules/gallery/views/admin/settings/index.php
+++ b/application/modules/gallery/views/admin/settings/index.php
@@ -1,0 +1,18 @@
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <legend><?=$this->getTrans('settings') ?></legend>
+    <div class="form-group">
+        <label for="picturesPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('picturesPerPage') ?>:
+        </label>
+        <div class="col-lg-8">
+            <input class="form-control"
+                   id="picturesPerPageInput"
+                   name="picturesPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('picturesPerPage')) ?>" />
+        </div>
+    </div>
+    <?=$this->getSaveBar() ?>
+</form>

--- a/application/modules/guestbook/controllers/Index.php
+++ b/application/modules/guestbook/controllers/Index.php
@@ -21,6 +21,7 @@ class Index extends \Ilch\Controller\Frontend
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('guestbook'), ['action' => 'index']);
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('gbook_entriesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('gbook_entriesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('entries', $guestbookMapper->getEntries(['setfree' => 1], $pagination));

--- a/application/modules/guestbook/controllers/admin/Settings.php
+++ b/application/modules/guestbook/controllers/admin/Settings.php
@@ -40,9 +40,11 @@ class Settings extends \Ilch\Controller\Admin
 
         if ($this->getRequest()->isPost()) {
             $this->getConfig()->set('gbook_autosetfree', $this->getRequest()->getPost('entrySettings'));
+            $this->getConfig()->set('gbook_entriesPerPage', $this->getRequest()->getPost('entriesPerPage'));
             $this->addMessage('saveSuccess');
         }
-        
+
         $this->getView()->set('setfree', $this->getConfig()->get('gbook_autosetfree'));
+        $this->getView()->set('entriesPerPage', $this->getConfig()->get('gbook_entriesPerPage'));
     }
 }

--- a/application/modules/guestbook/translations/de.php
+++ b/application/modules/guestbook/translations/de.php
@@ -36,6 +36,7 @@ return [
     'captchaRead' => 'Nicht lesbar? Text ändern!',
     'smilies' => 'Smilies',
     'close' => 'Schließen',
+    'entriesPerPage' => 'Einträge pro Seite',
 
     'validation.errors.required.fieldIsRequired'    => '%s muss ausgefüllt werden.',
     'validation.errors.same.fieldsDontMatch'        => '%s muss mit %s übereinstimmen.',

--- a/application/modules/guestbook/translations/en.php
+++ b/application/modules/guestbook/translations/en.php
@@ -36,4 +36,5 @@ return [
     'captchaRead' => 'Not readable? Change text!',
     'smilies' => 'Smilies',
     'close' => 'Close',
+    'entriesPerPage' => 'Einträge pro Seite',
 ];

--- a/application/modules/guestbook/views/admin/settings/index.php
+++ b/application/modules/guestbook/views/admin/settings/index.php
@@ -14,6 +14,19 @@
                 <span class="flipswitch-selection"></span>  
             </div>  
         </div>
-    </div> 
+    </div>
+    <div class="form-group">
+        <label for="entriesPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('entriesPerPage') ?>:
+        </label>
+        <div class="col-lg-2">
+            <input class="form-control"
+                   id="entriesPerPageInput"
+                   name="entriesPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('entriesPerPage')) ?>" />
+        </div>
+    </div>    
     <?=$this->getSaveBar()?>
 </form>

--- a/application/modules/media/controllers/admin/Ajax.php
+++ b/application/modules/media/controllers/admin/Ajax.php
@@ -16,6 +16,7 @@ class Ajax extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $lastId = $this->getRequest()->getParam('lastid');
@@ -38,6 +39,7 @@ class Ajax extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $lastId = $this->getRequest()->getParam('lastid');

--- a/application/modules/media/controllers/admin/Iframe.php
+++ b/application/modules/media/controllers/admin/Iframe.php
@@ -16,6 +16,7 @@ class Iframe extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $lastId = $this->getRequest()->getParam('lastid');
 
@@ -49,6 +50,7 @@ class Iframe extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $lastId = $this->getRequest()->getParam('lastid');
@@ -83,6 +85,7 @@ class Iframe extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $lastId = $this->getRequest()->getParam('lastid');
 
@@ -116,6 +119,7 @@ class Iframe extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('pagination', $pagination);

--- a/application/modules/media/controllers/admin/Index.php
+++ b/application/modules/media/controllers/admin/Index.php
@@ -70,6 +70,7 @@ class Index extends \Ilch\Controller\Admin
         }
 
         $pagination = new \Ilch\Pagination();
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         if ($this->getRequest()->getParam('rows')) {

--- a/application/modules/media/controllers/admin/Settings.php
+++ b/application/modules/media/controllers/admin/Settings.php
@@ -52,6 +52,7 @@ class Settings extends \Ilch\Controller\Admin
             $this->getConfig()->set('media_ext_img', strtolower($this->getRequest()->getPost('allowedImages')));
             $this->getConfig()->set('media_ext_file', strtolower($this->getRequest()->getPost('allowedFiles')));
             $this->getConfig()->set('media_ext_video', strtolower($this->getRequest()->getPost('allowedVideos')));
+            $this->getConfig()->set('media_picturesPerPage', $this->getRequest()->getPost('picturesPerPage'));
 
             $this->addMessage('success');
         }
@@ -59,5 +60,6 @@ class Settings extends \Ilch\Controller\Admin
         $this->getView()->set('media_ext_img', $this->getConfig()->get('media_ext_img'));
         $this->getView()->set('media_ext_file', $this->getConfig()->get('media_ext_file'));
         $this->getView()->set('media_ext_video', $this->getConfig()->get('media_ext_video'));
+        $this->getView()->set('picturesPerPage', $this->getConfig()->get('media_picturesPerPage'));
     }
 }

--- a/application/modules/media/controllers/admin/Settings.php
+++ b/application/modules/media/controllers/admin/Settings.php
@@ -52,7 +52,7 @@ class Settings extends \Ilch\Controller\Admin
             $this->getConfig()->set('media_ext_img', strtolower($this->getRequest()->getPost('allowedImages')));
             $this->getConfig()->set('media_ext_file', strtolower($this->getRequest()->getPost('allowedFiles')));
             $this->getConfig()->set('media_ext_video', strtolower($this->getRequest()->getPost('allowedVideos')));
-            $this->getConfig()->set('media_picturesPerPage', $this->getRequest()->getPost('picturesPerPage'));
+            $this->getConfig()->set('media_mediaPerPage', $this->getRequest()->getPost('mediaPerPage'));
 
             $this->addMessage('success');
         }
@@ -60,6 +60,6 @@ class Settings extends \Ilch\Controller\Admin
         $this->getView()->set('media_ext_img', $this->getConfig()->get('media_ext_img'));
         $this->getView()->set('media_ext_file', $this->getConfig()->get('media_ext_file'));
         $this->getView()->set('media_ext_video', $this->getConfig()->get('media_ext_video'));
-        $this->getView()->set('picturesPerPage', $this->getConfig()->get('media_picturesPerPage'));
+        $this->getView()->set('mediaPerPage', $this->getConfig()->get('media_mediaPerPage'));
     }
 }

--- a/application/modules/media/translations/de.php
+++ b/application/modules/media/translations/de.php
@@ -51,5 +51,5 @@ return [
     'noCats' => 'Keine Kategorien vorhanden',
     'treatCat' => 'Kategorie bearbeiten',
 
-    'picturesPerPage' => 'Bilder pro Seite',
+    'mediaPerPage' => 'Dateien pro Seite',
 ];

--- a/application/modules/media/translations/de.php
+++ b/application/modules/media/translations/de.php
@@ -50,4 +50,6 @@ return [
     'newCat' => 'Neue Kategorie anlegen',
     'noCats' => 'Keine Kategorien vorhanden',
     'treatCat' => 'Kategorie bearbeiten'
+
+    'picturesPerPage' => 'Bilder pro Seite',
 ];

--- a/application/modules/media/translations/de.php
+++ b/application/modules/media/translations/de.php
@@ -49,7 +49,7 @@ return [
     'menuActionAddNewCat' => 'Neue Kategorie',
     'newCat' => 'Neue Kategorie anlegen',
     'noCats' => 'Keine Kategorien vorhanden',
-    'treatCat' => 'Kategorie bearbeiten'
+    'treatCat' => 'Kategorie bearbeiten',
 
     'picturesPerPage' => 'Bilder pro Seite',
 ];

--- a/application/modules/media/translations/en.php
+++ b/application/modules/media/translations/en.php
@@ -50,4 +50,6 @@ return[
     'newCat' => 'Add new category',
     'noCats' => 'No categories available',
     'treatCat' => 'Treat category'
+
+    'picturesPerPage' => 'Pictures per page',
 ];

--- a/application/modules/media/translations/en.php
+++ b/application/modules/media/translations/en.php
@@ -49,7 +49,7 @@ return[
     'menuActionAddNewCat' => 'New category',
     'newCat' => 'Add new category',
     'noCats' => 'No categories available',
-    'treatCat' => 'Treat category'
+    'treatCat' => 'Treat category',
 
     'picturesPerPage' => 'Pictures per page',
 ];

--- a/application/modules/media/translations/en.php
+++ b/application/modules/media/translations/en.php
@@ -51,5 +51,5 @@ return[
     'noCats' => 'No categories available',
     'treatCat' => 'Treat category',
 
-    'picturesPerPage' => 'Pictures per page',
+    'mediaPerPage' => 'Media per page',
 ];

--- a/application/modules/media/views/admin/settings/index.php
+++ b/application/modules/media/views/admin/settings/index.php
@@ -36,16 +36,16 @@
         </div>
     </div>
     <div class="form-group">
-        <label for="picturesPerPageInput" class="col-lg-2 control-label">
-            <?=$this->getTrans('picturesPerPage') ?>:
+        <label for="mediaPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('mediaPerPage') ?>:
         </label>
         <div class="col-lg-2">
             <input class="form-control"
-                   id="picturesPerPageInput"
-                   name="picturesPerPage"
+                   id="mediaPerPageInput"
+                   name="mediaPerPage"
                    type="number"
                    min="1"
-                   value="<?=$this->escape($this->get('picturesPerPage')) ?>" />
+                   value="<?=$this->escape($this->get('mediaPerPage')) ?>" />
         </div>
     </div>
     <?=$this->getSaveBar() ?>

--- a/application/modules/media/views/admin/settings/index.php
+++ b/application/modules/media/views/admin/settings/index.php
@@ -5,36 +5,49 @@
 </legend>
 <form class="form-horizontal" method="POST" action="">
     <?=$this->getTokenField() ?>
-        <div class="form-group">
-            <label for="allowedImagesInput" class="col-lg-2 control-label">
-                <?=$this->getTrans('allowedImages') ?>:
-            </label>
-            <div class="col-lg-8">
-                <textarea class="form-control"
-                          id="allowedImagesInput"
-                          name="allowedImages"><?=$this->escape($this->get('media_ext_img')) ?></textarea>
-            </div>
+    <div class="form-group">
+        <label for="allowedImagesInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('allowedImages') ?>:
+        </label>
+        <div class="col-lg-8">
+            <textarea class="form-control"
+                      id="allowedImagesInput"
+                      name="allowedImages"><?=$this->escape($this->get('media_ext_img')) ?></textarea>
         </div>
-        <div class="form-group">
-            <label for="allowedVideosInput" class="col-lg-2 control-label">
-                <?=$this->getTrans('allowedVideos') ?>:
-            </label>
-            <div class="col-lg-8">
-                <textarea class="form-control"
-                          id="allowedVideosInput"
-                          name="allowedVideos"><?=$this->escape($this->get('media_ext_video')) ?></textarea>
-            </div>
+    </div>
+    <div class="form-group">
+        <label for="allowedVideosInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('allowedVideos') ?>:
+        </label>
+        <div class="col-lg-8">
+            <textarea class="form-control"
+                      id="allowedVideosInput"
+                      name="allowedVideos"><?=$this->escape($this->get('media_ext_video')) ?></textarea>
         </div>
-        <div class="form-group">
-            <label for="allowedFilesInput" class="col-lg-2 control-label">
-                <?=$this->getTrans('allowedFiles') ?>:
-            </label>
-            <div class="col-lg-8">
-                <textarea class="form-control"
-                          id="allowedFilesInput"
-                          name="allowedFiles"><?=$this->escape($this->get('media_ext_file')) ?></textarea>
-            </div>
+    </div>
+    <div class="form-group">
+        <label for="allowedFilesInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('allowedFiles') ?>:
+        </label>
+        <div class="col-lg-8">
+            <textarea class="form-control"
+                      id="allowedFilesInput"
+                      name="allowedFiles"><?=$this->escape($this->get('media_ext_file')) ?></textarea>
         </div>
+    </div>
+    <div class="form-group">
+        <label for="picturesPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('picturesPerPage') ?>:
+        </label>
+        <div class="col-lg-2">
+            <input class="form-control"
+                   id="picturesPerPageInput"
+                   name="picturesPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('picturesPerPage')) ?>" />
+        </div>
+    </div>
     <?=$this->getSaveBar() ?>
 </form>
 

--- a/application/modules/smilies/controllers/admin/Iframe.php
+++ b/application/modules/smilies/controllers/admin/Iframe.php
@@ -16,6 +16,7 @@ class Iframe extends \Ilch\Controller\Admin
         $smiliesMapper = new SmiliesMapper();
         $pagination = new \Ilch\Pagination();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('smilies_smiliesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('smilies_smiliesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $lastId = $this->getRequest()->getParam('lastid');
         $type = $this->getConfig()->get('smiley_filetypes');

--- a/application/modules/smilies/controllers/admin/Settings.php
+++ b/application/modules/smilies/controllers/admin/Settings.php
@@ -54,8 +54,10 @@ class Settings extends \Ilch\Controller\Admin
 
         if ($this->getRequest()->isPost()) {
             $this->getConfig()->set('smiley_filetypes', $this->getRequest()->getPost('smiley_filetypes'));
+            $this->getConfig()->set('smilies_smiliesPerPage', $this->getRequest()->getPost('smiliesPerPage'));
         }
 
         $this->getView()->set('smiley_filetypes', $this->getConfig()->get('smiley_filetypes'));
+        $this->getView()->set('smiliesPerPage', $this->getConfig()->get('smilies_smiliesPerPage'));
     }
 }

--- a/application/modules/smilies/translations/de.php
+++ b/application/modules/smilies/translations/de.php
@@ -18,4 +18,5 @@ return [
     'allowedFileExtensions' => 'Erlaubte Dateiendungen',
     'missingName' => 'Name muss ausgefüllt werden',
     'missingUrl' => 'Smilie muss ausgewählt werden',
+    'smiliesPerPage' => 'Smilies pro Seite',
 ];

--- a/application/modules/smilies/translations/en.php
+++ b/application/modules/smilies/translations/en.php
@@ -18,4 +18,5 @@ return [
     'allowedFileExtensions' => 'Allowed file extensions',
     'missingName' => 'Name was not filled',
     'missingUrl' => 'Smiley must be selected',
+    'smiliesPerPage' => 'Smilies per page',
 ];

--- a/application/modules/smilies/views/admin/settings/index.php
+++ b/application/modules/smilies/views/admin/settings/index.php
@@ -13,5 +13,18 @@
                    value="<?=$this->get('smiley_filetypes') ?>" />
         </div>
     </div>
+    <div class="form-group">
+        <label for="smiliesPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('smiliesPerPage') ?>:
+        </label>
+        <div class="col-lg-2">
+            <input class="form-control"
+                   id="smiliesPerPageInput"
+                   name="smiliesPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('smiliesPerPage')) ?>" />
+        </div>
+    </div>
     <?=$this->getSaveBar(); ?>
 </form>

--- a/application/modules/user/controllers/Gallery.php
+++ b/application/modules/user/controllers/Gallery.php
@@ -54,6 +54,7 @@ class Gallery extends \Ilch\Controller\Frontend
                 ->add($this->getTranslator()->trans('menuGallery'), ['controller' => 'gallery', 'action' => 'index', 'user' => $this->getRequest()->getParam('user')])
                 ->add($gallery->getTitle(), ['action' => 'show', 'user' => $this->getRequest()->getParam('user'), 'id' => $id]);
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('user_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('user_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('image', $imageMapper->getImageByGalleryId($id, $pagination));

--- a/application/modules/user/controllers/Iframe.php
+++ b/application/modules/user/controllers/Iframe.php
@@ -18,6 +18,7 @@ class Iframe extends \Ilch\Controller\Frontend
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('user_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('user_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $lastId = $this->getRequest()->getParam('lastid');
 

--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -484,6 +484,7 @@ class Panel extends BaseController
             }
         }
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('user_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('user_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $this->getView()->set('image', $imageMapper->getImageByGalleryId($id, $pagination));
         $this->getView()->set('pagination', $pagination);

--- a/application/modules/user/controllers/admin/Settings.php
+++ b/application/modules/user/controllers/admin/Settings.php
@@ -28,6 +28,7 @@ class Settings extends BaseController
             $this->getConfig()->set('regist_confirm_mail', $this->getRequest()->getPost('regist_confirm_mail'));
             $this->getConfig()->set('manually_confirm_mail', $this->getRequest()->getPost('manually_confirm_mail'));
             $this->getConfig()->set('password_change_mail', $this->getRequest()->getPost('password_change_mail'));
+            $this->getConfig()->set('user_picturesPerPage', $this->getRequest()->getPost('picturesPerPage'));
             $this->addMessage('saveSuccess');
         }
 
@@ -43,5 +44,6 @@ class Settings extends BaseController
         $this->getView()->set('regist_confirm_mail', $this->getConfig()->get('regist_confirm_mail'));
         $this->getView()->set('manually_confirm_mail', $this->getConfig()->get('manually_confirm_mail'));
         $this->getView()->set('password_change_mail', $this->getConfig()->get('password_change_mail'));
+        $this->getView()->set('picturesPerPage', $this->getConfig()->get('user_picturesPerPage'));
     }
 }

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -268,4 +268,6 @@ return [
     'newProfileFieldMsg' => 'Neues Profil-Feld erfolgreich hinzugefügt',
     'menuActionNewProfileField' => 'Neues Profil-Feld hinzufügen',
     'profileFieldInfoText' => 'Erstelle Profil-Felder oder Kategorien können durch ziehen und ablegen sortiert werden.',
+
+    'picturesPerPage' => 'Bilder pro Seite',
 ];

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -268,4 +268,6 @@ return [
     'newProfileFieldMsg' => 'New profile-field successfully added',
     'menuActionNewProfileField' => 'Create new profile-field',
     'profileFieldInfoText' => 'Created profile-fields and categories can be sorted by drag and drop.',
+
+    'picturesPerPage' => 'Pictures per page',
 ];

--- a/application/modules/user/views/admin/settings/index.php
+++ b/application/modules/user/views/admin/settings/index.php
@@ -187,6 +187,19 @@
                    value="<?=$this->get('usergallery_filetypes') ?>" />
         </div>
     </div>
+    <div class="form-group">
+        <label for="picturesPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('picturesPerPage') ?>:
+        </label>
+        <div class="col-lg-2">
+            <input class="form-control"
+                   id="picturesPerPageInput"
+                   name="picturesPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('picturesPerPage')) ?>" />
+        </div>
+    </div>
     <?=$this->getSaveBar() ?>
 </form>
 

--- a/application/modules/war/controllers/Group.php
+++ b/application/modules/war/controllers/Group.php
@@ -20,6 +20,7 @@ class Group extends \Ilch\Controller\Frontend
         $groupMapper = new GroupMapper();
         $pagination = new \Ilch\Pagination();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_warsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('groups', $groupMapper->getGroupList($pagination));
@@ -34,6 +35,7 @@ class Group extends \Ilch\Controller\Frontend
 
         $id = $this->getRequest()->getParam('id');
         $group = $groupMapper->getGroupById($id);
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_warsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getLayout()->getHmenu()

--- a/application/modules/war/controllers/Index.php
+++ b/application/modules/war/controllers/Index.php
@@ -20,6 +20,7 @@ class Index extends \Ilch\Controller\Frontend
         $pagination = new \Ilch\Pagination();
         $warMapper = new WarMapper();
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_warsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('war', $warMapper->getWarList($pagination));

--- a/application/modules/war/controllers/admin/Base.php
+++ b/application/modules/war/controllers/admin/Base.php
@@ -41,6 +41,12 @@ class Base extends \Ilch\Controller\Admin
                     'icon' => 'fa fa-group',
                     'url' => $this->getLayout()->getUrl(['controller' => 'group', 'action' => 'index'])
                 ],
+                [
+                    'name' => 'menuSettings',
+                    'active' => false,
+                    'icon' => 'fa fa-th-list',
+                    'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
+                ],
             ]
         );
     }

--- a/application/modules/war/controllers/admin/Enemy.php
+++ b/application/modules/war/controllers/admin/Enemy.php
@@ -39,6 +39,7 @@ class Enemy extends BaseController
             }
         }
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_enemiesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_enemiesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('enemy', $enemyMapper->getEnemyList($pagination));

--- a/application/modules/war/controllers/admin/Group.php
+++ b/application/modules/war/controllers/admin/Group.php
@@ -40,6 +40,7 @@ class Group extends BaseController
             }
         }
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_groupsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_groupsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('groups', $groupMapper->getGroupList($pagination));

--- a/application/modules/war/controllers/admin/Index.php
+++ b/application/modules/war/controllers/admin/Index.php
@@ -43,6 +43,7 @@ class Index extends BaseController
             }
         }
 
+        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_warsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         if ($this->getRequest()->getPost('filter') == 'filter' and $this->getRequest()->getPost('filterLastNext') !='0') {

--- a/application/modules/war/controllers/admin/Settings.php
+++ b/application/modules/war/controllers/admin/Settings.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\War\Controllers\Admin;
+
+use Modules\War\Controllers\Admin\Base as BaseController;
+
+class Settings extends BaseController
+{
+    public function indexAction()
+    {
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('manageWarOverview'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('settings'), ['action' => 'index']);
+
+        if ($this->getRequest()->isPost()) {
+            $this->getConfig()->set('war_warsPerPage', $this->getRequest()->getPost('warsPerPage'));
+            $this->addMessage('saveSuccess');
+        }
+
+        $this->getView()->set('warsPerPage', $this->getConfig()->get('war_warsPerPage'));
+    }
+}

--- a/application/modules/war/controllers/admin/Settings.php
+++ b/application/modules/war/controllers/admin/Settings.php
@@ -18,9 +18,13 @@ class Settings extends BaseController
 
         if ($this->getRequest()->isPost()) {
             $this->getConfig()->set('war_warsPerPage', $this->getRequest()->getPost('warsPerPage'));
+            $this->getConfig()->set('war_enemiesPerPage', $this->getRequest()->getPost('enemiesPerPage'));
+            $this->getConfig()->set('war_groupsPerPage', $this->getRequest()->getPost('groupsPerPage'));
             $this->addMessage('saveSuccess');
         }
 
         $this->getView()->set('warsPerPage', $this->getConfig()->get('war_warsPerPage'));
+        $this->getView()->set('enemiesPerPage', $this->getConfig()->get('war_enemiesPerPage'));
+        $this->getView()->set('groupsPerPage', $this->getConfig()->get('war_groupsPerPage'));
     }
 }

--- a/application/modules/war/translations/de.php
+++ b/application/modules/war/translations/de.php
@@ -135,4 +135,6 @@ return [
     'missingGroupPoints' => 'Es wurde nicht angegeben wie viele Punkte erzielt wurden.',
     'missingEnemyPoints' => 'Es wurde nicht angegeben wie viele Punkte der Gegner erzielt hat.',
     'warsPerPage' => 'Wars pro Seite',
+    'enemiesPerPage' => 'Gegner pro Seite',
+    'groupsPerPage' => 'Gruppen pro Seite',
 ];

--- a/application/modules/war/translations/de.php
+++ b/application/modules/war/translations/de.php
@@ -134,4 +134,5 @@ return [
     'missingWarMapPlayed' => 'Es wurde nicht angegeben welche Map gespielt wurde.',
     'missingGroupPoints' => 'Es wurde nicht angegeben wie viele Punkte erzielt wurden.',
     'missingEnemyPoints' => 'Es wurde nicht angegeben wie viele Punkte der Gegner erzielt hat.',
+    'warsPerPage' => 'Wars pro Seite',
 ];

--- a/application/modules/war/translations/en.php
+++ b/application/modules/war/translations/en.php
@@ -134,4 +134,5 @@ return [
     'missingWarMapPlayed' => 'No played map entered.',
     'missingGroupPoints' => 'No points added.',
     'missingEnemyPoints' => 'No points of the enemy added.',
+    'warsPerPage' => 'Wars per page',
 ];

--- a/application/modules/war/translations/en.php
+++ b/application/modules/war/translations/en.php
@@ -135,4 +135,6 @@ return [
     'missingGroupPoints' => 'No points added.',
     'missingEnemyPoints' => 'No points of the enemy added.',
     'warsPerPage' => 'Wars per page',
+    'enemiesPerPage' => 'Enemies per page',
+    'groupsPerPage' => 'Groups per page',
 ];

--- a/application/modules/war/views/admin/settings/index.php
+++ b/application/modules/war/views/admin/settings/index.php
@@ -5,7 +5,7 @@
         <label for="warsPerPageInput" class="col-lg-2 control-label">
             <?=$this->getTrans('warsPerPage') ?>:
         </label>
-        <div class="col-lg-8">
+        <div class="col-lg-2">
             <input class="form-control"
                    id="warsPerPageInput"
                    name="warsPerPage"

--- a/application/modules/war/views/admin/settings/index.php
+++ b/application/modules/war/views/admin/settings/index.php
@@ -1,0 +1,18 @@
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <legend><?=$this->getTrans('settings') ?></legend>
+    <div class="form-group">
+        <label for="warsPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('warsPerPagePerPage') ?>:
+        </label>
+        <div class="col-lg-8">
+            <input class="form-control"
+                   id="warsPerPageInput"
+                   name="warsPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('warsPerPage')) ?>" />
+        </div>
+    </div>
+    <?=$this->getSaveBar() ?>
+</form>

--- a/application/modules/war/views/admin/settings/index.php
+++ b/application/modules/war/views/admin/settings/index.php
@@ -3,7 +3,7 @@
     <legend><?=$this->getTrans('settings') ?></legend>
     <div class="form-group">
         <label for="warsPerPageInput" class="col-lg-2 control-label">
-            <?=$this->getTrans('warsPerPagePerPage') ?>:
+            <?=$this->getTrans('warsPerPage') ?>:
         </label>
         <div class="col-lg-8">
             <input class="form-control"

--- a/application/modules/war/views/admin/settings/index.php
+++ b/application/modules/war/views/admin/settings/index.php
@@ -14,5 +14,31 @@
                    value="<?=$this->escape($this->get('warsPerPage')) ?>" />
         </div>
     </div>
+    <div class="form-group">
+        <label for="enemiesPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('enemiesPerPage') ?>:
+        </label>
+        <div class="col-lg-2">
+            <input class="form-control"
+                   id="enemiesPerPageInput"
+                   name="enemiesPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('enemiesPerPage')) ?>" />
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="groupsPerPageInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('groupsPerPage') ?>:
+        </label>
+        <div class="col-lg-2">
+            <input class="form-control"
+                   id="groupsPerPageInput"
+                   name="groupsPerPage"
+                   type="number"
+                   min="1"
+                   value="<?=$this->escape($this->get('groupsPerPage')) ?>" />
+        </div>
+    </div>
     <?=$this->getSaveBar() ?>
 </form>


### PR DESCRIPTION
[Ticket 248](http://redmine.ilch2.de/issues/248)

Added settings to all modules currently using pagination as well as an general setting. If no value is set in the module-settings then the value of the general setting is used.

If the pagination is used without setting rowsPerPage by calling setRowsPerPage of the pagination-class then the hard-coded value of 20 is used, which is the same behavior as before.

The input-fields in the settings are of type number and with a minimum value of 1.

The media-module might need more work as there is a specific value of 40 set
for rowsPerPage in iframe.php on line ~36, ~71 and ~104. There need to be a
decision on what to do with these cases.