### PR TITLE
Hide the comment-id

### DIFF
--- a/application/modules/comment/translations/de.php
+++ b/application/modules/comment/translations/de.php
@@ -12,7 +12,6 @@ return [
     'commentLink' => 'Link',
     'noComments' => 'Keine Kommentare',
     'commentModul' => 'Modul',
-    'commentID' => 'ID',
     'submit' => 'Eintragen',
     'reply' => 'Antworten',
     'dateTime' => 'Datum/Uhrzeit',

--- a/application/modules/comment/translations/en.php
+++ b/application/modules/comment/translations/en.php
@@ -12,7 +12,6 @@ return [
     'commentLink' => 'Link',
     'noComments' => 'No comments',
     'commentModul' => 'Modul',
-    'commentID' => 'ID',
     'submit' => 'Save',
     'reply' => 'Reply',
     'dateTime' => 'Date/Time',

--- a/application/modules/comment/views/admin/index/index.php
+++ b/application/modules/comment/views/admin/index/index.php
@@ -9,18 +9,16 @@
                 <colgroup>
                     <col class="icon_width">
                     <col class="icon_width">
-                    <col class="icon_width">
                     <col class="col-lg-2">
                     <col class="col-lg-1">
                     <col class="col-lg-1">
-                    <col class="col-lg-1">				
+                    <col class="col-lg-1">
                     <col>
                 </colgroup>
                 <thead>
                     <tr>
                         <th><?=$this->getCheckAllCheckbox('check_comments') ?></th>
                         <th></th>
-                        <th><?=$this->getTrans('commentID') ?></th>
                         <th><?=$this->getTrans('commentDateTime') ?></th>
                         <th><?=$this->getTrans('commentFrom') ?></th>
                         <th><?=$this->getTrans('commentModul') ?></th>
@@ -39,7 +37,6 @@
                         <tr>
                             <td><input type="checkbox" name="check_comments[]" value="<?=$comment->getId() ?>" /></td>
                             <td><?=$this->getDeleteIcon(['action' => 'delete', 'id' => $comment->getId()]) ?></td>
-                            <td><?=$comment->getId() ?></td>
                             <td><?=$date->format("d.m.Y H:i", true) ?></td>
                             <td><a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><?=$this->escape($user->getName()) ?></a></td>
                             <td><?=$modules->getName() ?></td>


### PR DESCRIPTION
The comment-id, which is the auto-incrementing primary key in the
database is of no use to the user. Therefore no need to display it.