### PR TITLE
Menu: Adds allow-nesting option

### DIFF
--- a/application/libraries/Ilch/Layout/Helper/GetMenu.php
+++ b/application/libraries/Ilch/Layout/Helper/GetMenu.php
@@ -35,6 +35,7 @@ class GetMenu
                 'ul-class-child' => 'list-unstyled ilch_menu_ul',
                 'li-class-root' => '',
                 'li-class-child' => '',
+                'allow-nesting' => true,
             ],
             'boxes' => [
                 'render' => true,
@@ -51,7 +52,7 @@ class GetMenu
         }
 
         if (isset($args[2])) {
-            $options = array_merge($options, $args[2]);
+            $options = array_replace_recursive($options, $args[2]);
         }
 
         return $menu->getItems($template, $options);

--- a/application/libraries/Ilch/Layout/Helper/Menu/Model.php
+++ b/application/libraries/Ilch/Layout/Helper/Menu/Model.php
@@ -181,19 +181,23 @@ class Model
         } elseif ($item->isModuleLink()) {
             $html .= '<a href="'.$this->layout->getUrl(['module' => $item->getModuleKey(), 'action' => 'index', 'controller' => 'index']).'">'.$item->getTitle().'</a>';
         }
-        
+
         if (!empty($subItems)) {
             if ($item->isMenu()) {
                 $html .= '<ul class="' . array_dot($options, 'menus.ul-class-root') . '">';
             } else {
-                $html .= '<ul class="' . array_dot($options, 'menus.ul-class-child') . '">';
+                if (array_dot($options, 'menus.allow-nesting') === true) {
+                    $html .= '<ul class="' . array_dot($options, 'menus.ul-class-child') . '">';
+                }
             }
 
             foreach ($subItems as $subItem) {
                 $html .= $this->recGetItems($subItem, $locale, $options, $item->getType());
             }
 
-            $html .= '</ul>';
+            if ((! $item->isMenu() && array_dot($options, 'menus.allow-nesting') === true) || $item->isMenu()) {
+                $html .= '</ul>';
+            }
         }
 
         if (in_array($item->getType(), [1,2,3])) {

--- a/application/libraries/Ilch/Layout/Helper/Menu/Model.php
+++ b/application/libraries/Ilch/Layout/Helper/Menu/Model.php
@@ -166,7 +166,7 @@ class Model
 
         if ($item->isLink()) {
 
-            if ($parentType === 0) {
+            if ($parentType === 0 || array_dot($options, 'menus.allow-nesting') === false) {
                 $html = '<li class="' . array_dot($options, 'menus.li-class-root') . '">';
             } else {
                 $html = '<li class="' . array_dot($options, 'menus.li-class-child') . '">';


### PR DESCRIPTION
z.B. sinnvoll für die bootstrap navbar, die keine Verschachtelungen unterstützt. Ist im Layout bei dem Menü allow-nesting auf false, werden die Verschachtelungen nicht übernommen, sondern die Links ganz normal untereinander angezeigt.