### PR TITLE
Add deleting of subscribers

### DIFF
--- a/application/modules/newsletter/controllers/admin/Receiver.php
+++ b/application/modules/newsletter/controllers/admin/Receiver.php
@@ -46,6 +46,14 @@ class Receiver extends \Ilch\Controller\Admin
         if ($this->getRequest()->isPost()) {
             $newsletterModel = new NewsletterModel();
 
+            if ($this->getRequest()->getPost('check_entries')) {
+                if ($this->getRequest()->getPost('action') == 'delete') {
+                    foreach ($this->getRequest()->getPost('check_entries') as $email) {
+                        $newsletterMapper->deleteEmail($email);
+                    }
+                }
+            }
+
             foreach ($this->getRequest()->getPost('check_users') as $userEmail) {
                 if ($userEmail != '') {
                     $newsletterModel->setEmail($userEmail);
@@ -57,5 +65,18 @@ class Receiver extends \Ilch\Controller\Admin
 
         $this->getView()->set('emails', $newsletterMapper->getMail());
         $this->getView()->set('userList', $newsletterMapper->getSendMailUser());
-    }   
+    }
+
+    public function deleteAction()
+    {
+        if ($this->getRequest()->isSecure()) {
+            $newsletterMapper = new NewsletterMapper();
+
+            $newsletterMapper->deleteSubscriberBySelector($this->getRequest()->getParam('selector'));
+
+            $this->addMessage('deleteSuccess');
+        }
+
+        $this->redirect(['action' => 'index']);
+    }
 }

--- a/application/modules/newsletter/mappers/Newsletter.php
+++ b/application/modules/newsletter/mappers/Newsletter.php
@@ -205,6 +205,18 @@ class Newsletter extends \Ilch\Mapper
     }
 
     /**
+     * Deletes newsletter email with given selector.
+     *
+     * @param string $selector
+     */
+    public function deleteSubscriberBySelector($selector)
+    {
+        $this->db()->delete('newsletter_mails')
+                ->where(['selector' => $selector])
+                ->execute();
+    }
+
+    /**
      * Deletes newsletter with given id.
      *
      * @param integer $id
@@ -225,7 +237,7 @@ class Newsletter extends \Ilch\Mapper
     public function getSendMailUser()
     {
         return $this->db()->select()
-                ->fields(['nm.email'])
+                ->fields(['nm.email', 'nm.selector'])
                 ->from(['nm' => 'newsletter_mails'])
                 ->join(['u' => 'users'], 'u.email = nm.email', 'LEFT', ['name' => 'u.name'])
                 ->execute()

--- a/application/modules/newsletter/views/admin/receiver/index.php
+++ b/application/modules/newsletter/views/admin/receiver/index.php
@@ -1,29 +1,40 @@
 <legend><?=$this->getTrans('receiver') ?></legend>
-<div class="table-responsive">
-    <table class="table table-hover table-striped">
-        <colgroup>
-            <col class="col-lg-2">
-            <col>
-        </colgroup>
-        <thead>
-            <tr>
-                <th><?=$this->getTrans('userName') ?></th>
-                <th><?=$this->getTrans('userEmail') ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php if ($this->get('emails') != ''): ?>
-                <?php foreach ($this->get('userList') as $user): ?>
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <?php if ($this->get('emails') != ''): ?>
+        <div class="table-responsive">
+            <table class="table table-hover table-striped">
+                <colgroup>
+                    <col class="icon_width">
+                    <col class="icon_width">
+                    <col class="col-lg-2">
+                    <col>
+                </colgroup>
+                <thead>
                     <tr>
-                        <td><?=$this->escape($user['name']) ?></td>
-                        <td><?=($user['email'] === '') ? 'NotRegistUser' : $this->escape($user['email']) ?></td>
+                        <th><?=$this->getCheckAllCheckbox('check_entries') ?></th>
+                        <th></th>
+                        <th><?=$this->getTrans('userName') ?></th>
+                        <th><?=$this->getTrans('userEmail') ?></th>
                     </tr>
-                <?php endforeach; ?>
-            <?php else: ?>
-                <tr>
-                    <td colspan="2"><?=$this->getTrans('noEmails') ?></td>
-                </tr>
-            <?php endif; ?>
-        </tbody>
-    </table>
-</div>
+                </thead>
+                <tbody>
+                    <?php foreach ($this->get('userList') as $user): ?>
+                        <tr>
+                            <td><input type="checkbox" name="check_entries[]" value="<?=$user['email'] ?>" /></td>
+                            <td>
+                                <?php $deleteArray = ['action' => 'delete', 'selector' => $user['selector']] ?>
+                                <?=$this->getDeleteIcon($deleteArray) ?>
+                            </td>
+                            <td><?=$this->escape($user['name']) ?></td>
+                            <td><?=($user['email'] === '') ? 'NotRegistUser' : $this->escape($user['email']) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?=$this->getListBar(['delete' => 'delete']) ?>
+    <?php else: ?>
+        <?=$this->getTrans('noEmails') ?>
+    <?php endif; ?>
+</form>


### PR DESCRIPTION
Subscribers/Receivers can now be deleted in the admincenter.

Added deleteSubscriberBySelector() to avoid adding an email address as
parameter to the deleteAction-url. Instead of an email-address the
selector is now added as parameter.

Email addresses or other potential sensible data should not be added as
parameters in urls to avoid them being leaked in browser histories or to
proxies.

http://redmine.ilch2.de/issues/375