### PR TITLE
Fix fatal error when deleting last post

### DIFF
--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -90,7 +90,7 @@ class Showposts extends \Ilch\Controller\Frontend
 
         $postId = (int)$this->getRequest()->getParam('id');
         $topicId = (int)$this->getRequest()->getParam('topicid');
-        $forumId = (int)$this->getRequest()->getParam('forumid');
+        $forumId = $forumMapper->getForumByTopicId($topicId)->getId();
         $countPosts = $forumMapper->getCountPostsByTopicId($topicId);
         if ($this->getUser()) {
             if ($this->getUser()->isAdmin()) {


### PR DESCRIPTION
Fatal error: Call to a member function getParentId() on null in
application\modules\forum\controllers\Showtopics.php on line 25

This error happened when trying to delete the last post of a topic.
It was tried to get an request-parameter "forumid" where it doesn't exist. The integer-cast returned 0 by default, which can be an invalid forumid.