### PR TITLE
Move saveSuccess-translation

### DIFF
--- a/application/libraries/Ilch/Translations/de.php
+++ b/application/libraries/Ilch/Translations/de.php
@@ -25,4 +25,6 @@ return [
     'validation.errors.max.numeric' => '%s darf höchstens %s betragen.',
     'validation.errors.max.string' => '%s darf höchstens %s Zeichen lang sein.',
     'validation.errors.max.array' => '%s darf höchstens %s Einträge haben.',
+
+    'saveSuccess' => 'Erfolgreich gespeichert',
 ];

--- a/application/libraries/Ilch/Translations/en.php
+++ b/application/libraries/Ilch/Translations/en.php
@@ -25,4 +25,6 @@ return [
     'validation.errors.max.numeric' => '%s may not be greater than %s.',
     'validation.errors.max.string' => '%s may not be greater than %s characters.',
     'validation.errors.max.array' => '%s may not have more than %s items.',
+
+    'saveSuccess' => 'Saved successful',
 ];

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -9,7 +9,6 @@ return [
     'saveButton' => 'Speichern',
     'updateButton' => 'Aktualisieren',
     'selected' => 'markierte...',
-    'saveSuccess' => 'Erfolgreich gespeichert',
     'downSuccess' => 'Erfolgreich heruntergeladen',
     'deleteSuccess' => 'Erfolgreich gelöscht',
     'uninstallSuccess' => 'Erfolgreich deinstalliert',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -9,7 +9,6 @@ return [
     'saveButton' => 'Save',
     'updateButton' => 'Update',
     'selected' => 'selected...',
-    'saveSuccess' => 'Saved successful',
     'downSuccess' => 'Successfully downloaded',
     'deleteSuccess' => 'Deleted successful',
     'uninstallSuccess' => 'Successfully uninstalled',

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -234,7 +234,6 @@ return [
     'galleryItemAdd' => 'Hinzufügen',
     'noImages' => 'Keine Bilder vorhanden',
     'treatImage' => 'Bild bearbeiten',
-    'saveSuccess' => 'Erfolgreich gespeichert',
     'deleteSuccess' => 'Erfolgreich gelöscht',
     'images' => 'Bilder',
     'comments' => 'Kommentare',

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -234,7 +234,6 @@ return [
     'galleryItemAdd' => 'Append',
     'noImages' => 'No images available',
     'treatImage' => 'Treat image',
-    'saveSuccess' => 'Saved successful',
     'deleteSuccess' => 'Deleted successful',
     'images' => 'Images',
     'comments' => 'Comments',


### PR DESCRIPTION
Added the general translation "saveSuccess" to the general translation-file and removed it from the language-files of the modules.