### PR TITLE
Allow menu item root nesting class

### DIFF
--- a/application/libraries/Ilch/Layout/Helper/GetMenu.php
+++ b/application/libraries/Ilch/Layout/Helper/GetMenu.php
@@ -17,6 +17,8 @@ class GetMenu
             'ul-class-root' => 'list-unstyled ilch_menu_ul',
             'ul-class-child' => 'list-unstyled ilch_menu_ul',
             'li-class-root' => '',
+            'li-class-root-active' => '',
+            'li-class-root-nesting' => '',
             'li-class-child' => '',
             'allow-nesting' => true,
         ],

--- a/application/libraries/Ilch/Page.php
+++ b/application/libraries/Ilch/Page.php
@@ -268,4 +268,12 @@ class Page
     {
         return $this->request;
     }
+
+    /**
+     * @return \Ilch\Router
+     */
+    public function getRouter()
+    {
+        return $this->router;
+    }
 }

--- a/application/libraries/Ilch/Router.php
+++ b/application/libraries/Ilch/Router.php
@@ -27,6 +27,11 @@ class Router
     private $request;
 
     /**
+     * @var string
+     */
+    private $origin;
+
+    /**
      * Injects request.
      *
      * @param \Ilch\Request $request
@@ -122,6 +127,26 @@ class Router
     public function getQuery()
     {
         return $this->query;
+    }
+
+    /**
+     * Gets the origin path from which the user comes.
+     *
+     * @return string
+     */
+    public function getOrigin()
+    {
+        return $this->origin;
+    }
+
+    /**
+     * Fills the origin with the full url path from which the user comes.
+     */
+    protected function fillOrigin()
+    {
+        $this->origin = $_SERVER['REQUEST_SCHEME'].'://'
+                      . $_SERVER['HTTP_HOST']
+                      . $_SERVER['REQUEST_URI'];
     }
 
     /**
@@ -371,6 +396,7 @@ class Router
         $this->request->setControllerName('index');
         $this->request->setActionName('index');
 
+        $this->fillOrigin();
         $this->fillQuery();
         $query = $this->getQuery();
 


### PR DESCRIPTION
Implement new menu option menus.li-class-root-nesting, that only added
if a parent item has a nesting menu when nesting is true.