### PR TITLE
Avoid duplicated smilie-names (Ticket 339)

### DIFF
--- a/application/modules/smilies/controllers/admin/Index.php
+++ b/application/modules/smilies/controllers/admin/Index.php
@@ -100,7 +100,7 @@ class Index extends \Ilch\Controller\Admin
             ]);
 
             $validation = Validation::create($post, [
-                'name' => 'required',
+                'name' => 'required|unique:smilies,name',
                 'url' => 'required|url'
             ]);
 
@@ -156,6 +156,10 @@ class Index extends \Ilch\Controller\Admin
             $this->addMessage('writableMedia', 'danger');
         }
 
+        $values = [
+            'name' => ''
+        ];
+
         if ($this->getRequest()->isPost()) {
             $upload = new \Ilch\Upload();
             $upload->setFile($_FILES['upl']['name']);
@@ -168,8 +172,22 @@ class Index extends \Ilch\Controller\Admin
             }
             $upload->upload();
 
+            $index = 0;
+            do {
+                $values = [
+                    'name' => $upload->getName(),
+                ];
+
+                $values['name'] = $upload->getName().(($index > 0) ? $index : '');
+
+                $validation = Validation::create($values, [
+                    'name' => 'required|unique:smilies,name'
+                ]);
+                $index++;
+            } while(!$validation->isValid());
+
             $model = new SmiliesModel();
-            $model->setName($upload->getName());
+            $model->setName($values['name']);
             $model->setUrl($upload->getUrl());
             $model->setUrlThumb($upload->getUrlThumb());
             $model->setEnding($upload->getEnding());


### PR DESCRIPTION
Use unique-validator to prevent the user from giving a smilie a name, which is already in use.

Further when uploading a new smilie an index is added to its name. The index gets incremented as long as the resulting name would be still a already used one.

http://redmine.ilch2.de/issues/339