### PR TITLE
Add missing errorFields

### DIFF
--- a/application/modules/article/controllers/admin/Settings.php
+++ b/application/modules/article/controllers/admin/Settings.php
@@ -64,6 +64,7 @@ class Settings extends \Ilch\Controller\Admin
             $errorFields = $validation->getFieldsWithError();
         }
 
+        $this->getView()->set('errorFields', (isset($errorFields) ? $errorFields : []));
         $this->getView()->set('articlesPerPage', $this->getConfig()->get('article_articlesPerPage'));
     }
 }


### PR DESCRIPTION
PHP Warning:  in_array() expects parameter 2 to be array, null given in
application\modules\article\views\admin\settings\index.php on line 14