### PR TITLE
Validation, core translations, ...

### DIFF
--- a/application/libraries/Ilch/Page.php
+++ b/application/libraries/Ilch/Page.php
@@ -129,6 +129,8 @@ class Page
             $this->translator->load(APPLICATION_PATH.'/modules/admin/translations');
         }
 
+        Registry::set('translator', $this->translator);
+        
         $controller = $this->loadController();
         $controllerName = $this->request->getControllerName();
         $findSub = strpos($controllerName, '_');

--- a/application/libraries/Ilch/Page.php
+++ b/application/libraries/Ilch/Page.php
@@ -122,6 +122,7 @@ class Page
      */
     public function loadPage()
     {
+        $this->translator->load(APPLICATION_PATH.'/libraries/Ilch/Translations');
         $this->translator->load(APPLICATION_PATH.'/modules/'.$this->request->getModuleName().'/translations');
 
         if ($this->request->isAdmin()) {

--- a/application/libraries/Ilch/Translations/de.php
+++ b/application/libraries/Ilch/Translations/de.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+return [
+    // core translations
+];

--- a/application/libraries/Ilch/Translations/de.php
+++ b/application/libraries/Ilch/Translations/de.php
@@ -5,5 +5,12 @@
  */
 
 return [
-    // core translations
+    'validation.errors.required.fieldIsRequired'    => '%s muss ausgefüllt werden.',
+    'validation.errors.same.fieldsDontMatch'        => '%s muss mit %s übereinstimmen.',
+    'validation.errors.captcha.wrongCaptcha'        => '%s entspricht nicht der gezeigten Zeichenkombination',
+    'validation.errors.length.tooShort'             => '%s muss mindestens %s Zeichen lang sein.',
+    'validation.errors.length.tooLong'              => '%s darf höchstens %s Zeichen lang sein.',
+    'validation.errors.length.tooShortAndOrTooLong' => '%s muss mindestens %s und darf höchstens %s Zeichen lang sein',
+    'validation.errors.url.noValidUrl'              => '%s muss eine gültige URL sein.',
+    'validation.errors.email.noValidEmail'          => '%s muss eine gültige E-Mail-Adresse sein.',
 ];

--- a/application/libraries/Ilch/Translations/en.php
+++ b/application/libraries/Ilch/Translations/en.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+return [
+    // core translations
+];

--- a/application/libraries/Ilch/Translations/en.php
+++ b/application/libraries/Ilch/Translations/en.php
@@ -5,5 +5,12 @@
  */
 
 return [
-    // core translations
+    'validation.errors.required.fieldIsRequired'    => '%s was not filled out.',
+    'validation.errors.same.fieldsDontMatch'        => '%s must be equal %s.',
+    'validation.errors.captcha.wrongCaptcha'        => '%s is the wrong character combination.',
+    'validation.errors.length.tooShort'             => '%s must be at least %s chars long.',
+    'validation.errors.length.tooLong'              => '%s has to be a maximum of %s chars long.',
+    'validation.errors.length.tooShortAndOrTooLong' => '%s must be at least %s chars long and maximum %s chars long.',
+    'validation.errors.url.noValidUrl'              => '%s must be a valid URL.',
+    'validation.errors.email.noValidEmail'          => '%s must be a valid email address.',
 ];

--- a/application/libraries/Ilch/Validation.php
+++ b/application/libraries/Ilch/Validation.php
@@ -6,6 +6,8 @@
 
 namespace Ilch;
 
+use Ilch\Registry;
+
 use Ilch\Validation\Data;
 use Ilch\Validation\Error;
 
@@ -125,12 +127,17 @@ class Validation
     /**
      * Generating all the error messages
      * @param   Object \Ilch\Translator $translator The translator instance
-     * @returns Array  An array with translated error messages
+     * @return Array  An array with translated error messages
      */
-    public function getErrors(\Ilch\Translator $translator)
+    public function getErrors($translator = null)
     {
-        if (empty($this->errors))
+        if ($translator === null) {
+            $translator = Registry::get('translator');
+        }
+
+        if (empty($this->errors)) {
             return null;
+        }
 
         $errorMessages = [];
         $validationErrors = [];
@@ -187,7 +194,7 @@ class Validation
 
     /**
      * Returns the validation result
-     * @returns Boolean
+     * @return Boolean
      */
     public function isValid()
     {
@@ -198,7 +205,7 @@ class Validation
     /**
      * Checks if the specified field has a validation error
      * @param   String  $field Field name
-     * @returns Boolean
+     * @return Boolean
      */
     public function hasError($field)
     {
@@ -207,7 +214,7 @@ class Validation
 
     /**
      * Returns an array with all field names which have validation errors
-     * @returns Array
+     * @return Array
      */
     public function getFieldsWithError()
     {
@@ -235,7 +242,7 @@ class Validation
 
     /**
      * Gets all validators (added and builtIn combined)
-     * @returns Array All Validators known at this time during runtime
+     * @return Array All Validators known at this time during runtime
      */
     public static function getValidators()
     {

--- a/application/libraries/Ilch/Validation/Validators/Captcha.php
+++ b/application/libraries/Ilch/Validation/Validators/Captcha.php
@@ -12,10 +12,15 @@ namespace Ilch\Validation\Validators;
 class Captcha extends Base
 {
     protected $errorKey = 'validation.errors.captcha.wrongCaptcha';
+    protected $sessionKey = 'captcha';
 
     public function run()
     {
-        $result = $this->data->getValue() == $_SESSION['captcha'];
+        $result = false;
+        
+        if (isset($_SESSION[$this->sessionKey])) {
+            $result = $this->data->getValue() == $_SESSION[$this->sessionKey];
+        }
 
         return [
             'result' => $result,

--- a/application/modules/guestbook/controllers/Index.php
+++ b/application/modules/guestbook/controllers/Index.php
@@ -80,7 +80,7 @@ class Index extends \Ilch\Controller\Frontend
                     Validation::addValidator('same2', '\my\namespace\Validators\Same');
                     Als Vergleich können die bestehenden Validators genommen werden.
             */
-            Validation::addValidator('same2', function($data) {
+            Validation::addValidator('same2', function ($data) {
                 $validation = $data->getValue() == array_dot($data->getInput(), $data->getParam('as'));
                 return [
                     'result' => $validation,
@@ -149,7 +149,7 @@ class Index extends \Ilch\Controller\Frontend
                 $model->setFree($this->getConfig()->get('gbook_autosetfree'));
                 $guestbookMapper->save($model);
 
-                if ($this->getConfig()->get('gbook_autosetfree') == 0 ) {
+                if ($this->getConfig()->get('gbook_autosetfree') == 0) {
                     $this->addMessage('check', 'success');
                 }
 
@@ -166,7 +166,8 @@ class Index extends \Ilch\Controller\Frontend
                 Zurückgegeben wird einfach nur ein Array mit Fehler-Strings
                 Ansonsten siehe newEntry.php
             */
-            $this->getView()->set('errors', $validation->getErrors($this->getTranslator()));
+            // $this->getView()->set('errors', $validation->getErrors($this->getTranslator()));
+            $this->getView()->set('errors', $validation->getErrors());
 
             /*
                 $validation->getFieldsWithError() gibt ein Array mit allen Feldern, die Fehler beinhalten, zurück.

--- a/application/modules/guestbook/translations/de.php
+++ b/application/modules/guestbook/translations/de.php
@@ -38,13 +38,4 @@ return [
     'close' => 'Schließen',
     'entriesPerPage' => 'Einträge pro Seite',
     'errorsOccured' => 'Es sind folgende Fehler aufgetreten',
-
-    'validation.errors.required.fieldIsRequired'    => '%s muss ausgefüllt werden.',
-    'validation.errors.same.fieldsDontMatch'        => '%s muss mit %s übereinstimmen.',
-    'validation.errors.captcha.wrongCaptcha'        => '%s entspricht nicht der gezeigten Zeichenkombination',
-    'validation.errors.length.tooShort'             => '%s muss mindestens %s Zeichen lang sein.',
-    'validation.errors.length.tooLong'              => '%s darf höchstens %s Zeichen lang sein.',
-    'validation.errors.length.tooShortAndOrTooLong' => '%s muss mindestens %s und darf höchstens %s Zeichen lang sein',
-    'validation.errors.url.noValidUrl'              => '%s muss eine gültige URL sein.',
-    'validation.errors.email.noValidEmail'          => '%s muss eine gültige E-Mail-Adresse sein.',
 ];

--- a/application/modules/guestbook/translations/en.php
+++ b/application/modules/guestbook/translations/en.php
@@ -38,13 +38,4 @@ return [
     'close' => 'Close',
     'entriesPerPage' => 'Einträge pro Seite',
     'errorsOccured' => 'The following errors occured',
-
-    'validation.errors.required.fieldIsRequired'    => '%s was not filled out.',
-    'validation.errors.same.fieldsDontMatch'        => '%s must be equal %s.',
-    'validation.errors.captcha.wrongCaptcha'        => '%s is the wrong character combination.',
-    'validation.errors.length.tooShort'             => '%s must be at least %s chars long.',
-    'validation.errors.length.tooLong'              => '%s has to be a maximum of %s chars long.',
-    'validation.errors.length.tooShortAndOrTooLong' => '%s must be at least %s chars long and maximum %s chars long.',
-    'validation.errors.url.noValidUrl'              => '%s must be a valid URL.',
-    'validation.errors.email.noValidEmail'          => '%s must be a valid email address.',
 ];

--- a/application/modules/link/controllers/admin/Index.php
+++ b/application/modules/link/controllers/admin/Index.php
@@ -45,8 +45,7 @@ class Index extends \Ilch\Controller\Admin
             $items[0]['active'] = true;
         }
 
-        $this->getLayout()->addMenu
-        (
+        $this->getLayout()->addMenu(
             'menuLinks',
             $items
         );
@@ -183,9 +182,9 @@ class Index extends \Ilch\Controller\Admin
 
                 $this->addMessage('saveSuccess');
                 $this->redirect(['action' => 'index']);
-            } 
+            }
 
-            $this->getView()->set('errors', $validation->getErrors($this->getTranslator()));
+            $this->getView()->set('errors', $validation->getErrors());
             $errorFields = $validation->getFieldsWithError();
             $this->getView()->set('errorFields', (isset($errorFields) ? $errorFields : []));
         }

--- a/application/modules/link/translations/de.php
+++ b/application/modules/link/translations/de.php
@@ -29,7 +29,4 @@ return [
     'httpOrMedia' => 'http:// oder Medien',
     'deleteFailed' => 'Es befinden sich noch Einträge in der Kategorie',
     'errorsOccured' => 'Es sind folgende Fehler aufgetreten',
-
-    'validation.errors.required.fieldIsRequired'    => '%s muss ausgefüllt werden.',
-    'validation.errors.url.noValidUrl'              => '%s muss eine gültige URL sein.',
 ];

--- a/application/modules/link/translations/en.php
+++ b/application/modules/link/translations/en.php
@@ -29,7 +29,4 @@ return [
     'httpOrMedia' => 'http:// or Media',
     'deleteFailed' => 'There are still entries in the category',
     'errorsOccured' => 'The following errors occured',
-
-    'validation.errors.required.fieldIsRequired'    => '%s was not filled out.',
-    'validation.errors.url.noValidUrl'              => '%s must be a valid URL.',
 ];


### PR DESCRIPTION
Jedes mal Copy&Paste für die Fehlermeldungen ist unnötig und führt leicht zu Inkonsistenz (gleicher Fehler - viele verschiedene Formulierungen, da jedes Modul sie potenziell neu definiert).

Translations aus Modulen überschreiben dabei natürlich die vom Core, daher kann man, falls notwendig, weiterhin eigene Fehlermeldungen formulieren.