### PR TITLE
Revert escaping of the guestbook-text

### DIFF
--- a/application/modules/guestbook/views/index/index.php
+++ b/application/modules/guestbook/views/index/index.php
@@ -26,7 +26,7 @@
             <td><?=$this->getTrans('date') ?>: <?=$this->escape($entry->getDatetime()) ?></td>
         </tr>
         <tr>
-            <td colspan="3"><?=nl2br($this->getHtmlFromBBCode($this->escape($entry->getText()))) ?></td>
+            <td colspan="3"><?=nl2br($this->getHtmlFromBBCode($entry->getText())) ?></td>
         </tr>
     </table>
 <?php endforeach; ?>


### PR DESCRIPTION
Revert escaping of the guestbook-text, because this breaks smilies and
bbcode.