### PR TITLE
Set CURLOPT_TIMEOUT and CURLOPT_CONNECTTIMEOUT

### DIFF
--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -213,6 +213,8 @@ function url_get_contents($url)
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 20);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
     $output = curl_exec($ch);
     curl_close($ch);
     return $output;

--- a/application/modules/admin/controllers/admin/Index.php
+++ b/application/modules/admin/controllers/admin/Index.php
@@ -24,9 +24,12 @@ class Index extends \Ilch\Controller\Admin
         $update->setTransferUrl($this->getConfig()->get('master_update_url'));
         $update->setVersionNow($this->getConfig()->get('version'));
         $update->setCurlOpt(CURLOPT_RETURNTRANSFER, 1);
+        $update->setCurlOpt(CURLOPT_TIMEOUT, 20);
+        $update->setCurlOpt(CURLOPT_CONNECTTIMEOUT, 10);
         $update->setCurlOpt(CURLOPT_FAILONERROR, true);
 
         if ($update->getVersions() == '') {
+            $this->getView()->set('curlErrorOccured', true);
             $this->addMessage(curl_error($update->getTransferUrl()), 'danger');
         }
 

--- a/application/modules/admin/controllers/admin/Settings.php
+++ b/application/modules/admin/controllers/admin/Settings.php
@@ -181,6 +181,7 @@ HTACCESS;
         $update->setVersionNow($version);
         $update->setCurlOpt(CURLOPT_RETURNTRANSFER, 1);
         $update->setCurlOpt(CURLOPT_FAILONERROR, true);
+        $update->setCurlOpt(CURLOPT_CONNECTTIMEOUT, 10);
         $update->setZipSavePath(ROOT_PATH.'/updates/');
 
         $result = $update->getVersions();

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -154,6 +154,8 @@ return [
     'system' => 'System',
     'upToDate' => 'aktuell',
     'notUpToDate' => 'nicht aktuell',
+    'versionQueryFailed' => 'Versionsabfrage fehlgeschlagen',
+    'versionNA' => 'nicht verfügbar',
     'installedVersion' => 'Installierte Version',
     'serverVersion' => 'Server Version',
     'description' => 'Beschreibung',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -153,6 +153,8 @@ return [
     'system' => 'System',
     'upToDate' => 'up to date',
     'notUpToDate' => 'not up to date',
+    'versionQueryFailed' => 'Version query failed',
+    'versionNA' => 'not available',
     'installedVersion' => 'Installed Version',
     'serverVersion' => 'Server Version',
     'description' => 'Description',

--- a/application/modules/admin/views/admin/index/index.php
+++ b/application/modules/admin/views/admin/index/index.php
@@ -55,6 +55,8 @@ $ilchNews = json_decode($ilchNewsList);
             <?=$this->getTrans('system') ?>
             <?php if ($this->get('foundNewVersions')): ?>
                 <span class="label label-danger"><?=$this->getTrans('notUpToDate') ?></span>
+            <?php elseif ($this->get('curlErrorOccured')): ?>
+                <span class="label label-warning"><?=$this->getTrans('versionQueryFailed') ?></span>
             <?php else: ?>
                 <span class="label label-success"><?=$this->getTrans('upToDate') ?></span>
             <?php endif; ?>
@@ -79,6 +81,8 @@ $ilchNews = json_decode($ilchNewsList);
                         <td>
                             <?php if ($this->get('newVersion')): ?>
                                 <?=$this->get('newVersion') ?>
+                            <?php elseif ($this->get('curlErrorOccured')): ?>
+                                <?=$this->getTrans('versionNA') ?>
                             <?php else: ?>
                                 <?=VERSION ?>
                             <?php endif; ?>


### PR DESCRIPTION
On basic version-querys or list of modules/layouts timeout after 20
seconds.
For downloading updates/modules/layouts a timeout is not set for now.

Set the timeout for connecting to the update-server to 10 seconds. If
the server doesn't respond after 10 seconds then just give up.

These timeouts shoud avoid the case where we reach the max_execution_time of php and therefore would fail with a fatal error.