### PR TITLE
Fix/checkout module numberformatter

### DIFF
--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -181,6 +181,19 @@ abstract class Base
     }
 
     /**
+     * Returns an amount of money of the currency supplied formatted in locale-typical style.
+     *
+     * @param float amount
+     * @param string currency code (ISO 4217)
+     * @return string
+     */
+    public function getFormattedCurrency($amount, $currencyCode)
+    {
+      $args = func_get_args();
+      return call_user_func_array([$this->getTranslator(), 'getFormattedCurrency'], $args);
+    }
+
+    /**
      * Gets the base url.
      *
      * @param  string  $url

--- a/application/libraries/Ilch/Translator.php
+++ b/application/libraries/Ilch/Translator.php
@@ -167,4 +167,30 @@ class Translator
             }
         }
     }
+
+    /**
+     * Returns an amount of money of the currency supplied formatted in locale-typical style.
+     *
+     * @param float amount
+     * @param string currency code (ISO 4217)
+     * @return string
+     */
+    public function getFormattedCurrency($amount, $currencyCode)
+    {
+        $returnValue;
+
+        $numberFormatter = new \NumberFormatter($this->getLocale(), \NumberFormatter::CURRENCY); 
+        $returnValue = $numberFormatter->formatCurrency($amount, $currencyCode);
+
+        if (intl_is_failure($numberFormatter->getErrorCode())) {
+            // Error occured - probably the currency-code is wrong.
+            // Try to just format the number correctly and append $currencyCode.
+            $numberFormatter = new \NumberFormatter($this->getLocale(), \NumberFormatter::DECIMAL); 
+            $numberFormatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, 2); 
+            $numberFormatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, 2);
+            $returnValue = $numberFormatter->format($amount)." ".$currencyCode;
+        }
+
+        return $returnValue;
+    }
 }

--- a/application/modules/checkout/config/config.php
+++ b/application/modules/checkout/config/config.php
@@ -60,11 +60,11 @@ class Config extends \Ilch\Config\Install
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
 
-                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (1, "EUR (€)");
-                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (2, "USD ($)");
-                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (3, "GBP (£)");
-                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (4, "AUD ($)");
-                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (5, "NZD ($)");
+                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (1, "EUR");
+                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (2, "USD");
+                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (3, "GBP");
+                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (4, "AUD");
+                INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (5, "NZD");
                 INSERT INTO `[prefix]_checkout_currencies` (`id`, `name`) VALUES (6, "CHF");';
     }
 

--- a/application/modules/checkout/translations/de.php
+++ b/application/modules/checkout/translations/de.php
@@ -17,7 +17,7 @@ return [
     'accountdata' => 'Kontodaten',
     'book' => 'Buchen',
     'for' => 'für',
-    'amountinfo' => 'z.B. -30 für eine Ausgabe oder +30 für eine Einnahme, ohne Punkt oder Komma.',
+    'amountinfo' => 'z.B. -30.50 für eine Ausgabe oder +30 für eine Einnahme.',
     'balancetotal' => 'Kontostand Gesamt',
     'totalpaid' => 'Insgesamt eingezahlt',
     'totalpaidout' => 'Insgesamt ausgezahlt',

--- a/application/modules/checkout/translations/en.php
+++ b/application/modules/checkout/translations/en.php
@@ -17,7 +17,7 @@ return [
     'accountdata' => 'Account data',
     'book' => 'Book',
     'for' => 'for',
-    'amountinfo' => 'e.g. -30 for an expense or +30 for a revenue, with no point or comma.',
+    'amountinfo' => 'e.g. -30.50 for an expense or +30 for a revenue.',
     'balancetotal' => 'Balance total',
     'totalpaid' => 'Total paid',
     'totalpaidout' => 'Total paid out',

--- a/application/modules/checkout/views/admin/index/index.php
+++ b/application/modules/checkout/views/admin/index/index.php
@@ -57,17 +57,17 @@ $currency = $this->escape($this->get('currency'));
         <div class="panel panel-default">
             <div class="panel-body">
                 <strong>
-                    <?php if ($this->get('amount') != '') { echo $this->getTrans('balancetotal'),': ', $this->get('amount'), ' '.$currency ; } 
-                    else { echo $this->getTrans('balancetotal'), ': 0 ', $currency ;}
+                    <?php if ($this->get('amount') != '') { echo $this->getTrans('balancetotal'),': ', $this->escape($this->getFormattedCurrency($this->get('amount'), $currency)); } 
+                    else { echo $this->getTrans('balancetotal'), ': ', $this->escape($this->getFormattedCurrency(0, $currency)) ;}
                     ?>
                 </strong>
                 <br>
-                <?php if ($this->get('amountplus') != '') { echo $this->getTrans('totalpaid'),': ', $this->get('amountplus'), ' '.$currency ; }
-                else { echo $this->getTrans('totalpaid'), ': 0 ', $currency ;}
+                <?php if ($this->get('amountplus') != '') { echo $this->getTrans('totalpaid'),': ', $this->escape($this->getFormattedCurrency($this->get('amountplus'), $currency)); } 
+                else { echo $this->getTrans('totalpaid'), ': ', $this->escape($this->getFormattedCurrency(0, $currency)) ;}
                 ?>
                 <br>
-                <?php if ($this->get('amountminus') != '') { echo $this->getTrans('totalpaidout'),': ', $this->get('amountminus'), ' '.$currency ; }
-                else { echo $this->getTrans('totalpaidout'), ': 0 ', $currency ;}
+                <?php if ($this->get('amountminus') != '') { echo $this->getTrans('totalpaidout'),': ', $this->escape($this->getFormattedCurrency($this->get('amountminus'), $currency)); } 
+                else { echo $this->getTrans('totalpaidout'), ': ', $this->escape($this->getFormattedCurrency(0, $currency)) ;}
                 ?>
             </div>
         </div>
@@ -79,8 +79,7 @@ $currency = $this->escape($this->get('currency'));
                     <li class="list-group-item">
                         <?=$this->escape($checkout->getName()) ?>: 
                         <strong>
-                            <?=$this->escape($checkout->getAmount()) ?>
-                            <?=$currency ?>
+                            <?=$this->escape($this->getFormattedCurrency($checkout->getAmount(), $currency)) ?>
                         </strong> 
                         <?=$this->getTrans('for') ?>: 
                         <?=$this->escape($checkout->getUsage()) ?>

--- a/application/modules/checkout/views/index/index.php
+++ b/application/modules/checkout/views/index/index.php
@@ -9,17 +9,17 @@ $currency = $this->escape($this->get('currency'));
 <legend><?=$this->getTrans('bankbalance') ?></legend>
 <div>
     <strong>
-        <?php if ($this->get('amount') != '') { echo $this->getTrans('balancetotal'),': ', $this->get('amount'), ' '.$currency ; } 
-        else { echo $this->getTrans('balancetotal'), ': 0 ', $currency ;}
+        <?php if ($this->get('amount') != '') { echo $this->getTrans('balancetotal'),': ', $this->escape($this->getFormattedCurrency($this->get('amount'), $currency)); } 
+        else { echo $this->getTrans('balancetotal'), ': ', $this->escape($this->getFormattedCurrency(0, $currency)) ;}
         ?>
     </strong>
     <br>
-    <?php if ($this->get('amountplus') != '') { echo $this->getTrans('totalpaid'),': ', $this->get('amountplus'), ' '.$currency ; }
-    else { echo $this->getTrans('totalpaid'), ': 0 ', $currency ;}
+    <?php if ($this->get('amountplus') != '') { echo $this->getTrans('totalpaid'),': ', $this->escape($this->getFormattedCurrency($this->get('amountplus'), $currency)); } 
+    else { echo $this->getTrans('totalpaid'), ': ', $this->escape($this->getFormattedCurrency(0, $currency)) ;}
     ?>
     <br>
-    <?php if ($this->get('amountminus') != '') { echo $this->getTrans('totalpaidout'),': ', $this->get('amountminus'), ' '.$currency ; }
-    else { echo $this->getTrans('totalpaidout'), ': 0 ', $currency ;}
+    <?php if ($this->get('amountminus') != '') { echo $this->getTrans('totalpaidout'),': ', $this->escape($this->getFormattedCurrency($this->get('amountminus'), $currency)); } 
+    else { echo $this->getTrans('totalpaidout'), ': ', $this->escape($this->getFormattedCurrency(0, $currency)) ;}
     ?>
 </div>
 <br>
@@ -30,8 +30,7 @@ $currency = $this->escape($this->get('currency'));
     <li>
         <?=$this->escape($checkout->getName()) ?>: 
         <strong>
-            <?=$this->escape($checkout->getAmount()) ?> 
-            <?=$currency ?>
+            <?=$this->escape($this->getFormattedCurrency($checkout->getAmount(), $currency)) ?>
         </strong> 
         <?=$this->getTrans('for') ?>: 
         <?=$this->escape($checkout->getUsage()) ?>

--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -147,6 +147,10 @@ class Index extends \Ilch\Controller\Frontend
             $errors['writableCertificate'] = true;
         }
 
+        if (!extension_loaded('intl')) {
+            $errors['intlExtensionMissing'] = true;
+        }
+
         if (!extension_loaded('mbstring')) {
             $errors['mbstringExtensionMissing'] = true;
         }

--- a/application/modules/install/views/index/systemcheck.php
+++ b/application/modules/install/views/index/systemcheck.php
@@ -20,6 +20,17 @@
                 </td>
             </tr>
             <tr>
+                <td>PHP-<?=$this->getTrans('extension') ?> Internationalization support (intl)</td>
+                <td class="text-success"><?=$this->getTrans('existing') ?>
+                <td>
+                    <?php if (extension_loaded('intl')): ?>
+                        <span class="text-success"><?=$this->getTrans('existing') ?></span>
+                    <?php else: ?>
+                        <span class="text-danger"><?=$this->getTrans('missing') ?></span>
+                    <?php endif; ?>
+                </td>
+            </tr>
+            <tr>
                 <td>PHP-<?=$this->getTrans('extension') ?> Multibyte String (mbstring)</td>
                 <td class="text-success"><?=$this->getTrans('existing') ?>
                 <td>


### PR DESCRIPTION
http://redmine.ilch2.de/issues/333

Added getFormattedCurrency() to the Translator-class and to the
Base-class. Use this function in the checkout-module.

Adjusted the default currency-values added to the database when
installing the checkout-module. Now these are just the currency-codes.

If getFormattedCurrency() fails in applying the provided currency-code
it falls back to just formatting the number and appending the supplied
currency-code. This is for example the case when the currency is
"Bitcoin".

Check if intl-extension is loaded.