### PR TITLE
Use hash_equals()

### DIFF
--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -206,20 +206,6 @@ function url_get_contents($url)
     return $output;
 }
 
-function ilch_function_hash_equals($str1, $str2)
-{
-    if (strlen($str1) != strlen($str2)) {
-        return false;
-    } else {
-        $res = $str1 ^ $str2;
-        $ret = 0;
-        for ($i = strlen($res) - 1; $i >= 0; $i--) {
-            $ret |= ord($res[$i]);
-        }
-        return !$ret;
-    }
-}
-
 /**
  * @param mixed $var
  * @param string $indent

--- a/application/modules/user/plugins/BeforeControllerLoad.php
+++ b/application/modules/user/plugins/BeforeControllerLoad.php
@@ -30,7 +30,7 @@ class BeforeControllerLoad
             $row = $authTokenMapper->getAuthToken($selector);
 
             if (!empty($row) && strtotime($row['expires']) >= time()) {
-                if (ilch_function_hash_equals($row['token'], hash('sha256', base64_decode($authenticator)))) {
+                if (hash_equals($row['token'], hash('sha256', base64_decode($authenticator)))) {
                     $_SESSION['user_id'] = $row['userid'];
                     // A new token is generated, a new hash for the token is stored over the old record, and a new login cookie is issued to the user.
                     $authTokenModel = new \Modules\User\Models\AuthToken();


### PR DESCRIPTION
Use hash_equals() instead of ilch_function_hash_equals() as the minimum
supported PHP version for Ilch 2 is now 5.6.

ilch_function_hash_equals() was used because hash_equals() is only
available with PHP 5.6 and newer.

Remove ilch_function_hash_equals() as it is no longer needed.

This is basically a revert of https://github.com/IlchCMS/Ilch-2.0/commit/7f27530f5cdb4cf3a050ecb0b60852da6714de98