### PR TITLE
feature/profilefields-translations-ticket253

### DIFF
--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -24,6 +24,7 @@ use Ilch\Date as IlchDate;
 use Modules\User\Mappers\ProfileFieldsContent as ProfileFieldsContentMapper;
 use Modules\User\Mappers\ProfileFields as ProfileFieldsMapper;
 use Modules\User\Models\ProfileFieldContent as ProfileFieldContentModel;
+use Modules\User\Mappers\ProfileFieldsTranslation as ProfileFieldsTranslationMapper;
 
 class Panel extends BaseController
 {
@@ -51,12 +52,15 @@ class Panel extends BaseController
 
         $profileFieldsContentMapper = new ProfileFieldsContentMapper();
         $profileFieldsMapper = new ProfileFieldsMapper();
+        $profileFieldsTranslationMapper = new ProfileFieldsTranslationMapper();
 
         $profileFieldsContent = $profileFieldsContentMapper->getProfileFieldContentByUserId($this->getUser()->getId());
         $profileFields = $profileFieldsMapper->getProfileFields();
+        $profileFieldsTranslation = $profileFieldsTranslationMapper->getProfileFieldTranslationByLocale($this->getTranslator()->getLocale());
         $this->getView()->set('profileFieldsContent', $profileFieldsContent);
         $this->getView()->set('profileFields', $profileFields);
-        
+        $this->getView()->set('profileFieldsTranslation', $profileFieldsTranslation);
+
         $errors = [];
         if ($this->getRequest()->isPost()) {
             $email = trim($this->getRequest()->getPost('email'));

--- a/application/modules/user/controllers/Profil.php
+++ b/application/modules/user/controllers/Profil.php
@@ -10,6 +10,7 @@ use Modules\User\Mappers\User as UserMapper;
 use Modules\User\Mappers\Gallery as GalleryMapper;
 use Modules\User\Mappers\ProfileFieldsContent as ProfileFieldsContentMapper;
 use Modules\User\Mappers\ProfileFields as ProfileFieldsMapper;
+use Modules\User\Mappers\ProfileFieldsTranslation as ProfileFieldsTranslationMapper;
 
 class Profil extends \Ilch\Controller\Frontend
 {
@@ -19,10 +20,12 @@ class Profil extends \Ilch\Controller\Frontend
         $galleryMapper = new GalleryMapper();
         $profileFieldsContentMapper = new ProfileFieldsContentMapper();
         $profileFieldsMapper = new ProfileFieldsMapper();
+        $profileFieldsTranslationMapper = new ProfileFieldsTranslationMapper();
 
         $profil = $userMapper->getUserById($this->getRequest()->getParam('user'));
         $profileFieldsContent = $profileFieldsContentMapper->getProfileFieldContentByUserId($this->getRequest()->getParam('user'));
         $profileFields = $profileFieldsMapper->getProfileFields();
+        $profileFieldsTranslation = $profileFieldsTranslationMapper->getProfileFieldTranslationByLocale($this->getTranslator()->getLocale());
 
         if ($profil) {
             $this->getLayout()->getHmenu()
@@ -33,6 +36,7 @@ class Profil extends \Ilch\Controller\Frontend
             $this->getView()->set('profil', $profil);
             $this->getView()->set('profileFieldsContent', $profileFieldsContent);
             $this->getView()->set('profileFields', $profileFields);
+            $this->getView()->set('profileFieldsTranslation', $profileFieldsTranslation);
             $this->getView()->set('galleryAllowed', $this->getConfig()->get('usergallery_allowed'));
             $this->getView()->set('gallery', $galleryMapper->getCountGalleryByUser($this->getRequest()->getParam('user')));
         } else {

--- a/application/modules/user/mappers/ProfileFieldsTranslation.php
+++ b/application/modules/user/mappers/ProfileFieldsTranslation.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\User\Mappers;
+
+use Modules\User\Models\ProfileFieldTranslation as ProfileFieldTranslationModel;
+
+class ProfileFieldsTranslation extends \Ilch\Mapper
+{
+    /**
+     * Returns all ProfileFieldTranslation found by the locale.
+     *
+     * @param  string $locale
+     * @return array()|\Modules\User\Models\ProfileFieldTranslation
+     */
+    public function getProfileFieldTranslationByLocale($locale)
+    {
+        $profileFieldTranslationRows = $this->db()->select('*')
+            ->from('profile_trans')
+            ->where(['locale' => $locale])
+            ->execute()
+            ->fetchRows();
+
+        $profileFieldsTranslation = [];
+        if (!empty($profileFieldTranslationRows)) {
+            foreach ($profileFieldTranslationRows as $profileFieldTranslationRow) {
+                $profileFieldTranslation = $this->loadFromArray($profileFieldTranslationRow);
+                $profileFieldsTranslation[] = $profileFieldTranslation;
+            }
+        }
+        return $profileFieldsTranslation;
+    }
+
+    /**
+     * Returns a ProfileFieldTranslation model found by the fieldid.
+     *
+     * @param  int $fieldId
+     * @return array()|\Modules\User\Models\ProfileFieldTranslation
+     */
+    public function getProfileFieldTranslationByFieldId($fieldId)
+    {
+        $profileFieldTranslationRows = $this->db()->select('*')
+            ->from('profile_trans')
+            ->where(['field_id' => $fieldId])
+            ->execute()
+            ->fetchRows();
+
+        $profileFieldsTranslation = [];
+        if (!empty($profileFieldTranslationRows)) {
+            foreach ($profileFieldTranslationRows as $profileFieldTranslationRow) {
+                $profileFieldTranslation = $this->loadFromArray($profileFieldTranslationRow);
+                $profileFieldsTranslation[] = $profileFieldTranslation;
+            }
+        }
+        return $profileFieldsTranslation;
+    }
+
+    /**
+     * Returns a ProfileFieldTranslationModel created using an array with data.
+     *
+     * @param  mixed[] $profileFieldRow
+     * @return ProfileFieldTranslationModel
+     */
+    public function loadFromArray($profileFieldRow = [])
+    {
+        $profileFieldTranslation = new ProfileFieldTranslationModel();
+
+        if (isset($profileFieldRow['field_id'])) {
+            $profileFieldTranslation->setFieldId($profileFieldRow['field_id']);
+        }
+
+        if (isset($profileFieldRow['locale'])) {
+            $profileFieldTranslation->setLocale($profileFieldRow['locale']);
+        }
+
+        if (isset($profileFieldRow['name'])) {
+            $profileFieldTranslation->setName($profileFieldRow['name']);
+        }
+
+        return $profileFieldTranslation;
+    }
+
+    /**
+     * Deletes the profilefield-translations with a given fieldid.
+     * Use this function when a profilefield got deleted and it's
+     * translations are no longer needed.
+     *
+     * @param  int $fieldId
+     *
+     * @return boolean True if success, otherwise false.
+     */
+    public function deleteProfileFieldTranslationsByFieldId($fieldId) {
+        return $this->db()->delete('profile_trans')
+            ->where(['field_id' => $fieldId])
+            ->execute();
+    }
+
+    /**
+     * Deletes the profilefield-translation with a given locale and fieldid.
+     *
+     * @param  string $locale
+     * @param  int $fieldId
+     *
+     * @return boolean True if success, otherwise false.
+     */
+    public function deleteProfileFieldTranslation($locale, $fieldId) {
+        return $this->db()->delete('profile_trans')
+            ->where(['locale' => $locale, 'field_id' => $fieldId])
+            ->execute();
+    }
+
+    /**
+     * Inserts or updates a ProfileFieldTranslation model in the database.
+     *
+     * @param ProfileFieldTranslationModel $profileFieldTranslation
+     */
+    public function save(ProfileFieldTranslationModel $profileFieldTranslation)
+    {
+        $fields = [];
+        $fieldId = $profileFieldTranslation->getFieldId();
+
+        if (!empty($fieldId)) {
+            $fields['field_id'] = $profileFieldTranslation->getFieldId();
+            $fields['locale'] = $profileFieldTranslation->getLocale();
+            $fields['name'] = $profileFieldTranslation->getName();
+        }
+
+        $fieldId = (int) $this->db()->select('field_id')
+            ->from('profile_trans')
+            ->where(['field_id' => $fieldId, 'locale' => $profileFieldTranslation->getLocale()])
+            ->execute()
+            ->fetchCell();
+
+        if ($fieldId) {
+            /*
+             * profileFieldTranslation does exist already, update.
+             */
+            $this->db()->update('profile_trans')
+                ->values($fields)
+                ->where(['field_id' => $fieldId, 'locale' => $profileFieldTranslation->getLocale()])
+                ->execute();
+        } else {
+            /*
+             * profileFieldTranslation does not exist yet, insert.
+             */
+            $this->db()->insert('profile_trans')
+                ->values($fields)
+                ->execute();
+        }
+    }
+}

--- a/application/modules/user/models/ProfileFieldTranslation.php
+++ b/application/modules/user/models/ProfileFieldTranslation.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\User\Models;
+
+class ProfileFieldTranslation extends \Ilch\Model
+{
+    /**
+     * The field-id of the ProfileFieldTranslation.
+     *
+     * @var int
+     */
+    protected $fieldId;
+
+    /**
+     * The locale of the ProfileFieldTranslation.
+     *
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * The name of the ProfileFieldTranslation.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Returns the field-id of the ProfileFieldTranslation.
+     *
+     * @return int
+     */
+    public function getFieldId()
+    {
+        return $this->fieldId;
+    }
+
+    /**
+     * Sets the field-id.
+     *
+     * @param int $fieldId
+     * @return ProfileFieldTranslation
+     */
+    public function setFieldId($fieldId)
+    {
+        $this->fieldId = (int)$fieldId;
+
+        return $this;
+    }
+
+    /**
+     * Returns the locale of the ProfileFieldTranslation.
+     *
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * Sets the locale.
+     *
+     * @param string $locale
+     * @return ProfileFieldTranslation
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    /**
+     * Returns the name of the ProfileFieldTranslation.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Sets the name.
+     *
+     * @param string $name
+     * @return ProfileFieldTranslation
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -267,7 +267,8 @@ return [
     'addProfileField' => 'Profil-Feld hinzufügen',
     'newProfileFieldMsg' => 'Neues Profil-Feld erfolgreich hinzugefügt',
     'menuActionNewProfileField' => 'Neues Profil-Feld hinzufügen',
-    'profileFieldInfoText' => 'Erstelle Profil-Felder oder Kategorien können durch ziehen und ablegen sortiert werden.',
+    'profileFieldInfoText' => 'Erstellte Profil-Felder oder Kategorien können durch ziehen und ablegen sortiert werden.',
+    'profileFieldTransInfoText' => 'Übersetzungen können mit der Plus-Schaltfläche hinzugefügt und mit der Minus-Schaltfläche oder durch das Löschen des Textes gelöscht werden.',
 
     'picturesPerPage' => 'Bilder pro Seite',
 ];

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -269,6 +269,7 @@ return [
     'menuActionNewProfileField' => 'Neues Profil-Feld hinzufügen',
     'profileFieldInfoText' => 'Erstellte Profil-Felder oder Kategorien können durch ziehen und ablegen sortiert werden.',
     'profileFieldTransInfoText' => 'Übersetzungen können mit der Plus-Schaltfläche hinzugefügt und mit der Minus-Schaltfläche oder durch das Löschen des Textes gelöscht werden.',
+    'translationAlreadyExisting' => 'Es kann nur eine Übersetzung pro Sprache angelegt werden.',
 
     'picturesPerPage' => 'Bilder pro Seite',
 ];

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -269,6 +269,7 @@ return [
     'menuActionNewProfileField' => 'Create new profile-field',
     'profileFieldInfoText' => 'Created profile-fields and categories can be sorted by drag and drop.',
     'profileFieldTransInfoText' => 'Translations can be added with the plus-button and deleted with the minus-button or by deleting the text.',
+    'translationAlreadyExisting' => 'There can only be one translation per language.',
 
     'picturesPerPage' => 'Pictures per page',
 ];

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -268,6 +268,7 @@ return [
     'newProfileFieldMsg' => 'New profile-field successfully added',
     'menuActionNewProfileField' => 'Create new profile-field',
     'profileFieldInfoText' => 'Created profile-fields and categories can be sorted by drag and drop.',
+    'profileFieldTransInfoText' => 'Translations can be added with the plus-button and deleted with the minus-button or by deleting the text.',
 
     'picturesPerPage' => 'Pictures per page',
 ];

--- a/application/modules/user/views/admin/profilefields/index.php
+++ b/application/modules/user/views/admin/profilefields/index.php
@@ -25,6 +25,7 @@
         <tbody id="sortable">
             <?php
             $profileFields = $this->get('profileFields');
+            $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 
             foreach ($profileFields as $profileField) :
             ?>
@@ -38,10 +39,26 @@
                 <td>
                     <?=$this->getDeleteIcon(['action' => 'delete', 'id' => $profileField->getId()]) ?>
                 </td>
-                <?php if(!$profileField->getType()) : ?>
-                    <td><?=$this->escape($profileField->getName()) ?></td>
-                <?php else : ?>
-                    <td><b><?=$this->escape($profileField->getName()) ?></b></td>
+                <?php
+                $found = false;
+
+                foreach ($profileFieldsTranslation as $profileFieldTrans) {
+                    if ($profileField->getId() == $profileFieldTrans->getFieldId()) {
+                        $profileFieldName = $profileFieldTrans->getName();
+                        $found = true;
+                        break;
+                    }
+                } 
+
+                if (!$found) {
+                    $profileFieldName = $profileField->getName();
+                }
+                ?>
+
+                <?php if (!$profileField->getType()) : ?>
+                    <td><?=$this->escape($profileFieldName) ?></td>
+                <?php else: ?>
+                    <td><b><?=$this->escape($profileFieldName) ?></b></td>
                 <?php endif; ?>
             </tr>
             <?php endforeach; ?>

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -11,6 +11,14 @@ if ($profileField->getId()) {
 }
 ?>
 
+<script>
+var indexList = [];
+
+function addIndex(index) {
+    indexList.push(index);
+}
+</script>
+
 <fieldset>
     <legend>
         <?=$fieldsetLegend ?>
@@ -77,6 +85,7 @@ if ($profileField->getId()) {
                        placeholder="<?=$this->getTrans('profileFieldName') ?>"
                        value="<?=$this->escape($profileFieldTranslation->getName()) ?>" />
             </div>
+            <script>addIndex(<?=$i ?>)</script>
         </div>
         <?php $i++;
         endforeach; ?>
@@ -97,13 +106,18 @@ var index = <?=$i ?>;
 $('#profileFieldForm').validate();
 
 function addTranslations() {
+    if (isDuplicate()) {
+        return;
+    }
+
     var html =  '<div class="form-group" id="profileFieldTrans'+index+'">'+
                     '<input name="profileFieldTrans'+index+'[field_id]"'+
                         'type="hidden"'+
                         'value="<?=$profileField->getId() ?>" />'+
                     '<div class="col-lg-3">'+
                         '<button type="button" class="btn" onclick="deleteTranslation('+index+')">-</button>'+
-                        '<select name="profileFieldTrans'+index+'[locale]">'+
+                        '<select name="profileFieldTrans'+index+'[locale]" onchange="isDuplicate()">'+
+                            '<option value=""></option>'+
                         <?php
                         foreach ($localeList as $locale) :?>
                             '<option value="<?=key($localeList) ?>"><?=$locale ?></option>'+
@@ -122,7 +136,34 @@ function addTranslations() {
                 '</div>';
     var d1 = document.getElementById('addTranslations');
     d1.insertAdjacentHTML('beforeend', html);
+    addIndex(index);
     index++;
+}
+
+function isDuplicate() {
+    var allElements;
+    var select_id;
+
+    // indexList is undefined after deleting the last element with array.splice().
+    if (indexList == undefined) {
+        indexList = [];
+    }
+
+    for(x = 0; x < indexList.length; x++) {
+        allElements = document.getElementsByName('profileFieldTrans'+indexList[x]+'[locale]')[0];
+        for(y = x+1; y < indexList.length; y++) {
+            select_id = document.getElementsByName('profileFieldTrans'+indexList[y]+'[locale]')[0];
+            if(select_id.options[select_id.selectedIndex].value != "" && select_id.options[select_id.selectedIndex].value == allElements.value) {
+                alert('<?=$this->getTrans('translationAlreadyExisting') ?>');
+                deleteTranslation(indexList[y]);
+                // Delete the locale so this one gets discarded.
+                document.getElementsByName('profileFieldTrans'+indexList[y]+'[locale]')[0].value = '';
+                indexList.splice(y,1);
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 function deleteTranslation(a) {

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -1,6 +1,8 @@
 <?php
 $countOfProfileFields = $this->get('countOfProfileFields');
 $profileField = $this->get('profileField');
+$profileFieldsTranslation = $this->get('profileFieldsTranslation');
+$localeList = $this->get('localeList');
 
 if ($profileField->getId()) {
     $fieldsetLegend = $this->getTrans('editProfileField');
@@ -10,7 +12,12 @@ if ($profileField->getId()) {
 ?>
 
 <fieldset>
-    <legend><?=$fieldsetLegend ?></legend>
+    <legend>
+        <?=$fieldsetLegend ?>
+        <a class="badge" data-toggle="modal" data-target="#infoModal">
+            <i class="fa fa-info"></i>
+        </a>
+    </legend>
     <form action="<?=$this->getUrl(['module' => 'user', 'controller' => 'profilefields', 'action' => 'save']) ?>"
           method="POST"
           class="form-horizontal"
@@ -45,10 +52,81 @@ if ($profileField->getId()) {
                        value="<?=($profileField->getId()) ? $profileField->getPosition() : $countOfProfileFields ?>" />
             </div>
         </div>
+        <?php 
+        $i = 0;
+        foreach ($profileFieldsTranslation as $profileFieldTranslation) : ?>
+        <div class="form-group" id="profileFieldTrans<?=$i ?>">
+            <div class="col-lg-3">
+                <button type="button" class="btn" onclick="deleteTranslation(<?=$i ?>)">-</button>
+                <label for="profileFieldName"
+                       class="control-label">
+                    <?=(isset($localeList[$profileFieldTranslation->getLocale()])) ? $localeList[$profileFieldTranslation->getLocale()] : $profileFieldTranslation->getLocale() ?>
+                </label>
+            </div>
+            <input name="profileFieldTrans<?=$i?>[field_id]"
+                   type="hidden"
+                   value="<?=$profileField->getId() ?>" />
+            <input name="profileFieldTrans<?=$i?>[locale]"
+                   type="hidden"
+                   value="<?=$profileFieldTranslation->getLocale() ?>" />
+            <div class="col-lg-9">
+                <input name="profileFieldTrans<?=$i?>[name]"
+                       type="text"
+                       id="profileFieldName"
+                       class="form-control"
+                       placeholder="<?=$this->getTrans('profileFieldName') ?>"
+                       value="<?=$this->escape($profileFieldTranslation->getName()) ?>" />
+            </div>
+        </div>
+        <?php $i++;
+        endforeach; ?>
+        <div id="addTranslations">
+        </div>
+        <div class="col-lg-3">
+            <button type="button" class="btn" onclick="addTranslations()">+</button>
+        </div>
         <?=$this->getSaveBar() ?>
     </form>
 </fieldset>
 
+<?=$this->getDialog("infoModal", $this->getTrans('info'), $this->getTrans('profileFieldTransInfoText')); ?>
+
 <script>
+var index = <?=$i ?>;
+
 $('#profileFieldForm').validate();
+
+function addTranslations() {
+    var html =  '<div class="form-group" id="profileFieldTrans'+index+'">'+
+                    '<input name="profileFieldTrans'+index+'[field_id]"'+
+                        'type="hidden"'+
+                        'value="<?=$profileField->getId() ?>" />'+
+                    '<div class="col-lg-3">'+
+                        '<button type="button" class="btn" onclick="deleteTranslation('+index+')">-</button>'+
+                        '<select name="profileFieldTrans'+index+'[locale]">'+
+                        <?php
+                        foreach ($localeList as $locale) :?>
+                            '<option value="<?=key($localeList) ?>"><?=$locale ?></option>'+
+                        <?php next($localeList);
+                        endforeach; ?>
+                        '</select>'+
+                    '</div>'+
+                    '<div class="col-lg-9">'+
+                        '<input name="profileFieldTrans'+index+'[name]"'+
+                               'type="text"'+
+                               'id="profileFieldName"'+
+                               'class="form-control"'+
+                               'placeholder="<?=$this->getTrans('profileFieldName') ?>"'+
+                               'value="" />'+
+                    '</div>'+
+                '</div>';
+    var d1 = document.getElementById('addTranslations');
+    d1.insertAdjacentHTML('beforeend', html);
+    index++;
+}
+
+function deleteTranslation(a) {
+    document.getElementById('profileFieldTrans'+a).style.display = 'none';
+    document.getElementsByName('profileFieldTrans'+a+'[name]')[0].value = '';    
+}
 </script>

--- a/application/modules/user/views/panel/profile.php
+++ b/application/modules/user/views/panel/profile.php
@@ -2,6 +2,7 @@
 $profil = $this->get('profil');
 $profileFields = $this->get('profileFields');
 $profileFieldsContent = $this->get('profileFieldsContent');
+$profileFieldsTranslation = $this->get('profileFieldsTranslation');
 $birthday = new \Ilch\Date($profil->getBirthday());
 ?>
 
@@ -134,6 +135,14 @@ $birthday = new \Ilch\Date($profil->getBirthday());
                         continue;
                     }
 
+                    $profileFieldName = $profileField->getName();
+                    foreach ($profileFieldsTranslation as $profileFieldTranslation) {
+                        if($profileField->getId() == $profileFieldTranslation->getFieldId()) {
+                            $profileFieldName = $profileFieldTranslation->getName();
+                            break;
+                        }
+                    }
+
                     $value = '';
                     foreach($profileFieldsContent as $profileFieldContent) {
                         if($profileField->getId() == $profileFieldContent->getFieldId()) {
@@ -144,7 +153,7 @@ $birthday = new \Ilch\Date($profil->getBirthday());
                 ?>
                 <div class="form-group">
                     <label class="col-lg-2 control-label">
-                        <?=$this->escape($profileField->getName()) ?>
+                        <?=$this->escape($profileFieldName) ?>
                     </label>
                     <div class="col-lg-8">
                        <input type="text"

--- a/application/modules/user/views/profil/index.php
+++ b/application/modules/user/views/profil/index.php
@@ -4,6 +4,7 @@ $profil = $this->get('profil');
 $birthday = new \Ilch\Date($profil->getBirthday());
 $profileFields = $this->get('profileFields');
 $profileFieldsContent = $this->get('profileFieldsContent');
+$profileFieldsTranslation = $this->get('profileFieldsTranslation');
 
 $groups = '';
 foreach ($profil->getGroups() as $group) {
@@ -93,28 +94,38 @@ foreach ($profil->getGroups() as $group) {
                 <?php if ($profil->getBirthday() != '0000-00-00') { echo $birthday->format('d-m-Y', true); } ?>
             </div>
         </div>
+
         <?php
-        foreach ($profileFields as $profileField) :
-            if($profileField->getType() == 0) :
-                foreach ($profileFieldsContent as $profileFieldContent) :
-                    if($profileField->getId() == $profileFieldContent->getFieldId()) : ?>
+        foreach ($profileFields as $profileField) {
+            foreach ($profileFieldsContent as $profileFieldContent) {
+                if($profileField->getId() == $profileFieldContent->getFieldId()) {
+                    $profileFieldName = $profileField->getName();
+                    foreach ($profileFieldsTranslation as $profileFieldTrans) {
+                        if($profileField->getId() == $profileFieldTrans->getFieldId()) {
+                            $profileFieldName = $profileFieldTrans->getName();
+                            break;
+                        }
+                    }
+                    if($profileField->getType() == 0) : ?>
                         <div class="row">
                             <div class="col-lg-2 detail bold">
-                                <?=$this->escape($profileField->getName()) ?>
+                                <?=$this->escape($profileFieldName) ?>
                             </div>
                             <div class="col-lg-10 detail">
                                 <?=$this->escape($profileFieldContent->getValue()) ?>
                             </div>
                         </div>
-                <?php   break;
-                    endif;
-                endforeach;
-            else : ?>
-                <div class="clearfix"></div>
-                <br />
-                <legend><?=$this->escape($profileField->getName()) ?></legend>
-            <?php endif;
-        endforeach; ?>
+                    <?php else : ?>
+                        <div class="clearfix"></div>
+                        <br />
+                        <legend><?=$this->escape($profileFieldName) ?></legend>
+                    <?php endif;
+                    break;
+                }
+            }
+        }
+        ?>
+
         <?php if ($profil->getSignature() != ''): ?>
             <div class="clearfix"></div>
             <br />


### PR DESCRIPTION
[User profile fields translations](http://redmine.ilch2.de/issues/253)

The administrator can now add translations for profilefields when adding or editing a profilefield.
This can be done by clicking on a plus-button. Its is possible to add multiple translations for a profilefield at once.

Translations can be deleted by clicking on a minus-button or deleting the text of the translation.

It is possible to modify the translations when editing a profile-field.

All translations of a profilefield get deleted if the profilefield gets deleted.