### PR TITLE
Adds Redirect class

### DIFF
--- a/application/libraries/Ilch/Controller/Base.php
+++ b/application/libraries/Ilch/Controller/Base.php
@@ -64,15 +64,16 @@ class Base
      *
      * @param array|string $url
      * @param string  $route
-     * @param boolean $rewrite
      */
-    public function redirect($url = [], $route = null, $rewrite = false)
+    public function redirect($url = null, $route = null)
     {
-        if (!is_string($url) || preg_match('~^[a-z]+://.*~', $url) === 0) {
-            $url = $this->getLayout()->getUrl($url, $route, $rewrite);
+        $redirector = new \Ilch\Redirect($this->getRequest());
+
+        if (!is_null($url)) {
+            $redirector->to($url, $route);
         }
-        header("Location: " . $url);
-        exit;
+
+        return $redirector;
     }
 
     /**
@@ -134,7 +135,7 @@ class Base
     {
         return $this->view;
     }
-    
+
     /**
      * Gets the user object.
      *

--- a/application/libraries/Ilch/Layout/Base.php
+++ b/application/libraries/Ilch/Layout/Base.php
@@ -92,7 +92,7 @@ abstract class Base extends \Ilch\Design\Base
         }
 
         foreach ($messages as $key => $message) {
-            $html = '<div class="alert alert-'.$message['type'].' alert-dismissable">
+            $html .= '<div class="alert alert-'.$message['type'].' alert-dismissable">
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             '.$this->escape($message['text']).'</div>';
             unset($_SESSION['messages'][$key]);

--- a/application/libraries/Ilch/Redirect.php
+++ b/application/libraries/Ilch/Redirect.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Ilch;
+
+class Redirect
+{
+    /**
+     * The current request instance
+     *
+     * @var \Ilch\Request
+     */
+    protected $request;
+
+    /**
+     * The translator instance
+     *
+     * @var \Ilch\Translator
+     */
+    protected $translator;
+
+    /**
+     * Flash messages translation keys
+     *
+     * @var string
+     */
+    protected $messages = array();
+
+    /**
+     * Input for the next request.
+     *
+     * @var array
+     */
+    protected $input = array();
+
+    /**
+     * The errors for the next request.
+     *
+     * @var array
+     */
+    protected $errors = array();
+
+    /**
+     * Constructor
+     *
+     * @param \Ilch\Request $request Request instance
+     */
+    public function __construct($request)
+    {
+        $this->request = $request;
+        $this->translator = \Ilch\Registry::get('translator');
+    }
+
+    /**
+     * Adds a flash message
+     *
+     * @param  string $message Translation key for the flash message
+     * @return self
+     */
+    public function withMessage($message, $type = 'success')
+    {
+        if (!is_string($message)) {
+            throw new \Exception("Wrong parameter type: expected string, got ".gettype($message));
+        }
+
+        array_push($this->messages, ['text' => $message, 'type' => $type]);
+
+        return $this;
+    }
+
+    /**
+     * Sets the input for the next request.
+     *
+     * @param array|null $input Input data
+     * @return self
+     */
+    public function withInput($input = null)
+    {
+        if (is_null($input)) {
+            $input = $this->request->getPost();
+        }
+
+        $this->input = array_merge($this->input, $input);
+
+        return $this;
+    }
+
+    /**
+     * Sets the errors for the next request.
+     *
+     * @param \Ilch\Validation\ErrorBag $errorBag The errorBag instance
+     *
+     * @return self
+     */
+    public function withErrors(\Ilch\Validation\ErrorBag $errorBag)
+    {
+        $this->errors = array_merge($this->errors, $errorBag->getErrors());
+
+        return $this;
+    }
+
+    /**
+     * Redirects the user to $destination.
+     *
+     * @param mixed $destination
+     * @param bool  $route
+     * @param int   $status
+     * @param array $headers
+     */
+    public function to($destination, $route = null, $status = 302, $headers = [])
+    {
+        if (!is_string($destination) || preg_match('~^[a-z]+://.*~', $destination) === 0) {
+            $destination = $this->getUrl($destination, $route);
+        }
+
+        $this->perform($destination, $status, $headers);
+    }
+
+    /**
+     * Redirects to the desired location.
+     *
+     * @param string    $default Default location
+     * @param int       $status  HTTP Status Code
+     * @param array     $headers An array with headers
+     * @param bool|null $secure  Whether or not it is a secure request
+     */
+    protected function perform($destination = '/', $status = 302, $headers = [])
+    {
+        if (!empty($this->errors)) {
+            array_dot_set($_SESSION, 'ilch_validation_errors', $this->errors);
+        }
+
+        if (!empty($this->input)) {
+            array_dot_set($_SESSION, 'ilch_old_input', $this->input);
+        }
+
+        if (!empty($this->messages)) {
+            $messages = array();
+
+            foreach ($this->messages as $message) {
+                $messages[] = [
+                    'text' => $this->translator->trans($message['text']),
+                    'type' => $message['type'],
+                ];
+            }
+
+            if (is_array(array_dot($_SESSION, 'messages'))) {
+                array_dot_set($_SESSION, 'messages', array_merge(array_dot($_SESSION, 'messages'), $messages));
+            } else {
+                array_dot_set($_SESSION, 'messages', $messages);
+            }
+        }
+
+        foreach ($headers as $header) {
+            header($header);
+        }
+
+        header('Location: '.$destination, true, $status);
+        exit;
+    }
+
+    /**
+     * Creates a full url for the given parts.
+     *
+     * @param array|string $url
+     * @param string       $route
+     *
+     * @return string
+     */
+    public function getUrl($url = [], $route = null)
+    {
+        $config = \Ilch\Registry::get('config');
+
+        $modRewrite = false;
+
+        if ($config !== null) {
+            $modRewrite = (bool) $config->get('mod_rewrite');
+        }
+
+        if (empty($url)) {
+            return BASE_URL;
+        }
+
+        if (is_string($url)) {
+            return BASE_URL.'/index.php/'.$url;
+        }
+
+        $urlParts = [];
+
+        if (!isset($url['module'])) {
+            $urlParts[] = $this->request->getModuleName();
+        } else {
+            $urlParts[] = $url['module'];
+            unset($url['module']);
+        }
+
+        if (!isset($url['controller'])) {
+            $urlParts[] = $this->request->getControllerName();
+        } else {
+            $urlParts[] = $url['controller'];
+            unset($url['controller']);
+        }
+
+        if (!isset($url['action'])) {
+            $urlParts[] = $this->request->getActionName();
+        } else {
+            $urlParts[] = $url['action'];
+            unset($url['action']);
+        }
+
+        foreach ($url as $key => $value) {
+            $urlParts[] = $key.'/'.$value;
+        }
+
+        $s = '';
+
+        if (($this->request->isAdmin() && $route === null) || ($route !== null && $route == 'admin')) {
+            $s = 'admin/';
+        }
+
+        if ($modRewrite && empty($s)) {
+            return BASE_URL.'/'.$s.implode('/', $urlParts);
+        } else {
+            return BASE_URL.'/index.php/'.$s.implode('/', $urlParts);
+        }
+    }
+}

--- a/application/libraries/Ilch/Request.php
+++ b/application/libraries/Ilch/Request.php
@@ -39,6 +39,77 @@ class Request
     protected $params;
 
     /**
+     * Form input from the last request.
+     *
+     * @var array
+     */
+    protected $oldInput;
+
+    /**
+     * Validation errors from the last request.
+     *
+     * @var \Ilch\Validation\ErrorBag
+     */
+    protected $validationErrors;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->oldInput = array();
+        $this->validationErrors = new \Ilch\Validation\ErrorBag();
+
+        $this->checkForOldInput();
+        $this->checkForValidationErrors();
+    }
+
+    /**
+     * Checks the session for old input data.
+     */
+    public function checkForOldInput()
+    {
+        if (isset($_SESSION['ilch_old_input'])) {
+            $this->oldInput = $_SESSION['ilch_old_input'];
+            unset($_SESSION['ilch_old_input']);
+        }
+    }
+
+    /**
+     * Checks the session for validation errors.
+     */
+    public function checkForValidationErrors()
+    {
+        if (isset($_SESSION['ilch_validation_errors'])) {
+            $this->validationErrors->setErrors($_SESSION['ilch_validation_errors']);
+            unset($_SESSION['ilch_validation_errors']);
+        }
+    }
+
+    /**
+     * Returns the old input for the given key.
+     *
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function getOldInput($key = null, $default = '')
+    {
+        return array_dot($this->oldInput, $key, $default);
+    }
+
+    /**
+     * Returns the validation errorbag.
+     *
+     * @return \Ilch\Validation\ErrorBag
+     */
+    public function getErrors()
+    {
+        return $this->validationErrors;
+    }
+
+    /**
      * Gets admin request flag.
      *
      * @return string

--- a/application/libraries/Ilch/View.php
+++ b/application/libraries/Ilch/View.php
@@ -88,7 +88,7 @@ class View extends Design\Base
                                 }
         $html .= '</ul></div></div>';
 
-        return $html; 
+        return $html;
     }
 
     /**
@@ -128,5 +128,28 @@ class View extends Design\Base
     public function getCheckAllCheckbox($childs)
     {
         return '<input type="checkbox" class="check_all" data-childs="'.$childs.'" />';
+    }
+
+    /**
+     * Returns the input data from the last request.
+     *
+     * @param string $key     Array key
+     * @param string $default Default value if key not found
+     *
+     * @return mixed
+     */
+    public function old($key = null, $default = '')
+    {
+        return $this->getRequest()->getOldInput($key, $default);
+    }
+
+    /**
+     * Returns the validation errors from the last request.
+     *
+     * @return \Ilch\Validation\ErrorBag
+     */
+    public function validation()
+    {
+        return $this->getRequest()->getErrors();
     }
 }

--- a/application/libraries/Ilch/View.php
+++ b/application/libraries/Ilch/View.php
@@ -138,7 +138,7 @@ class View extends Design\Base
      *
      * @return mixed
      */
-    public function old($key = null, $default = '')
+    public function originalInput($key = null, $default = '')
     {
         return $this->getRequest()->getOldInput($key, $default);
     }

--- a/application/modules/guestbook/controllers/Index.php
+++ b/application/modules/guestbook/controllers/Index.php
@@ -8,7 +8,6 @@ namespace Modules\Guestbook\Controllers;
 
 use Modules\Guestbook\Mappers\Guestbook as GuestbookMapper;
 use Modules\Guestbook\Models\Entry as GuestbookModel;
-use Ilch\Date as IlchDate;
 use Ilch\Validation;
 
 class Index extends \Ilch\Controller\Frontend
@@ -31,103 +30,19 @@ class Index extends \Ilch\Controller\Frontend
     public function newEntryAction()
     {
         $guestbookMapper = new GuestbookMapper();
-        $ilchdate = new IlchDate;
+        $ilchdate = new \Ilch\Date;
 
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('guestbook'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('entry'), ['action' => 'newentry']);
 
-        $post = [
-            'name'      => '',
-            'email'     => '',
-            'homepage'  => '',
-            'text'      => ''
-        ];
-
         if ($this->getRequest()->getPost('saveGuestbook') and ($this->getRequest()->getPost('bot') === '')) {
-            $post = [
-                'name'      => $this->getRequest()->getPost('name'),
-                'email'     => trim($this->getRequest()->getPost('email')),
-                'homepage'  => trim($this->getRequest()->getPost('homepage')),
-                'text'      => trim($this->getRequest()->getPost('text')),
-                'captcha'   => trim($this->getRequest()->getPost('captcha'))
-            ];
 
-            /*
-                Selbstverständlich können auch eigene Validatoren hinzugefügt werden. Hier
-                gibt es zwei Möglichkeiten:
-
-                Möglichkeit 1: Eine Closure oder auch anonyme Funktion
-                    Zu beachten ist hier, dass der Name des Validators nicht bereits
-                    vorhanden sein darf, 'same' würde eine Exception werfen!
-
-                    Ansonsten wird immer der Parameter $data übergeben, in dem am Ende alle
-                    Informationen stecken, die der Validator braucht.
-
-                    $data->getValue()  -> Der Wert, der durch den Benutzer im Formular eingetragen wurde
-                    $data->getInput()  -> Alle Daten, die durch den Benutzer eingetragen wurden
-                    $data->getParam()  -> Hier koennen die an den Validator übergebenen Parameter gefunden werden
-                    $data->getParams() -> Gibt einfach das komplette Array an Parametern zurück
-
-                    Zurückgeben muss diese Closure nun immer ein Array mit mindestens dem Ergebnis der Validation ('result')
-                    und dem Übersetzungsschlüssel für die Fehlermeldung ('error_key'). Alternativ können noch
-                    weitere Parameter für die Fehlermeldung übergeben werden ('error_params'). Soll ein Parameter
-                    Übersetzt werden, muss er als Array übergeben werden, wo zunächst der der Übersetzungsschlüssel und dann
-                    ein true hineingehört ['key', true].
-                    Siehe Beispiel, hier soll der Name des anderen Feldes ebenfalls übersetzt werden.
-
-                Möglichkeit 2: Eine eigene Validatorklasse, die von \Ilch\Validation\Validators\Base erben sollte
-                    Validation::addValidator('same2', '\my\namespace\Validators\Same');
-                    Als Vergleich können die bestehenden Validators genommen werden.
-            */
-            Validation::addValidator('same2', function ($data) {
-                $validation = $data->getValue() == array_dot($data->getInput(), $data->getParam('as'));
-                return [
-                    'result' => $validation,
-                    'error_key' => 'validation.errors.differentValues',
-                    'error_params' => [[$data->getParam('as'), true]]
-                ];
-            });
-
-            /*
-                Standardmäßig werden alle Feldnamen automatisch übersetzt.
-                D.h. wenn ein Input-Feld mit name="email" existiert,
-                dann wird bei der Generierung der Fehlermeldungen eine
-                Übersetzung mit dem Schlüssel 'email' gesucht.
-
-                In den meisten Fällen sollte das kein Problem sein. Falls doch,
-                können mit Validation::setCustomFieldAliases() aliase festgelegt werden,
-                nach denen stattdessen gesucht werden soll.
-
-                Als Beispiel dient in diesem Fall das Feld 'homepage'. Das Feld hat den Namen
-                'homepage', bei der Übersetzung wurde jedoch der Schlüssel 'page' gewählt.
-            */
             Validation::setCustomFieldAliases([
                 'homepage' => 'page',
             ]);
 
-            /*
-                Validation rules werden als ein Array übergeben und sind immer im Format wie
-                unten zu sehen.
-
-                Bei multidimensionalen Arrays wird ebenfalls die Punktnotation unterstützt,
-                d.h. um an $post['foo']['bar'] zu kommen, muss einfach nur 'foo.bar' als
-                Schlüssel gesetzt werden.
-
-                Die einzelnen Validatoren werden mit | getrennt. Weitere Parameter werden mit einem
-                Komma getrennt, während Schlüssel und Wert mit einem Doppelpunkt getrennt werden, Beispiel:
-                    'name'      => 'required|length,max:16,min:3',
-
-                Um für eine Validation rule eine eigene Fehlermeldung anzugeben, die alle vom Validator
-                selbst generierten Fehlermeldungen überschreibt, kann jeder Validation rule ein
-                customErrorAlias:translation.key als Parameter mitgegeben werden. Siehe Beispiel:
-                    'email'     => 'required,customErrorAlias:unsupportedEmailAddress|email
-
-                Bei Validatoren, die unterschiedliche Fehlermeldungen generieren können, können stattdessen
-                auch die einzelnen, spezifischen Fehlermeldungen überschrieben werden. Dies ist dann
-                allerdings immer vom genutzten Validator abhängig.
-            */
-            $validation = Validation::create($post, [
+            $validation = Validation::create($this->getRequest()->getPost(), [
                 'name'      => 'required',
                 'email'     => 'required|email',
                 'homepage'  => 'url',
@@ -135,54 +50,30 @@ class Index extends \Ilch\Controller\Frontend
                 'captcha'   => 'captcha'
             ]);
 
-            /*
-                Um herauszufinden, ob eine Validation nun erfolgreich war oder ob
-                Fehler gefunden wurden, ist die Methode isValid nötig.
-            */
             if ($validation->isValid()) {
                 $model = new GuestbookModel();
-                $model->setName($post['name']);
-                $model->setEmail($post['email']);
-                $model->setText($post['text']);
-                $model->setHomepage($post['homepage']);
-                $model->setDatetime($ilchdate->toDb());
-                $model->setFree($this->getConfig()->get('gbook_autosetfree'));
+                $model->setName($this->getRequest()->getPost('name'))
+                    ->setEmail($this->getRequest()->getPost('email'))
+                    ->setText($this->getRequest()->getPost('text'))
+                    ->setHomepage($this->getRequest()->getPost('homepage'))
+                    ->setDatetime($ilchdate->toDb())
+                    ->setFree($this->getConfig()->get('gbook_autosetfree'));
+
                 $guestbookMapper->save($model);
 
-                unset($_SESSION['captcha']);
-                
                 if ($this->getConfig()->get('gbook_autosetfree') == 0) {
-                    $this->addMessage('check', 'success');
+                    $this->addMessage('check', 'info');
                 }
-                $this->redirect(['action' => 'index']);
+
+                $this->redirect()
+                    ->withMessage('saveSuccess')
+                    ->to(['action' => 'index']);
             }
 
-            unset($_SESSION['captcha']);
-            /*
-                Nun werden noch die Fehler generiert und an das View übergeben.
-                $validation->getErrors() benötigt immer die aktuelle Translator-Instanz, damit
-                die Fehlermeldungen übersetzt werden können.
-
-                Zurückgegeben wird einfach nur ein Array mit Fehler-Strings
-                Ansonsten siehe newEntry.php
-            */
-            // $this->getView()->set('errors', $validation->getErrors());
-            $this->getView()->set('errors', $validation->getErrorBag()->getErrorMessages());
-
-            /*
-                $validation->getFieldsWithError() gibt ein Array mit allen Feldern, die Fehler beinhalten, zurück.
-            */
-            $errorFields = $validation->getFieldsWithError();
+            $this->redirect()
+                ->withInput()
+                ->withErrors($validation->getErrorBag())
+                ->to(['action' => 'newEntry']);
         }
-
-        $this->getView()->set('post', $post);
-
-        /*
-            Um die Felder mit Fehlern dementsprechen Kennzeichnen zu können, wird noch ein Array
-            mit allen Feldernamen, die Fehler beinhalten, ans View übergeben.
-
-            Falls $errorFields nicht existiert wird einfach ein leeres Array übergeben, um eine Fehlermeldung zu vermeiden.
-        */
-        $this->getView()->set('errorFields', (isset($errorFields) ? $errorFields : []));
     }
 }

--- a/application/modules/guestbook/models/Entry.php
+++ b/application/modules/guestbook/models/Entry.php
@@ -135,6 +135,8 @@ class Entry extends \Ilch\Model
     public function setId($id)
     {
         $this->id = (int)$id;
+
+        return $this;
     }
 
     /**
@@ -145,6 +147,8 @@ class Entry extends \Ilch\Model
     public function setEmail($email)
     {
         $this->email = (string)$email;
+
+        return $this;
     }
 
     /**
@@ -155,6 +159,8 @@ class Entry extends \Ilch\Model
     public function setText($text)
     {
         $this->text = (string)$text;
+
+        return $this;
     }
 
     /**
@@ -165,6 +171,8 @@ class Entry extends \Ilch\Model
     public function setName($name)
     {
         $this->name = (string)$name;
+
+        return $this;
     }
 
     /**
@@ -175,6 +183,8 @@ class Entry extends \Ilch\Model
     public function setHomepage($homepage)
     {
         $this->homepage = (string)$homepage;
+
+        return $this;
     }
 
     /**
@@ -185,6 +195,8 @@ class Entry extends \Ilch\Model
     public function setDatetime($datetime)
     {
         $this->datetime = (string)$datetime;
+
+        return $this;
     }
 
     /**
@@ -195,5 +207,7 @@ class Entry extends \Ilch\Model
     public function setFree($free)
     {
         $this->setFree = (integer)$free;
+
+        return $this;
     }
 }

--- a/application/modules/guestbook/views/index/newentry.php
+++ b/application/modules/guestbook/views/index/newentry.php
@@ -35,7 +35,7 @@
                    class="form-control"
                    name="name"
                    placeholder="Name"
-                   value="<?= $this->old('name') ?>" />
+                   value="<?= $this->originalInput('name') ?>" />
         </div>
     </div>
     <div class="form-group <?= $this->validation()->hasError('email') ? 'has-error' : '' ?>">
@@ -47,7 +47,7 @@
                    class="form-control"
                    name="email"
                    placeholder="E-Mail"
-                   value="<?= $this->old('email') ?>" />
+                   value="<?= $this->originalInput('email') ?>" />
         </div>
     </div>
     <div class="form-group <?= $this->validation()->hasError('homepage') ? 'has-error' : '' ?>">
@@ -59,7 +59,7 @@
                   class="form-control"
                   name="homepage"
                   placeholder="<?=$this->getTrans('page') ?>"
-                  value="<?= $this->old('homepage') ?>" />
+                  value="<?= $this->originalInput('homepage') ?>" />
         </div>
     </div>
     <div class="form-group <?= $this->validation()->hasError('text') ? 'has-error' : '' ?>">
@@ -71,7 +71,7 @@
                       id="ck_1"
                       name="text"
                       toolbar="ilch_bbcode"
-                      required><?= $this->old('text') ?></textarea>
+                      required><?= $this->originalInput('text') ?></textarea>
         </div>
     </div>
     <div class="form-group <?= $this->validation()->hasError('captcha') ? 'has-error' : '' ?>">

--- a/application/modules/guestbook/views/index/newentry.php
+++ b/application/modules/guestbook/views/index/newentry.php
@@ -1,11 +1,11 @@
 <legend><?=$this->getTrans('menuGuestbook') ?></legend>
 
 <!-- Fehlerausgabe der Validation -->
-<?php if (!empty($this->get('errors'))): ?>
+<?php if ($this->validation()->hasErrors()): ?>
     <div class="alert alert-danger" role="alert">
         <strong> <?=$this->getTrans('errorsOccured') ?>:</strong>
         <ul>
-            <?php foreach ($this->get('errors') as $error): ?>
+            <?php foreach ($this->validation()->getErrorMessages() as $error): ?>
                 <li><?= $error; ?></li>
             <?php endforeach; ?>
         </ul>
@@ -26,7 +26,7 @@
                    placeholder="Bot" />
         </div>
     </div>
-    <div class="form-group <?=in_array('name', $this->get('errorFields')) ? 'has-error' : '' ?>">
+    <div class="form-group <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
         <label class="col-lg-2 control-label">
             <?=$this->getTrans('name') ?>*
         </label>
@@ -35,10 +35,10 @@
                    class="form-control"
                    name="name"
                    placeholder="Name"
-                   value="<?=$this->get('post')['name'] ?>" />
+                   value="<?= $this->old('name') ?>" />
         </div>
     </div>
-    <div class="form-group <?=in_array('email', $this->get('errorFields')) ? 'has-error' : '' ?>">
+    <div class="form-group <?= $this->validation()->hasError('email') ? 'has-error' : '' ?>">
         <label class="col-lg-2 control-label">
             <?=$this->getTrans('email') ?>*
         </label>
@@ -47,10 +47,10 @@
                    class="form-control"
                    name="email"
                    placeholder="E-Mail"
-                   value="<?=$this->get('post')['email'] ?>" />
+                   value="<?= $this->old('email') ?>" />
         </div>
     </div>
-    <div class="form-group <?=in_array('homepage', $this->get('errorFields')) ? 'has-error' : '' ?>">
+    <div class="form-group <?= $this->validation()->hasError('homepage') ? 'has-error' : '' ?>">
         <label class="col-lg-2 control-label">
             <?=$this->getTrans('page') ?>
         </label>
@@ -59,10 +59,10 @@
                   class="form-control"
                   name="homepage"
                   placeholder="<?=$this->getTrans('page') ?>"
-                  value="<?=$this->get('post')['homepage'] ?>" />
+                  value="<?= $this->old('homepage') ?>" />
         </div>
     </div>
-    <div class="form-group <?=in_array('text', $this->get('errorFields')) ? 'has-error' : '' ?>">
+    <div class="form-group <?= $this->validation()->hasError('text') ? 'has-error' : '' ?>">
         <label class="col-lg-2 control-label">
             <?=$this->getTrans('message') ?>*
         </label>
@@ -71,18 +71,10 @@
                       id="ck_1"
                       name="text"
                       toolbar="ilch_bbcode"
-                      required>
-                <?=$this->get('post')['text'] ?>
-            </textarea>
+                      required><?= $this->old('text') ?></textarea>
         </div>
     </div>
-    <?php
-    $message = $this->get('message');
-    if (!empty($message)) {
-        echo $message;
-    }
-    ?>
-    <div class="form-group <?=in_array('captcha', $this->get('errorFields')) ? 'has-error' : '' ?>">
+    <div class="form-group <?= $this->validation()->hasError('captcha') ? 'has-error' : '' ?>">
         <label class="col-lg-2 control-label">
             <?=$this->getTrans('captcha') ?>
         </label>
@@ -90,7 +82,7 @@
             <?=$this->getCaptchaField() ?>
         </div>
     </div>
-    <div class="form-group <?=in_array('captcha', $this->get('errorFields')) ? 'has-error' : '' ?>">
+    <div class="form-group <?= $this->validation()->hasError('captcha') ? 'has-error' : '' ?>">
         <div class="col-lg-offset-2 col-lg-8 input-group captcha">
             <input type="text"
                   id="captcha-form"


### PR DESCRIPTION
`$this->redirect([...])` sollte weiterhin so funktionieren, wie vorher (Stichprobenartig ausprobiert).

`$this->redirect()` gibt nun eine Instanz von \Ilch\Redirect zurück.
```php
$this->redirect()
    ->withMessage($translationKey, 'success')
    ->withInput($dataArray = $_POST) // Leer für $_POST
    ->withErrors(\Ilch\Validation\ErrorBag $errorBag) // \Ilch\Validation::getErrorBag()
    ->to(['controller' => 'x', 'action' => 'y']);
```

Im View dann durch die hinzugefügten helper methods
```php
// Zugriff auf die ErrorBag-Instanz
$this->validation();

// Prüfen, ob Fehler der Validation existieren
$this->validation()->hasErrors();

// Array mit Fehlermeldungen
$this->validation()->getErrorMessages();

// Auf Fehler bei einem einzelnen Formularfeld prüèen
$this->validation()->hasError('field');

// Auf die $_POST bzw. withInput()-Daten zugreifen
$this->old('field');
```

Durch die Änderung kann man nun auch überall ohne Aufwand eine erneute Formularabsendung verhindern, da man den Benutzer nun nach jeder Formularabsendung weiterleitet.

Sonst wie immer, das Gästebuch ist bereits darauf umgeschrieben. Hab es wieder stichprobenartig überprüft, die alte Variante funktioniert selbstverständlich weiterhin.