### PR TITLE
Fix invalid argument supplied for foreach()

### DIFF
--- a/application/modules/page/mappers/Page.php
+++ b/application/modules/page/mappers/Page.php
@@ -30,7 +30,7 @@ class Page extends \Ilch\Mapper
         $pageArray = $this->db()->queryArray($sql);
 
         if (empty($pageArray)) {
-            return null;
+            return [];
         }
 
         $pages = [];


### PR DESCRIPTION
This fixes the following issue:
PHP Warning:  Invalid argument supplied for foreach() in
application\modules\admin\views\admin\settings\index.php on line 11

This one occured when there was no page. getPageList() returned 'null' in this case, which lead to the issue above when passed as argument for foreach().