### PR TITLE
Shifts addMessage translation

### DIFF
--- a/application/libraries/Ilch/Controller/Base.php
+++ b/application/libraries/Ilch/Controller/Base.php
@@ -153,6 +153,6 @@ class Base
      */
     public function addMessage($message, $type = 'success')
     {
-        $_SESSION['messages'][] = ['text' => $message, 'type' => $type];
+        $_SESSION['messages'][] = ['text' => $this->getTranslator()->trans($message), 'type' => $type];
     }
 }

--- a/application/libraries/Ilch/Layout/Base.php
+++ b/application/libraries/Ilch/Layout/Base.php
@@ -94,7 +94,7 @@ abstract class Base extends \Ilch\Design\Base
         foreach ($messages as $key => $message) {
             $html = '<div class="alert alert-'.$message['type'].' alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-            '.$this->escape($this->getTranslator()->trans($message['text'])).'</div>';
+            '.$this->escape($message['text']).'</div>';
             unset($_SESSION['messages'][$key]);
         }
 


### PR DESCRIPTION
Szenario:
- Modul A ruft addMessage auf, leitet weiter auf Modul B.
- Übersetzung von addMessage wird in den Übersetzungen von Modul B gesucht
- Modul B besitzt die Übersetzung nicht, da es die Message von Modul A gar nicht kennt.
-> keine Übersetzung

Mit der Änderung ist jedes Modul für seine eigenen addMessage Aufrufe zuständig, vorher das, bei dem die Message letztlich angezeigt wurde.