### PR TITLE
Feature/redirect with input and errors

### DIFF
--- a/application/libraries/Ilch/Controller/Base.php
+++ b/application/libraries/Ilch/Controller/Base.php
@@ -64,15 +64,16 @@ class Base
      *
      * @param array|string $url
      * @param string  $route
-     * @param boolean $rewrite
      */
-    public function redirect($url = [], $route = null, $rewrite = false)
+    public function redirect($url = null, $route = null)
     {
-        if (!is_string($url) || preg_match('~^[a-z]+://.*~', $url) === 0) {
-            $url = $this->getLayout()->getUrl($url, $route, $rewrite);
+        $redirector = new \Ilch\Redirect($this->getRequest());
+
+        if (!is_null($url)) {
+            $redirector->to($url, $route);
         }
-        header("Location: " . $url);
-        exit;
+
+        return $redirector;
     }
 
     /**
@@ -134,7 +135,7 @@ class Base
     {
         return $this->view;
     }
-    
+
     /**
      * Gets the user object.
      *

--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -179,21 +179,6 @@ abstract class Base
     }
 
     /**
-     * Returns the translated text for a specific key.
-     *
-     * @param string   $key
-     * @param [, mixed $args [, mixed $... ]]
-     *
-     * @return string
-     */
-    public function t($key)
-    {
-        $args = func_get_args();
-
-        return call_user_func_array([$this->getTranslator(), 'trans'], $args);
-    }
-
-    /**
      * Gets the base url.
      *
      * @param string $url

--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -1,11 +1,13 @@
 <?php
 /**
  * @copyright Ilch 2.0
- * @package ilch
  */
 
 namespace Ilch\Design;
 
+/**
+ * Base class.
+ */
 abstract class Base
 {
     /**
@@ -16,7 +18,7 @@ abstract class Base
     private $helpers = [];
 
     /**
-     * Name of the layout that will be used
+     * Name of the layout that will be used.
      *
      * @var string
      */
@@ -27,7 +29,7 @@ abstract class Base
      *
      * @param string $name
      * @param string $type
-     * @param mixed $obj
+     * @param mixed  $obj
      */
     public function addHelper($name, $type, $obj)
     {
@@ -66,7 +68,7 @@ abstract class Base
     private $data = [];
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $modRewrite;
 
@@ -87,7 +89,8 @@ abstract class Base
     /**
      * Gets view data.
      *
-     * @param  string     $key
+     * @param string $key
+     *
      * @return mixed|null
      */
     public function get($key)
@@ -96,14 +99,14 @@ abstract class Base
             return $this->data[$key];
         }
 
-        return null;
+        return;
     }
 
     /**
      * Set view data.
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      */
     public function set($key, $value)
     {
@@ -163,20 +166,38 @@ abstract class Base
     /**
      * Returns the translated text for a specific key.
      *
-     * @param string $key
+     * @param string   $key
      * @param [, mixed $args [, mixed $... ]]
+     *
      * @return string
      */
     public function getTrans($key)
     {
-      $args = func_get_args();
-      return call_user_func_array([$this->getTranslator(), 'trans'], $args);
+        $args = func_get_args();
+
+        return call_user_func_array([$this->getTranslator(), 'trans'], $args);
+    }
+
+    /**
+     * Returns the translated text for a specific key.
+     *
+     * @param string   $key
+     * @param [, mixed $args [, mixed $... ]]
+     *
+     * @return string
+     */
+    public function t($key)
+    {
+        $args = func_get_args();
+
+        return call_user_func_array([$this->getTranslator(), 'trans'], $args);
     }
 
     /**
      * Gets the base url.
      *
-     * @param  string  $url
+     * @param string $url
+     *
      * @return string
      */
     public function getBaseUrl($url = '')
@@ -184,10 +205,11 @@ abstract class Base
         return BASE_URL.'/'.$url;
     }
 
-   /**
+    /**
      * Gets the layout url.
      *
      * @param string $url
+     *
      * @return string
      */
     public function getLayoutUrl($url = '')
@@ -203,6 +225,7 @@ abstract class Base
      * Gets the module url.
      *
      * @param string $url
+     *
      * @return string
      */
     public function getModuleUrl($url = '')
@@ -217,7 +240,8 @@ abstract class Base
     /**
      * Gets the system, static url.
      *
-     * @param  string $url
+     * @param string $url
+     *
      * @return string
      */
     public function getStaticUrl($url = '')
@@ -232,7 +256,8 @@ abstract class Base
     /**
      * Escape the given string.
      *
-     * @param  string $string
+     * @param string $string
+     *
      * @return string
      */
     public function escape($string)
@@ -244,6 +269,7 @@ abstract class Base
      * Gets html from bbcode.
      *
      * @param string $bbcode
+     *
      * @return string
      */
     public function getHtmlFromBBCode($bbcode)
@@ -255,22 +281,22 @@ abstract class Base
 
         $builder = new \JBBCode\CodeDefinitionBuilder('quote', '<div class="quote">{param}</div>');
         $parser->addCodeDefinition($builder->build());
-        
+
         $builder = new \JBBCode\CodeDefinitionBuilder('list', '<ul>{param}</ul>');
         $parser->addCodeDefinition($builder->build());
-        
+
         $builder = new \JBBCode\CodeDefinitionBuilder('*', '<li>{param}</li>');
         $parser->addCodeDefinition($builder->build());
-        
+
         $builder = new \JBBCode\CodeDefinitionBuilder('email', '<a href="mailto:{param}">{param}</a>');
         $parser->addCodeDefinition($builder->build());
 
         $builder = new \JBBCode\CodeDefinitionBuilder('img', '<img src="{param}" alt="Image">');
         $parser->addCodeDefinition($builder->build());
-        
+
         $builder = new \JBBCode\CodeDefinitionBuilder('i', '<em>{param}</em>');
         $parser->addCodeDefinition($builder->build());
- 
+
         $builder = new \JBBCode\CodeDefinitionBuilder('u', '<u>{param}</u>');
         $parser->addCodeDefinition($builder->build());
 
@@ -290,17 +316,18 @@ abstract class Base
     /**
      * Creates a full url for the given parts.
      *
-     * @param  array|string $url
-     * @param  string  $route
-     * @param  boolean $secure
+     * @param array|string $url
+     * @param string       $route
+     * @param bool         $secure
+     *
      * @return string
      */
     public function getUrl($url = [], $route = null, $secure = false)
     {
         $config = \Ilch\Registry::get('config');
- 
+
         if ($config !== null && $this->modRewrite === null) {
-            $this->modRewrite = (bool)$config->get('mod_rewrite');
+            $this->modRewrite = (bool) $config->get('mod_rewrite');
         }
 
         if (empty($url)) {
@@ -356,10 +383,12 @@ abstract class Base
     }
 
     /**
-     * Returns a full url for the current url with only the given parts changed
+     * Returns a full url for the current url with only the given parts changed.
+     *
      * @param array $urlParts
-     * @param bool $resetParams
-     * @param bool $secure
+     * @param bool  $resetParams
+     * @param bool  $secure
+     *
      * @return string
      */
     public function getCurrentUrl(array $urlParts = [], $resetParams = true, $secure = false)
@@ -367,7 +396,7 @@ abstract class Base
         $currentUrlParts = [
             'module' => $this->request->getModuleName(),
             'controller' => $this->request->getControllerName(),
-            'action' => $this->request->getActionName()
+            'action' => $this->request->getActionName(),
         ];
 
         $params = $this->request->getParams();
@@ -395,11 +424,12 @@ abstract class Base
     }
 
     /**
-     * Generates a token and stores it in user-session
+     * Generates a token and stores it in user-session.
      *
      * @return string
      */
-    public function generateToken() {
+    public function generateToken()
+    {
         $token = bin2hex(openssl_random_pseudo_bytes(32));
         $_SESSION['token'][$token] = $token;
 
@@ -421,9 +451,11 @@ abstract class Base
     /**
      * Gets the MediaModal.
      * Place inside Javascript tag.
-     * 
-     * @param string $mediaButton Define Media Button by given URL
+     *
+     * @param string $mediaButton  Define Media Button by given URL
      * @param string $actionButton Define Action Button by given URL
+     * @param int    $inputId
+     *
      * @return string
      */
     public function getMedia($mediaButton = null, $actionButton = null, $inputId = null)
@@ -446,7 +478,7 @@ abstract class Base
     /**
      * Gets the page queries.
      *
-     * @return integer
+     * @return int
      */
     public function queryCount()
     {
@@ -458,8 +490,9 @@ abstract class Base
     /**
      * Limit the given string to the given length.
      *
-     * @param  string  $str
-     * @param  integer $length
+     * @param string $str
+     * @param int    $length
+     *
      * @return string
      */
     public function limitString($str, $length)
@@ -467,7 +500,7 @@ abstract class Base
         if (strlen($str) <= $length) {
             return $str;
         } else {
-            return preg_replace("/[^ ]*$/", '', substr($str, 0, $length)).'...';
+            return preg_replace('/[^ ]*$/', '', substr($str, 0, $length)).'...';
         }
     }
 
@@ -492,7 +525,12 @@ abstract class Base
     }
 
     /**
-     * Gets the dialog.
+     * Generates a modal.
+     *
+     * @param string $id
+     * @param string $name
+     * @param string $content
+     * @param bool   $submit
      *
      * @return string
      */
@@ -513,8 +551,8 @@ abstract class Base
                         '.$content.'
                     </div>
                     <div class="modal-footer">';
-                        if ($submit != null) {
-                            $html .= '<button type="button"
+        if ($submit) {
+            $html .= '<button type="button"
                                  class="btn btn-primary"
                                  id="modalButton">'.$this->getTrans('ack').'
                             </button>
@@ -522,14 +560,14 @@ abstract class Base
                                     class="btn btn-default"
                                     data-dismiss="modal">'.$this->getTrans('cancel').'
                             </button>';
-                        } else {
-                            $html .= '<button type="button"
+        } else {
+            $html .= '<button type="button"
                                 class="btn btn-primary"
                                 data-dismiss="modal">
                             '.$this->getTrans('close').'
                             </button>';
-                        }
-                    $html .= '</div>
+        }
+        $html .= '</div>
                 </div>
             </div>
         </div>';

--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -365,7 +365,7 @@ if (! function_exists('random_int')) {
          * lose precision, so the <= and => operators might accidentally let a float
          * through.
          */
-        
+
         try {
             $min = RandomCompat_intval($min);
         } catch (TypeError $ex) {
@@ -380,7 +380,7 @@ if (! function_exists('random_int')) {
                 'random_int(): $max must be an integer'
             );
         }
-        
+
         /**
          * Now that we've verified our weak typing system has given us an integer,
          * let's validate the logic then we can move forward with generating random
@@ -493,4 +493,21 @@ if (! function_exists('random_int')) {
         } while (!is_int($val) || $val > $max || $val < $min);
         return (int) $val;
     }
+}
+
+/**
+ * Translation shortcut
+ * @return string Translation
+ */
+function t()
+{
+    static $translator;
+
+    if (is_null($translator)) {
+        $translator = \Ilch\Registry::get('translator');
+    }
+
+    $args = func_get_args();
+
+    return call_user_func_array([$translator, 'trans'], $args);
 }

--- a/application/libraries/Ilch/Redirect.php
+++ b/application/libraries/Ilch/Redirect.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ */
+
+namespace Ilch;
+
+/**
+ * Class to build a redirect.
+ */
+class Redirect
+{
+    /**
+     * The request instance.
+     *
+     * @var \Ilch\Request
+     */
+    protected $request;
+
+    /**
+     * Input for the next request.
+     *
+     * @var array
+     */
+    protected $input = array();
+
+    /**
+     * The errors for the next request.
+     *
+     * @var array
+     */
+    protected $errors = array();
+
+    /**
+     * Constructor.
+     *
+     * @param \Ilch\Request $request The current request instance
+     */
+    public function __construct(\Ilch\Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Sets the input for the next request.
+     *
+     * @param array $input Input data
+     *
+     * @return self
+     */
+    public function withInput(array $input)
+    {
+        $this->input = array_merge($this->input, $input);
+
+        return $this;
+    }
+
+    /**
+     * Sets the errors for the next request.
+     *
+     * @param \Ilch\Validation\ErrorBag $errorBag The errorBag instance
+     *
+     * @return self
+     */
+    public function withErrors(\Ilch\Validation\ErrorBag $errorBag)
+    {
+        $this->errors = array_merge($this->errors, $errorBag->getErrors());
+
+        return $this;
+    }
+
+    /**
+     * Redirects the user to $destination.
+     *
+     * @param mixed $destination
+     * @param bool  $route
+     * @param int   $status
+     * @param array $headers
+     */
+    public function to($destination, $route = null, $status = 302, $headers = [])
+    {
+        if (!is_string($destination) || preg_match('~^[a-z]+://.*~', $destination) === 0) {
+            $destination = $this->getUrl($destination, $route);
+        }
+
+        $this->perform($destination, $status, $headers);
+    }
+
+    /**
+     * Redirects to the desired location.
+     *
+     * @param string    $default Default location
+     * @param int       $status  HTTP Status Code
+     * @param array     $headers An array with headers
+     * @param bool|null $secure  Whether or not it is a secure request
+     */
+    protected function perform($destination = '/', $status = 302, $headers = [])
+    {
+        if (!empty($this->errors)) {
+            $_SESSION['ilch_validation_errors'] = $this->errors;
+        }
+
+        if (!empty($this->input)) {
+            $_SESSION['ilch_old_input'] = $this->input;
+        }
+
+        foreach ($headers as $header) {
+            header($header);
+        }
+
+        header('Location: '.$destination, true, $status);
+        exit;
+    }
+
+    /**
+     * Creates a full url for the given parts.
+     *
+     * @param array|string $url
+     * @param string       $route
+     *
+     * @return string
+     */
+    public function getUrl($url = [], $route = null)
+    {
+        $config = \Ilch\Registry::get('config');
+
+        $modRewrite = false;
+
+        if ($config !== null) {
+            $modRewrite = (bool) $config->get('mod_rewrite');
+        }
+
+        if (empty($url)) {
+            return BASE_URL;
+        }
+
+        if (is_string($url)) {
+            return BASE_URL.'/index.php/'.$url;
+        }
+
+        $urlParts = [];
+
+        if (!isset($url['module'])) {
+            $urlParts[] = $this->request->getModuleName();
+        } else {
+            $urlParts[] = $url['module'];
+            unset($url['module']);
+        }
+
+        if (!isset($url['controller'])) {
+            $urlParts[] = $this->request->getControllerName();
+        } else {
+            $urlParts[] = $url['controller'];
+            unset($url['controller']);
+        }
+
+        if (!isset($url['action'])) {
+            $urlParts[] = $this->request->getActionName();
+        } else {
+            $urlParts[] = $url['action'];
+            unset($url['action']);
+        }
+
+        foreach ($url as $key => $value) {
+            $urlParts[] = $key.'/'.$value;
+        }
+
+        $s = '';
+
+        if (($this->request->isAdmin() && $route === null) || ($route !== null && $route == 'admin')) {
+            $s = 'admin/';
+        }
+
+        if ($modRewrite && empty($s)) {
+            return BASE_URL.'/'.$s.implode('/', $urlParts);
+        } else {
+            return BASE_URL.'/index.php/'.$s.implode('/', $urlParts);
+        }
+    }
+}

--- a/application/libraries/Ilch/View.php
+++ b/application/libraries/Ilch/View.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * @copyright Ilch 2.0
- * @package ilch
  */
 
 namespace Ilch;
@@ -11,7 +10,8 @@ class View extends Design\Base
     /**
      * Loads a view script.
      *
-     * @param  string $viewScript
+     * @param string $viewScript
+     *
      * @return string
      */
     public function loadScript($viewScript)
@@ -28,15 +28,17 @@ class View extends Design\Base
     /**
      * Loads a view file.
      *
-     * @param string $url
-     * @param mixed[] $data
+     * @param string $file
+     * @param array  $data
      */
     public function load($file, $data = [])
     {
         $request = $this->getRequest();
-        $view = new \Ilch\View($request,
+        $view = new \Ilch\View(
+            $request,
             $this->getTranslator(),
-            $this->getRouter());
+            $this->getRouter()
+        );
         $view->setArray($data);
 
         echo $view->loadScript(APPLICATION_PATH.'/modules/'.$request->getModuleName().'/views/'.$file);
@@ -46,7 +48,9 @@ class View extends Design\Base
      * Gets the save bar html.
      *
      * @param string $saveKey
+     * @param string $nameKey
      * @param string $deleteKey
+     *
      * @return string
      */
     public function getSaveBar($saveKey = 'saveButton', $nameKey = null, $deleteKey = '')
@@ -70,8 +74,9 @@ class View extends Design\Base
     /**
      * Gets the list bar html.
      *
-     * @param array $actions
+     * @param array  $actions
      * @param string $name
+     *
      * @return string
      */
     public function getListBar($actions = [], $name = '')
@@ -83,23 +88,26 @@ class View extends Design\Base
                                 $this->getTrans('selected').' <span class="caret"></span>
                             </button>
                             <ul class="dropdown-menu listChooser" role="menu">';
-                                foreach ($actions as $key => $name) {
-                                    $html .= '<li><a href="#" data-hiddenkey="'.$key.'">'.$this->getTrans($name).'</a></li>';
-                                }
+        foreach ($actions as $key => $name) {
+            $html .= '<li><a href="#" data-hiddenkey="'.$key.'">'.$this->getTrans($name).'</a></li>';
+        }
         $html .= '</ul></div></div>';
 
-        return $html; 
+        return $html;
     }
 
     /**
      * Gets the edit icon html.
      *
      * @param array $url
+     *
      * @return string
      */
     public function getEditIcon($url)
     {
-        $html = '<a href="'.$this->getUrl($url).'" title="'.$this->getTrans('edit').'"><span class="fa fa-edit text-success"></span></a>';
+        $html = '<a href="'.$this->getUrl($url).'" title="'.$this->getTrans('edit').'">
+            <span class="fa fa-edit text-success"></span>
+        </a>';
 
         return $html;
     }
@@ -108,11 +116,15 @@ class View extends Design\Base
      * Gets the delete icon html.
      *
      * @param array $url
+     *
      * @return string
      */
     public function getDeleteIcon($url)
     {
-        $html = '<a class="delete_button" href="'.$this->getUrl($url, null, true).'" title="'.$this->getTrans('delete').'">
+        $html = '<a class="delete_button"
+                    href="'.$this->getUrl($url, null, true).'"
+                    title="'.$this->getTrans('delete').'"
+                >
                     <span class="fa fa-trash-o text-danger"></span>
                  </a>';
 
@@ -123,10 +135,34 @@ class View extends Design\Base
      * Gets check all checkbox.
      *
      * @param string $childs
+     *
      * @return string
      */
     public function getCheckAllCheckbox($childs)
     {
         return '<input type="checkbox" class="check_all" data-childs="'.$childs.'" />';
+    }
+
+    /**
+     * Returns the input data from the last request.
+     *
+     * @param string $key     Array key
+     * @param string $default Default value if key not found
+     *
+     * @return mixed
+     */
+    public function old($key = null, $default = '')
+    {
+        return $this->getRequest()->old($key, $default);
+    }
+
+    /**
+     * Returns the validation errors from the last request.
+     *
+     * @return \Ilch\Validation\ErrorBag
+     */
+    public function errors()
+    {
+        return $this->getRequest()->errors();
     }
 }

--- a/application/modules/guestbook/controllers/Index.php
+++ b/application/modules/guestbook/controllers/Index.php
@@ -31,103 +31,18 @@ class Index extends \Ilch\Controller\Frontend
     public function newEntryAction()
     {
         $guestbookMapper = new GuestbookMapper();
-        $ilchdate = new IlchDate;
 
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('guestbook'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('entry'), ['action' => 'newentry']);
 
-        $post = [
-            'name'      => '',
-            'email'     => '',
-            'homepage'  => '',
-            'text'      => ''
-        ];
-
         if ($this->getRequest()->getPost('saveGuestbook') and ($this->getRequest()->getPost('bot') === '')) {
-            $post = [
-                'name'      => $this->getRequest()->getPost('name'),
-                'email'     => trim($this->getRequest()->getPost('email')),
-                'homepage'  => trim($this->getRequest()->getPost('homepage')),
-                'text'      => trim($this->getRequest()->getPost('text')),
-                'captcha'   => trim($this->getRequest()->getPost('captcha'))
-            ];
 
-            /*
-                Selbstverständlich können auch eigene Validatoren hinzugefügt werden. Hier
-                gibt es zwei Möglichkeiten:
-
-                Möglichkeit 1: Eine Closure oder auch anonyme Funktion
-                    Zu beachten ist hier, dass der Name des Validators nicht bereits
-                    vorhanden sein darf, 'same' würde eine Exception werfen!
-
-                    Ansonsten wird immer der Parameter $data übergeben, in dem am Ende alle
-                    Informationen stecken, die der Validator braucht.
-
-                    $data->getValue()  -> Der Wert, der durch den Benutzer im Formular eingetragen wurde
-                    $data->getInput()  -> Alle Daten, die durch den Benutzer eingetragen wurden
-                    $data->getParam()  -> Hier koennen die an den Validator übergebenen Parameter gefunden werden
-                    $data->getParams() -> Gibt einfach das komplette Array an Parametern zurück
-
-                    Zurückgeben muss diese Closure nun immer ein Array mit mindestens dem Ergebnis der Validation ('result')
-                    und dem Übersetzungsschlüssel für die Fehlermeldung ('error_key'). Alternativ können noch
-                    weitere Parameter für die Fehlermeldung übergeben werden ('error_params'). Soll ein Parameter
-                    Übersetzt werden, muss er als Array übergeben werden, wo zunächst der der Übersetzungsschlüssel und dann
-                    ein true hineingehört ['key', true].
-                    Siehe Beispiel, hier soll der Name des anderen Feldes ebenfalls übersetzt werden.
-
-                Möglichkeit 2: Eine eigene Validatorklasse, die von \Ilch\Validation\Validators\Base erben sollte
-                    Validation::addValidator('same2', '\my\namespace\Validators\Same');
-                    Als Vergleich können die bestehenden Validators genommen werden.
-            */
-            Validation::addValidator('same2', function ($data) {
-                $validation = $data->getValue() == array_dot($data->getInput(), $data->getParam('as'));
-                return [
-                    'result' => $validation,
-                    'error_key' => 'validation.errors.differentValues',
-                    'error_params' => [[$data->getParam('as'), true]]
-                ];
-            });
-
-            /*
-                Standardmäßig werden alle Feldnamen automatisch übersetzt.
-                D.h. wenn ein Input-Feld mit name="email" existiert,
-                dann wird bei der Generierung der Fehlermeldungen eine
-                Übersetzung mit dem Schlüssel 'email' gesucht.
-
-                In den meisten Fällen sollte das kein Problem sein. Falls doch,
-                können mit Validation::setCustomFieldAliases() aliase festgelegt werden,
-                nach denen stattdessen gesucht werden soll.
-
-                Als Beispiel dient in diesem Fall das Feld 'homepage'. Das Feld hat den Namen
-                'homepage', bei der Übersetzung wurde jedoch der Schlüssel 'page' gewählt.
-            */
             Validation::setCustomFieldAliases([
                 'homepage' => 'page',
             ]);
 
-            /*
-                Validation rules werden als ein Array übergeben und sind immer im Format wie
-                unten zu sehen.
-
-                Bei multidimensionalen Arrays wird ebenfalls die Punktnotation unterstützt,
-                d.h. um an $post['foo']['bar'] zu kommen, muss einfach nur 'foo.bar' als
-                Schlüssel gesetzt werden.
-
-                Die einzelnen Validatoren werden mit | getrennt. Weitere Parameter werden mit einem
-                Komma getrennt, während Schlüssel und Wert mit einem Doppelpunkt getrennt werden, Beispiel:
-                    'name'      => 'required|length,max:16,min:3',
-
-                Um für eine Validation rule eine eigene Fehlermeldung anzugeben, die alle vom Validator
-                selbst generierten Fehlermeldungen überschreibt, kann jeder Validation rule ein
-                customErrorAlias:translation.key als Parameter mitgegeben werden. Siehe Beispiel:
-                    'email'     => 'required,customErrorAlias:unsupportedEmailAddress|email
-
-                Bei Validatoren, die unterschiedliche Fehlermeldungen generieren können, können stattdessen
-                auch die einzelnen, spezifischen Fehlermeldungen überschrieben werden. Dies ist dann
-                allerdings immer vom genutzten Validator abhängig.
-            */
-            $validation = Validation::create($post, [
+            $validation = Validation::create($this->getRequest()->getPost(), [
                 'name'      => 'required',
                 'email'     => 'required|email',
                 'homepage'  => 'url',
@@ -135,54 +50,27 @@ class Index extends \Ilch\Controller\Frontend
                 'captcha'   => 'captcha'
             ]);
 
-            /*
-                Um herauszufinden, ob eine Validation nun erfolgreich war oder ob
-                Fehler gefunden wurden, ist die Methode isValid nötig.
-            */
             if ($validation->isValid()) {
                 $model = new GuestbookModel();
-                $model->setName($post['name']);
-                $model->setEmail($post['email']);
-                $model->setText($post['text']);
-                $model->setHomepage($post['homepage']);
-                $model->setDatetime($ilchdate->toDb());
+                $model->setName($this->getRequest()->getPost('name'));
+                $model->setEmail($this->getRequest()->getPost('email'));
+                $model->setText($this->getRequest()->getPost('text'));
+                $model->setHomepage($this->getRequest()->getPost('homepage'));
+                $model->setDatetime((new \Ilch\Date())->toDb(true));
                 $model->setFree($this->getConfig()->get('gbook_autosetfree'));
                 $guestbookMapper->save($model);
 
-                unset($_SESSION['captcha']);
-                
                 if ($this->getConfig()->get('gbook_autosetfree') == 0) {
                     $this->addMessage('check', 'success');
                 }
+
                 $this->redirect(['action' => 'index']);
             }
 
-            unset($_SESSION['captcha']);
-            /*
-                Nun werden noch die Fehler generiert und an das View übergeben.
-                $validation->getErrors() benötigt immer die aktuelle Translator-Instanz, damit
-                die Fehlermeldungen übersetzt werden können.
-
-                Zurückgegeben wird einfach nur ein Array mit Fehler-Strings
-                Ansonsten siehe newEntry.php
-            */
-            // $this->getView()->set('errors', $validation->getErrors());
-            $this->getView()->set('errors', $validation->getErrorBag()->getErrorMessages());
-
-            /*
-                $validation->getFieldsWithError() gibt ein Array mit allen Feldern, die Fehler beinhalten, zurück.
-            */
-            $errorFields = $validation->getFieldsWithError();
+            $this->redirect()
+                ->withInput($this->getRequest()->getPost())
+                ->withErrors($validation->getErrorBag())
+                ->to(['action' => 'newentry']);
         }
-
-        $this->getView()->set('post', $post);
-
-        /*
-            Um die Felder mit Fehlern dementsprechen Kennzeichnen zu können, wird noch ein Array
-            mit allen Feldernamen, die Fehler beinhalten, ans View übergeben.
-
-            Falls $errorFields nicht existiert wird einfach ein leeres Array übergeben, um eine Fehlermeldung zu vermeiden.
-        */
-        $this->getView()->set('errorFields', (isset($errorFields) ? $errorFields : []));
     }
 }

--- a/application/modules/guestbook/views/index/newentry.php
+++ b/application/modules/guestbook/views/index/newentry.php
@@ -1,8 +1,8 @@
-<legend><?=$this->t('menuGuestbook') ?></legend>
+<legend><?=t('menuGuestbook') ?></legend>
 
 <?php if (!empty($this->errors()->hasErrors())): ?>
     <div class="alert alert-danger" role="alert">
-        <strong> <?=$this->t('errorsOccured') ?>:</strong>
+        <strong> <?=t('errorsOccured') ?>:</strong>
         <ul>
             <?php foreach ($this->errors()->getErrorMessages() as $error): ?>
                 <li><?= $error; ?></li>
@@ -15,7 +15,7 @@
     <?=$this->getTokenField() ?>
     <div class="form-group hidden">
         <label class="col-lg-2 control-label">
-            <?=$this->t('bot') ?>*
+            <?=t('bot') ?>*
         </label>
         <div class="col-lg-8">
             <input type="text"
@@ -26,7 +26,7 @@
     </div>
     <div class="form-group<?= $this->errors()->hasError('name') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->t('name') ?>*
+            <?=t('name') ?>*
         </label>
         <div class="col-lg-8">
             <input type="text"
@@ -38,7 +38,7 @@
     </div>
     <div class="form-group<?= $this->errors()->hasError('email') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->t('email') ?>*
+            <?=t('email') ?>*
         </label>
         <div class="col-lg-8">
             <input type="text"
@@ -50,19 +50,19 @@
     </div>
     <div class="form-group<?= $this->errors()->hasError('homepage') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->t('page') ?>
+            <?=t('page') ?>
         </label>
         <div class="col-lg-8">
            <input type="text"
                   class="form-control"
                   name="homepage"
-                  placeholder="<?=$this->t('page') ?>"
+                  placeholder="<?=t('page') ?>"
                   value="<?=$this->old('homepage'); ?>" />
         </div>
     </div>
     <div class="form-group<?= $this->errors()->hasError('text') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->t('message') ?>*
+            <?=t('message') ?>*
         </label>
         <div class="col-lg-8">
             <textarea class="form-control ckeditor"
@@ -80,7 +80,7 @@
     ?>
     <div class="form-group<?= $this->errors()->hasError('captcha') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->t('captcha') ?>
+            <?=t('captcha') ?>
         </label>
         <div class="col-lg-8">
             <?=$this->getCaptchaField() ?>
@@ -93,7 +93,7 @@
                   class="form-control"
                   autocomplete="off"
                   name="captcha"
-                  placeholder="<?=$this->t('captcha') ?>" />
+                  placeholder="<?=t('captcha') ?>" />
             <span class="input-group-addon">
                 <a href="javascript:void(0)" onclick="
                     document.getElementById('captcha').src='<?=$this->getUrl() ?>/application/libraries/Captcha/Captcha.php?'+Math.random();
@@ -111,4 +111,4 @@
     </div>
 </form>
 
-<?=$this->getDialog("smiliesModal", $this->t('smilies'), "<iframe frameborder='0'></iframe>"); ?>
+<?=$this->getDialog("smiliesModal", t('smilies'), "<iframe frameborder='0'></iframe>"); ?>

--- a/application/modules/guestbook/views/index/newentry.php
+++ b/application/modules/guestbook/views/index/newentry.php
@@ -1,23 +1,21 @@
-<legend><?=$this->getTrans('menuGuestbook') ?></legend>
+<legend><?=$this->t('menuGuestbook') ?></legend>
 
-<!-- Fehlerausgabe der Validation -->
-<?php if (!empty($this->get('errors'))): ?>
+<?php if (!empty($this->errors()->hasErrors())): ?>
     <div class="alert alert-danger" role="alert">
-        <strong> <?=$this->getTrans('errorsOccured') ?>:</strong>
+        <strong> <?=$this->t('errorsOccured') ?>:</strong>
         <ul>
-            <?php foreach ($this->get('errors') as $error): ?>
+            <?php foreach ($this->errors()->getErrorMessages() as $error): ?>
                 <li><?= $error; ?></li>
             <?php endforeach; ?>
         </ul>
     </div>
 <?php endif; ?>
-<!-- Ende Fehlerausgabe der Validation -->
 
 <form action="" class="form-horizontal" method="POST">
     <?=$this->getTokenField() ?>
     <div class="form-group hidden">
         <label class="col-lg-2 control-label">
-            <?=$this->getTrans('bot') ?>*
+            <?=$this->t('bot') ?>*
         </label>
         <div class="col-lg-8">
             <input type="text"
@@ -26,54 +24,52 @@
                    placeholder="Bot" />
         </div>
     </div>
-    <div class="form-group<?=in_array('name', $this->get('errorFields')) ? ' has-error' : '' ?>">
+    <div class="form-group<?= $this->errors()->hasError('name') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->getTrans('name') ?>*
+            <?=$this->t('name') ?>*
         </label>
         <div class="col-lg-8">
             <input type="text"
                    class="form-control"
                    name="name"
                    placeholder="Name"
-                   value="<?=$this->get('post')['name'] ?>" />
+                   value="<?=$this->old('name'); ?>" />
         </div>
     </div>
-    <div class="form-group<?=in_array('email', $this->get('errorFields')) ? ' has-error' : '' ?>">
+    <div class="form-group<?= $this->errors()->hasError('email') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->getTrans('email') ?>*
+            <?=$this->t('email') ?>*
         </label>
         <div class="col-lg-8">
             <input type="text"
                    class="form-control"
                    name="email"
                    placeholder="E-Mail"
-                   value="<?=$this->get('post')['email'] ?>" />
+                   value="<?=$this->old('email'); ?>" />
         </div>
     </div>
-    <div class="form-group<?=in_array('homepage', $this->get('errorFields')) ? ' has-error' : '' ?>">
+    <div class="form-group<?= $this->errors()->hasError('homepage') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->getTrans('page') ?>
+            <?=$this->t('page') ?>
         </label>
         <div class="col-lg-8">
            <input type="text"
                   class="form-control"
                   name="homepage"
-                  placeholder="<?=$this->getTrans('page') ?>"
-                  value="<?=$this->get('post')['homepage'] ?>" />
+                  placeholder="<?=$this->t('page') ?>"
+                  value="<?=$this->old('homepage'); ?>" />
         </div>
     </div>
-    <div class="form-group<?=in_array('text', $this->get('errorFields')) ? ' has-error' : '' ?>">
+    <div class="form-group<?= $this->errors()->hasError('text') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->getTrans('message') ?>*
+            <?=$this->t('message') ?>*
         </label>
         <div class="col-lg-8">
             <textarea class="form-control ckeditor"
                       id="ck_1"
                       name="text"
                       toolbar="ilch_bbcode"
-                      required>
-                <?=$this->get('post')['text'] ?>
-            </textarea>
+                      required><?=$this->old('text'); ?></textarea>
         </div>
     </div>
     <?php
@@ -82,22 +78,22 @@
         echo $message;
     }
     ?>
-    <div class="form-group<?=in_array('captcha', $this->get('errorFields')) ? ' has-error' : '' ?>">
+    <div class="form-group<?= $this->errors()->hasError('captcha') ? ' has-error' : '' ?>">
         <label class="col-lg-2 control-label">
-            <?=$this->getTrans('captcha') ?>
+            <?=$this->t('captcha') ?>
         </label>
         <div class="col-lg-8">
             <?=$this->getCaptchaField() ?>
         </div>
     </div>
-    <div class="form-group<?=in_array('captcha', $this->get('errorFields')) ? ' has-error' : '' ?>">
+    <div class="form-group<?= $this->errors()->hasError('captcha') ? ' has-error' : '' ?>">
         <div class="col-lg-offset-2 col-lg-8 input-group captcha">
             <input type="text"
                   id="captcha-form"
                   class="form-control"
                   autocomplete="off"
                   name="captcha"
-                  placeholder="<?=$this->getTrans('captcha') ?>" />
+                  placeholder="<?=$this->t('captcha') ?>" />
             <span class="input-group-addon">
                 <a href="javascript:void(0)" onclick="
                     document.getElementById('captcha').src='<?=$this->getUrl() ?>/application/libraries/Captcha/Captcha.php?'+Math.random();
@@ -115,4 +111,4 @@
     </div>
 </form>
 
-<?=$this->getDialog("smiliesModal", $this->getTrans('smilies'), "<iframe frameborder='0'></iframe>"); ?>
+<?=$this->getDialog("smiliesModal", $this->t('smilies'), "<iframe frameborder='0'></iframe>"); ?>


### PR DESCRIPTION
- alle vorhandenen redirects sollten wie gewohnt weiterfunktionieren
- t() als shortcut für sämtliche translation funktionen eingeführt (kein nervige $this->getTrans()) mehr sondern einfach nur t()) - optional, die alte Variante funktioniert weiterhin.

- Beispiel, wie das mit den Redirects, dem alten POST und Validation errors funktioniert, siehe Guestbook module