### PR TITLE
Fix/awards module reference error disablefield

### DIFF
--- a/application/modules/admin/views/admin/index/index.php
+++ b/application/modules/admin/views/admin/index/index.php
@@ -41,7 +41,7 @@ $ilchNews = json_decode($ilchNewsList);
                         <?php endif; ?>
                         <?php if ($this->get('usersNotConfirmed')) : ?>
                             <tr>
-                                <td><a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'index', 'action' => 'index')) ?>"><?=$this->get('moduleLocales')['user']->getName() ?></a></td>
+                                <td><a href="<?=$this->getUrl(array('module' => 'user', 'controller' => 'index', 'action' => 'index', 'showsetfree' => 1)) ?>"><?=$this->get('moduleLocales')['user']->getName() ?></a></td>
                                 <td><?=count($this->get('usersNotConfirmed')) ?></td>
                             </tr>
                         <?php endif; ?>

--- a/application/modules/awards/views/admin/index/treat.php
+++ b/application/modules/awards/views/admin/index/treat.php
@@ -141,11 +141,6 @@ $(document).ready(function() {
     });
 });
 
-window.onload = function() {
-    document.getElementById('typ_user').onchange = disablefield;
-    document.getElementById('typ_team').onchange = disablefield;
-}
-
 function toggleStatus() {
     if ($('#typ_user').is(':checked')) {
         $('#user').removeAttr('disabled');

--- a/application/modules/link/controllers/admin/Index.php
+++ b/application/modules/link/controllers/admin/Index.php
@@ -179,7 +179,7 @@ class Index extends \Ilch\Controller\Admin
 
             if ($validation->isValid()) {
                 $model->setName($this->getRequest()->getPost('name'));
-                $model->setLink($this->getRequest()->getPost('link'));
+                $model->setLink($post['link']);
                 // Used on purpose instead of $banner to save some bytes in the database
                 $model->setBanner($this->getRequest()->getPost('banner'));
                 $model->setDesc($this->getRequest()->getPost('desc'));

--- a/application/modules/statistic/views/index/index.php
+++ b/application/modules/statistic/views/index/index.php
@@ -133,7 +133,7 @@ $registNewUser = $userMapper->getUserById($this->get('registNewUser'));
                             }
                             ?>
                             <div class="col-xs-12 col-md-6 col-lg-3">
-                                <div class="box">							
+                                <div class="box">
                                     <div class="icon" title="<?=$this->getTrans('author') ?>: <?=$modules->getAuthor() ?>" style="cursor: help;">
                                         <div class="image">
                                             <?=$smallIcon ?>


### PR DESCRIPTION
Uncaught ReferenceError: disablefield is not defined

- Adjust link in admincenter startpage
- Use $post['link'], because it contains the trimmed link
- Remove some tabulators

