### PR TITLE
Check if mbstring- and zip-extension are loaded

### DIFF
--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -147,6 +147,14 @@ class Index extends \Ilch\Controller\Frontend
             $errors['writableCertificate'] = true;
         }
 
+        if (!extension_loaded('mbstring')) {
+            $errors['mbstringExtensionMissing'] = true;
+        }
+
+        if (!extension_loaded('zip')) {
+            $errors['zipExtensionMissing'] = true;
+        }
+
         if (!extension_loaded('openssl')) {
             $errors['opensslExtensionMissing'] = true;
             $errors['expiredCertUnknown'] = true;

--- a/application/modules/install/views/index/systemcheck.php
+++ b/application/modules/install/views/index/systemcheck.php
@@ -20,6 +20,28 @@
                 </td>
             </tr>
             <tr>
+                <td>PHP-<?=$this->getTrans('extension') ?> Multibyte String (mbstring)</td>
+                <td class="text-success"><?=$this->getTrans('existing') ?>
+                <td>
+                    <?php if (extension_loaded('mbstring')): ?>
+                        <span class="text-success"><?=$this->getTrans('existing') ?></span>
+                    <?php else: ?>
+                        <span class="text-danger"><?=$this->getTrans('missing') ?></span>
+                    <?php endif; ?>
+                </td>
+            </tr>
+            <tr>
+                <td>PHP-<?=$this->getTrans('extension') ?> Zip</td>
+                <td class="text-success"><?=$this->getTrans('existing') ?>
+                <td>
+                    <?php if (extension_loaded('zip')): ?>
+                        <span class="text-success"><?=$this->getTrans('existing') ?></span>
+                    <?php else: ?>
+                        <span class="text-danger"><?=$this->getTrans('missing') ?></span>
+                    <?php endif; ?>
+                </td>
+            </tr>
+            <tr>
                 <td>PHP-<?=$this->getTrans('extension') ?> OpenSSL</td>
                 <td class="text-success"><?=$this->getTrans('existing') ?>
                 <td>


### PR DESCRIPTION
Functions of mbstring are currently used in the validator and password_compat.

Zip-extension is used in the transfer-class.

http://redmine.ilch2.de/issues/335

