### PR TITLE
fix/return-value-write-context

### DIFF
--- a/application/modules/article/controllers/Archive.php
+++ b/application/modules/article/controllers/Archive.php
@@ -41,7 +41,7 @@ class Archive extends \Ilch\Controller\Frontend
                 ->add($this->getTranslator()->trans('menuArticle'), ['controller' => 'index', 'action' => 'index'])
                 ->add($this->getTranslator()->trans('menuArchives'), ['action' => 'index']);
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('article_articlesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('article_articlesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('categoryMapper', $categoryMapper);

--- a/application/modules/article/controllers/Cats.php
+++ b/application/modules/article/controllers/Cats.php
@@ -54,7 +54,7 @@ class Cats extends \Ilch\Controller\Frontend
                 ->add($this->getTranslator()->trans('menuCats'), ['action' => 'index'])
                 ->add($articlesCats->getName(), ['action' => 'show', 'id' => $articlesCats->getId()]);
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('article_articlesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('article_articlesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('categoryMapper', $categoryMapper);

--- a/application/modules/article/controllers/Index.php
+++ b/application/modules/article/controllers/Index.php
@@ -39,7 +39,7 @@ class Index extends \Ilch\Controller\Frontend
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('menuArticle'), ['action' => 'index']);
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('article_articlesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('article_articlesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('categoryMapper', $categoryMapper);

--- a/application/modules/downloads/controllers/Index.php
+++ b/application/modules/downloads/controllers/Index.php
@@ -47,7 +47,7 @@ class Index extends \Ilch\Controller\Frontend
                 ->add($this->getTranslator()->trans('menuDownloadsOverview'), ['action' => 'index'])
                 ->add($downloads->getTitle(), ['action' => 'show', 'id' => $id]);
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('downloads_downloadsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('downloads_downloadsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         
         $this->getView()->set('file', $fileMapper->getFileByDownloadsId($id, $pagination));

--- a/application/modules/downloads/controllers/admin/Downloads.php
+++ b/application/modules/downloads/controllers/admin/Downloads.php
@@ -56,7 +56,7 @@ class Downloads extends BaseController
             }
         }
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('downloads_downloadsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('downloads_downloadsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $this->getView()->set('file', $fileMapper->getFileByDownloadsId($id, $pagination));
         $this->getView()->set('pagination', $pagination);

--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -24,7 +24,7 @@ class Showposts extends \Ilch\Controller\Frontend
         $topicModel = new ForumTopicModel;
         $pagination = new \Ilch\Pagination();
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('forum_postsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('forum_postsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $topicId = (int)$this->getRequest()->getParam('topicid');

--- a/application/modules/forum/controllers/Showtopics.php
+++ b/application/modules/forum/controllers/Showtopics.php
@@ -51,7 +51,7 @@ class Showtopics extends \Ilch\Controller\Frontend
                 ->add($cat->getTitle(), ['controller' => 'showcat','action' => 'index', 'id' => $cat->getId()])
                 ->add($forum->getTitle(), ['action' => 'index', 'forumid' => $forumId]);
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('forum_threadsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_threadsPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('forum_threadsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_threadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('forum', $forum);

--- a/application/modules/forum/controllers/Showunread.php
+++ b/application/modules/forum/controllers/Showunread.php
@@ -33,7 +33,7 @@ class Showunread extends \Ilch\Controller\Frontend
 
             $groupIdsArray = explode(',',implode(',', $groupIds));
 
-            $pagination->setRowsPerPage(empty($this->getConfig()->get('forum_postsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
+            $pagination->setRowsPerPage(!$this->getConfig()->get('forum_postsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
             $pagination->setPage($this->getRequest()->getParam('page'));
 
             $this->getLayout()->getHmenu()

--- a/application/modules/gallery/controllers/Index.php
+++ b/application/modules/gallery/controllers/Index.php
@@ -38,7 +38,7 @@ class Index extends \Ilch\Controller\Frontend
 
         $id = $this->getRequest()->getParam('id');
         $gallery = $galleryMapper->getGalleryById($id);
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('gallery_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('gallery_picturesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('gallery_picturesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('gallery_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getLayout()->set('metaTitle', $this->getTranslator()->trans('gallery').' - '.$gallery->getTitle());

--- a/application/modules/gallery/controllers/admin/Gallery.php
+++ b/application/modules/gallery/controllers/admin/Gallery.php
@@ -61,7 +61,7 @@ class Gallery extends BaseController
             }
         }
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('gallery_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('gallery_picturesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('gallery_picturesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('gallery_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $this->getView()->set('image', $imageMapper->getImageByGalleryId($id, $pagination));
         $this->getView()->set('pagination', $pagination);

--- a/application/modules/guestbook/controllers/Index.php
+++ b/application/modules/guestbook/controllers/Index.php
@@ -21,7 +21,7 @@ class Index extends \Ilch\Controller\Frontend
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('guestbook'), ['action' => 'index']);
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('gbook_entriesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('gbook_entriesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('gbook_entriesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('gbook_entriesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('entries', $guestbookMapper->getEntries(['setfree' => 1], $pagination));

--- a/application/modules/media/controllers/admin/Ajax.php
+++ b/application/modules/media/controllers/admin/Ajax.php
@@ -16,7 +16,7 @@ class Ajax extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('media_mediaPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $lastId = $this->getRequest()->getParam('lastid');
@@ -39,7 +39,7 @@ class Ajax extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('media_mediaPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $lastId = $this->getRequest()->getParam('lastid');

--- a/application/modules/media/controllers/admin/Iframe.php
+++ b/application/modules/media/controllers/admin/Iframe.php
@@ -16,7 +16,7 @@ class Iframe extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('media_mediaPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $lastId = $this->getRequest()->getParam('lastid');
 
@@ -50,7 +50,7 @@ class Iframe extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('media_mediaPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $lastId = $this->getRequest()->getParam('lastid');
@@ -119,7 +119,7 @@ class Iframe extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('media_mediaPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('pagination', $pagination);

--- a/application/modules/media/controllers/admin/Index.php
+++ b/application/modules/media/controllers/admin/Index.php
@@ -70,7 +70,7 @@ class Index extends \Ilch\Controller\Admin
         }
 
         $pagination = new \Ilch\Pagination();
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('media_mediaPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('media_mediaPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('media_mediaPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         if ($this->getRequest()->getParam('rows')) {

--- a/application/modules/user/controllers/Gallery.php
+++ b/application/modules/user/controllers/Gallery.php
@@ -54,7 +54,7 @@ class Gallery extends \Ilch\Controller\Frontend
                 ->add($this->getTranslator()->trans('menuGallery'), ['controller' => 'gallery', 'action' => 'index', 'user' => $this->getRequest()->getParam('user')])
                 ->add($gallery->getTitle(), ['action' => 'show', 'user' => $this->getRequest()->getParam('user'), 'id' => $id]);
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('user_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('user_picturesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('user_picturesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('user_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('image', $imageMapper->getImageByGalleryId($id, $pagination));

--- a/application/modules/user/controllers/Iframe.php
+++ b/application/modules/user/controllers/Iframe.php
@@ -18,7 +18,7 @@ class Iframe extends \Ilch\Controller\Frontend
         $mediaMapper = new MediaMapper();
         $pagination = new \Ilch\Pagination();
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('user_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('user_picturesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('user_picturesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('user_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $lastId = $this->getRequest()->getParam('lastid');
 

--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -504,7 +504,7 @@ class Panel extends BaseController
             }
         }
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('user_picturesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('user_picturesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('user_picturesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('user_picturesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
         $this->getView()->set('image', $imageMapper->getImageByGalleryId($id, $pagination));
         $this->getView()->set('pagination', $pagination);

--- a/application/modules/war/controllers/Group.php
+++ b/application/modules/war/controllers/Group.php
@@ -20,7 +20,7 @@ class Group extends \Ilch\Controller\Frontend
         $groupMapper = new GroupMapper();
         $pagination = new \Ilch\Pagination();
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_warsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('war_warsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('groups', $groupMapper->getGroupList($pagination));
@@ -35,7 +35,7 @@ class Group extends \Ilch\Controller\Frontend
 
         $id = $this->getRequest()->getParam('id');
         $group = $groupMapper->getGroupById($id);
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_warsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('war_warsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getLayout()->getHmenu()

--- a/application/modules/war/controllers/Index.php
+++ b/application/modules/war/controllers/Index.php
@@ -20,7 +20,7 @@ class Index extends \Ilch\Controller\Frontend
         $pagination = new \Ilch\Pagination();
         $warMapper = new WarMapper();
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_warsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('war_warsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('war', $warMapper->getWarList($pagination));

--- a/application/modules/war/controllers/admin/Enemy.php
+++ b/application/modules/war/controllers/admin/Enemy.php
@@ -39,7 +39,7 @@ class Enemy extends BaseController
             }
         }
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_enemiesPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_enemiesPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('war_enemiesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_enemiesPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('enemy', $enemyMapper->getEnemyList($pagination));

--- a/application/modules/war/controllers/admin/Group.php
+++ b/application/modules/war/controllers/admin/Group.php
@@ -40,7 +40,7 @@ class Group extends BaseController
             }
         }
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_groupsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_groupsPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('war_groupsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_groupsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('groups', $groupMapper->getGroupList($pagination));

--- a/application/modules/war/controllers/admin/Index.php
+++ b/application/modules/war/controllers/admin/Index.php
@@ -43,7 +43,7 @@ class Index extends BaseController
             }
         }
 
-        $pagination->setRowsPerPage(empty($this->getConfig()->get('war_warsPerPage')) ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
+        $pagination->setRowsPerPage(!$this->getConfig()->get('war_warsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('war_warsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         if ($this->getRequest()->getPost('filter') == 'filter' and $this->getRequest()->getPost('filterLastNext') !='0') {


### PR DESCRIPTION
Fatal error: Can't use method return value in write context in ...

This error is visible in the demo and not on my machine (PHP 5.6). Could not verify the fix other than that it is still working as before.

http://stackoverflow.com/a/4328049