### PR TITLE
Fix fatal-error in rule-module

### DIFF
--- a/application/modules/rule/controllers/Index.php
+++ b/application/modules/rule/controllers/Index.php
@@ -16,6 +16,6 @@ class Index extends \Ilch\Controller\Frontend
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('menuRules'), ['action' => 'index']);
 
-        $this->getView()->set('rules', $ruleMapper->getEntries());
+        $this->getView()->set('rules', $ruleMapper->getRules());
     }
 }

--- a/application/modules/rule/controllers/admin/Index.php
+++ b/application/modules/rule/controllers/admin/Index.php
@@ -57,9 +57,9 @@ class Index extends \Ilch\Controller\Admin
             }
         }
 
-        $entries = $ruleMapper->getEntries();
+        $rules = $ruleMapper->getRules();
 
-        $this->getView()->set('entries', $entries);
+        $this->getView()->set('rules', $rules);
     }
 
     public function treatAction() 

--- a/application/modules/rule/mappers/Rule.php
+++ b/application/modules/rule/mappers/Rule.php
@@ -6,7 +6,7 @@
 
 namespace Modules\Rule\Mappers;
 
-use Modules\Rule\Models\Entry as RuleModel;
+use Modules\Rule\Models\Rule as RuleModel;
 
 class Rule extends \Ilch\Mapper
 {
@@ -16,30 +16,30 @@ class Rule extends \Ilch\Mapper
      * @param array $where
      * @return RuleModel[]|array
      */
-    public function getEntries($where = [])
+    public function getRules($where = [])
     {
-        $entryArray = $this->db()->select('*')
+        $rulesArray = $this->db()->select('*')
             ->from('rules')
             ->where($where)
             ->order(['paragraph' => 'ASC'])
             ->execute()
             ->fetchRows();
 
-        if (empty($entryArray)) {
+        if (empty($rulesArray)) {
             return null;
         }
 
-        $entry = [];
-        foreach ($entryArray as $entries) {
-            $entryModel = new RuleModel();
-            $entryModel->setId($entries['id']);
-            $entryModel->setParagraph($entries['paragraph']);
-            $entryModel->setTitle($entries['title']);
-            $entryModel->setText($entries['text']);
-            $entry[] = $entryModel;
+        $rules = [];
+        foreach ($rulesArray as $rule) {
+            $ruleModel = new RuleModel();
+            $ruleModel->setId($rule['id']);
+            $ruleModel->setParagraph($rule['paragraph']);
+            $ruleModel->setTitle($rule['title']);
+            $ruleModel->setText($rule['text']);
+            $rules[] = $ruleModel;
         }
 
-        return $entry;
+        return $rules;
     }
 
     /**

--- a/application/modules/rule/views/admin/index/index.php
+++ b/application/modules/rule/views/admin/index/index.php
@@ -1,5 +1,5 @@
 <legend><?=$this->getTrans('manage') ?></legend>
-<?php if ($this->get('entries') != ''): ?>
+<?php if ($this->get('rules') != ''): ?>
     <form class="form-horizontal" method="POST" action="">
         <?=$this->getTokenField() ?>
         <div class="table-responsive">
@@ -23,14 +23,14 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($this->get('entries') as $entry): ?>
+                    <?php foreach ($this->get('rules') as $rule): ?>
                         <tr>
-                            <td><input value="<?=$entry->getId() ?>" type="checkbox" name="check_entries[]" /></td>
-                            <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $entry->getId()]) ?></td>
-                            <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $entry->getId()]) ?></td>
-                            <td><?=$this->escape($entry->getParagraph()) ?></td>
-                            <td><?=$this->escape($entry->getTitle()) ?></td>
-                            <td><?=$entry->getText() ?></td>
+                            <td><input value="<?=$rule->getId() ?>" type="checkbox" name="check_entries[]" /></td>
+                            <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $rule->getId()]) ?></td>
+                            <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $rule->getId()]) ?></td>
+                            <td><?=$this->escape($rule->getParagraph()) ?></td>
+                            <td><?=$this->escape($rule->getTitle()) ?></td>
+                            <td><?=$rule->getText() ?></td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>


### PR DESCRIPTION
Fixed the issue found by NDHellfire.

> Catchable fatal error: Argument 1 passed to Modules\Rule\Mappers\Rule::save() must be an instance of Modules\Rule\Models\Entry, instance of Modules\Rule\Models\Rule given, called in application\modules\rule\controllers\admin\Index.php on line 99 and defined in application\modules\rule\mappers\Rule.php on line 110

Thread related to this issue:
http://www.ilch.de/forum-showposts-53407.html

Further finished the started work of renaming "entry" or
"entries" to a more specific name like "rule" or "rules".