### PR TITLE
Add curlClose() and a destructor to the transfer-class

### DIFF
--- a/application/libraries/Ilch/Transfer.php
+++ b/application/libraries/Ilch/Transfer.php
@@ -372,6 +372,7 @@ class Transfer
         zip_close($zipHandle);
         unlink($this->zipFile);
         unlink($this->zipFile.'-signature.sig');
+        $this->curlClose();
         $this->setContent($content);
         return true;
     }
@@ -432,7 +433,20 @@ class Transfer
         $zip->close();
         unlink($this->zipFile);
         unlink($this->zipFile.'-signature.sig');
+        $this->curlClose();
         $this->setContent($content);
         return true;
+    }
+
+    private function curlClose()
+    {
+        if (is_resource($this->transferUrl)) {
+          curl_close($this->transferUrl);
+        }
+    }
+
+    public function __destruct()
+    {
+        $this->curlClose();
     }
 }

--- a/application/modules/admin/controllers/admin/Settings.php
+++ b/application/modules/admin/controllers/admin/Settings.php
@@ -187,7 +187,6 @@ HTACCESS;
         if ($result == '') {
             $this->addMessage(curl_error($update->getTransferUrl()), 'danger');
         }
-        curl_close($this->getTransferUrl());
 
         $this->getView()->set('versions', $result);
 


### PR DESCRIPTION
Add curlClose() and a destructor to the transfer-class.

Call curlClose() after installing/updating.
The destructor calls curlClose(). 

> The destructor method will be called as soon as there are no other
> references to a particular object, or in any order during the shutdown
> sequence.
Currently this is for example the case with the update-check happening on the admincenter-startpage and an ilch update-check with no new version.