### PR TITLE
Feature/checkout basic module

### DIFF
--- a/application/modules/checkout/controllers/admin/Index.php
+++ b/application/modules/checkout/controllers/admin/Index.php
@@ -124,8 +124,8 @@ class Index extends \Ilch\Controller\Admin
             ]);
 
             if ($validation->isValid()) {
-                $this->getConfig()->set('checkout_contact', $post['checkoutContact']);
-                $this->getConfig()->set('checkout_currency', $post['checkoutCurrency']);
+                $this->getConfig()->set('checkout_contact', $this->getRequest()->getPost('checkoutContact'));
+                $this->getConfig()->set('checkout_currency', $this->getRequest()->getPost('checkoutCurrency'));
                 $this->addMessage('saveSuccess');
             }
 

--- a/application/modules/checkoutBasic/config/config.php
+++ b/application/modules/checkoutBasic/config/config.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\CheckoutBasic\Config;
+
+class Config extends \Ilch\Config\Install
+{
+    public $config = [
+        'key' => 'checkoutBasic',
+        'version' => '1.0',
+        'icon_small' => 'fa-credit-card',
+        'author' => 'Stantin, Thomas',
+        'link' => 'http://ilch.de',
+        'languages' => [
+            'de_DE' => [
+                'name' => 'Kasse',
+                'description' => 'Hier kann die Clan-Kasse gepflegt werden.',
+            ],
+            'en_EN' => [
+                'name' => 'Checkout',
+                'description' => 'Here you can manage your clan cash.',
+            ],
+        ],
+        'ilchCore' => '2.0.0',
+        'phpVersion' => '5.6'
+    ];
+
+    public function install()
+    {
+        $this->db()->queryMulti($this->getInstallSql());
+
+        $databaseConfig = new \Ilch\Config\Database($this->db());
+        $databaseConfig->set('checkoutBasic_contact', '<p>Kontoinhaber: Max Mustermann</p><p>Bankname: Muster Sparkasse</p><p>Kontonummer: 123</p><p>Bankleitzahl: 123</p><p>BIC: 123</p><p>IBAN: 123</p><p>Verwendungszweck: Spende f&uuml;r ilch.de ;-)</p>');
+        $databaseConfig->set('checkoutBasic_currency', '1');
+    }
+
+    public function uninstall()
+    {
+        $this->db()->queryMulti('DROP TABLE `[prefix]_checkoutBasic`');
+        $this->db()->queryMulti('DROP TABLE `[prefix]_checkoutBasic_currencies`');
+        $this->db()->queryMulti("DELETE FROM `[prefix]_config` WHERE `key` = 'checkoutBasic_contact'");
+        $this->db()->queryMulti("DELETE FROM `[prefix]_config` WHERE `key` = 'checkoutBasic_currency'");
+    }
+
+    public function getInstallSql()
+    {
+        return 'CREATE TABLE IF NOT EXISTS `[prefix]_checkoutBasic` (
+                  `id` INT(14) NOT NULL AUTO_INCREMENT,
+                  `date_created` DATETIME NOT NULL,
+                  `name` VARCHAR(255) NOT NULL,
+                  `usage` VARCHAR(255) NOT NULL,
+                  `amount` FLOAT NOT NULL DEFAULT 0,
+                  PRIMARY KEY (`id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
+
+                CREATE TABLE IF NOT EXISTS `[prefix]_checkoutBasic_currencies` (
+                  `id` INT(14) NOT NULL AUTO_INCREMENT,
+                  `name` VARCHAR(255) NOT NULL,
+                  PRIMARY KEY (`id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
+
+                INSERT INTO `[prefix]_checkoutBasic_currencies` (`id`, `name`) VALUES (1, "EUR (€)");
+                INSERT INTO `[prefix]_checkoutBasic_currencies` (`id`, `name`) VALUES (2, "USD ($)");
+                INSERT INTO `[prefix]_checkoutBasic_currencies` (`id`, `name`) VALUES (3, "GBP (£)");
+                INSERT INTO `[prefix]_checkoutBasic_currencies` (`id`, `name`) VALUES (4, "AUD ($)");
+                INSERT INTO `[prefix]_checkoutBasic_currencies` (`id`, `name`) VALUES (5, "NZD ($)");
+                INSERT INTO `[prefix]_checkoutBasic_currencies` (`id`, `name`) VALUES (6, "CHF");';
+    }
+
+    public function getUpdate()
+    {
+
+    }
+}

--- a/application/modules/checkoutBasic/controllers/Index.php
+++ b/application/modules/checkoutBasic/controllers/Index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\CheckoutBasic\Controllers;
+
+use Modules\CheckoutBasic\Mappers\Checkout as CheckoutMapper;
+use Modules\CheckoutBasic\Mappers\Currency as CurrencyMapper;
+use Ilch\Date as IlchDate;
+
+class Index extends \Ilch\Controller\Frontend
+{
+    public function indexAction()
+    {
+        $checkoutMapper = new CheckoutMapper();
+        $currencyMapper = new CurrencyMapper();
+
+        $checkout = $checkoutMapper->getEntries();
+        $amount = $checkoutMapper->getAmount();
+        $amountplus = $checkoutMapper->getAmountPlus();
+        $amountminus = $checkoutMapper->getAmountMinus();
+        $currency = $currencyMapper->getCurrencyById($this->getConfig()->get('checkoutBasic_currency'))[0];
+
+        $this->getLayout()->getHmenu()->add($this->getTranslator()->trans('checkout'), ['action' => 'index']);
+        $this->getView()->set('checkout', $checkout);
+        $this->getView()->set('amount', $amount);
+        $this->getView()->set('amountplus', $amountplus);
+        $this->getView()->set('amountminus', $amountminus);
+        $this->getView()->set('checkout_contact', $this->getConfig()->get('checkoutBasic_contact'));
+        $this->getView()->set('currency', $currency->getName());
+    }
+}

--- a/application/modules/checkoutBasic/controllers/admin/Currency.php
+++ b/application/modules/checkoutBasic/controllers/admin/Currency.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\CheckoutBasic\Controllers\Admin;
+
+use Modules\CheckoutBasic\Mappers\Currency as CurrencyMapper;
+use Modules\CheckoutBasic\Models\Currency as CurrencyModel;
+use Ilch\Validation;
+
+class Currency extends \Ilch\Controller\Admin
+{
+    public function init()
+    {
+        $items = [
+            [
+                'name' => 'manage',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+            ],
+            [
+                'name' => 'currencies',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'currency', 'action' => 'index']),
+                [
+                    'name' => 'add',
+                    'active' => false,
+                    'icon' => 'fa fa-plus-circle',
+                    'url' => $this->getLayout()->getUrl(['controller' => 'currency', 'action' => 'treat'])
+                ]
+            ],
+            [
+                'name' => 'settings',
+                'active' => false,
+                'icon' => 'fa fa-cogs',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'settings'])
+            ]
+        ];
+
+        if ($this->getRequest()->getActionName() == 'treat') {
+            $items[1][0]['active'] = true;
+        } else {
+            $items[1]['active'] = true;
+        }
+
+        $this->getLayout()->addMenu
+        (
+            'checkout',
+            $items
+        );
+    }
+
+    public function indexAction()
+    {
+        $currencyMapper = new CurrencyMapper();
+
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('checkout'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('currencies'), ['action' => 'index']);
+
+        if ($this->getRequest()->isPost() && $this->getRequest()->isSecure()) {
+            if ($this->getRequest()->getPost('action') == 'delete' && $this->getRequest()->getPost('check_currencies')) {
+                foreach ($this->getRequest()->getPost('check_currencies') as $id) {
+                    if ($currencyMapper->getCurrencyById($id)[0]->getId() == $this->getConfig()->get('checkoutBasic_currency')) {
+                        $this->addMessage('currencyInUse', 'danger');
+                        continue;
+                    }
+                    $currencyMapper->deleteCurrencyById($id);
+                }
+            }
+        }
+
+        $this->getView()->set('currencies', $currencyMapper->getCurrencies());
+    }
+
+    public function treatAction()
+    {
+        $currencyMapper = new CurrencyMapper();
+        $id = $this->getRequest()->getParam('id');
+
+        if ($this->getRequest()->getParam('id')) {
+            $this->getLayout()->getAdminHmenu()
+                    ->add($this->getTranslator()->trans('checkout'), ['action' => 'index'])
+                    ->add($this->getTranslator()->trans('currencies'), ['action' => 'index'])
+                    ->add($this->getTranslator()->trans('edit'), ['action' => 'treat', 'id' => 'treat']);
+        } else {
+            $this->getLayout()->getAdminHmenu()
+                    ->add($this->getTranslator()->trans('checkout'), ['action' => 'index'])
+                    ->add($this->getTranslator()->trans('currencies'), ['action' => 'index'])
+                    ->add($this->getTranslator()->trans('add'), ['action' => 'treat', 'id' => 'treat']);
+        }
+
+        $post = [
+            'id' => '',
+            'name' => ''
+        ];
+
+        if ($this->getRequest()->isPost() && $this->getRequest()->isSecure()) {
+            $post = [
+                'id' => $this->getRequest()->getPost('id'),
+                'name' => trim($this->getRequest()->getPost('name'))
+            ];
+
+            $idValidators = 'required|numeric|integer|min:1';
+            
+            if (!$this->getRequest()->getParam('id')) {
+                $idValidators = 'numeric|integer|min:1';
+            }
+
+            $validation = Validation::create($post, [
+                'id' => $idValidators,
+                'name' => 'required'
+            ]);
+
+            if ($validation->isValid()) {
+                if ($currencyMapper->currencyWithNameExists($post['name'])) {
+                    $this->addMessage('alreadyExisting', 'danger');
+                } else {
+                    $currencyModel = new CurrencyModel();
+
+                    $currencyModel->setId($post['id']);
+                    $currencyModel->setName($post['name']);
+                    $currencyMapper->save($currencyModel);
+
+                    $this->addMessage('saveSuccess');
+                    $this->redirect(['action' => 'index']);
+                }
+            }
+
+            $this->getView()->set('errors', $validation->getErrorBag()->getErrorMessages());
+            $errorFields = $validation->getFieldsWithError();
+        }
+
+        $currency = $currencyMapper->getCurrencyById($id);
+        if (count($currency) > 0) {
+            $currency = $currency[0];
+        } else {
+            $currency = new CurrencyModel();
+        }
+
+        $this->getView()->set('errorFields', (isset($errorFields) ? $errorFields : []));
+        $this->getView()->set('currency', $currency);
+    }
+
+    public function deleteAction()
+    {
+        if ($this->getRequest() && $this->getRequest()->isSecure()) {
+            $currencyMapper = new CurrencyMapper();
+
+            $id = $this->getRequest()->getParam('id');
+            if ($currencyMapper->getCurrencyById($id)[0]->getId() == $this->getConfig()->get('checkoutBasic_currency')) {
+                $this->addMessage('currencyInUse', 'danger');
+                $this->redirect(['action' => 'index']);
+            }
+
+            $currencyMapper->deleteCurrencyById($id);
+
+            $this->addMessage('deleteSuccess');
+            $this->redirect(['action' => 'index']);
+        }
+    }
+}

--- a/application/modules/checkoutBasic/controllers/admin/Index.php
+++ b/application/modules/checkoutBasic/controllers/admin/Index.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\CheckoutBasic\Controllers\Admin;
+
+use Modules\CheckoutBasic\Mappers\Checkout as CheckoutMapper;
+use Modules\CheckoutBasic\Mappers\Currency as CurrencyMapper;
+use Ilch\Date as IlchDate;
+use Ilch\Validation;
+
+class Index extends \Ilch\Controller\Admin
+{
+    public function init()
+    {
+        $items = [
+            [
+                'name' => 'manage',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+            ],
+            [
+                'name' => 'currencies',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'currency', 'action' => 'index'])
+            ],
+            [
+                'name' => 'settings',
+                'active' => false,
+                'icon' => 'fa fa-cogs',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'settings'])
+            ]
+        ];
+
+        if ($this->getRequest()->getActionName() == 'settings') {
+            $items[2]['active'] = true;
+        } else {
+            $items[0]['active'] = true;
+        }
+
+        $this->getLayout()->addMenu
+        (
+            'checkout',
+            $items
+        );
+    }
+
+    public function indexAction()
+    {
+        $ilchdate = new IlchDate;
+        $checkoutMapper = new CheckoutMapper();
+        $currencyMapper = new CurrencyMapper();
+
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('checkout'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('manage'), ['action' => 'index']);
+
+        $post = [
+            'name' => '',
+            'datetime' => '',
+            'usage' => '',
+            'amount' => ''
+        ];
+
+        if ($this->getRequest()->isPost()) {
+            $post = [
+                'name' => $this->getRequest()->getPost('name'),
+                'datetime' => trim($this->getRequest()->getPost('datetime')),
+                'usage' => trim($this->getRequest()->getPost('usage')),
+                'amount' => trim($this->getRequest()->getPost('amount'))
+            ];
+
+            $validation = Validation::create($post, [
+                'name' => 'required',
+                'datetime' => 'required',
+                'usage' => 'required',
+                'amount' => 'required|numeric'
+            ]);
+
+            if ($validation->isValid()) {
+                $model = new \Modules\CheckoutBasic\Models\Entry();
+                $model->setName($post['name']);
+                $model->setDatetime($post['datetime']);
+                $model->setUsage($post['usage']);
+                $model->setAmount($post['amount']);
+                $checkoutMapper->save($model);
+
+                $this->addMessage('saveSuccess');
+            }
+
+            $this->redirect()
+                ->withInput($post)
+                ->withErrors($validation->getErrorBag())
+                ->to(['action' => 'index']);
+        }
+
+        $currency = $currencyMapper->getCurrencyById($this->getConfig()->get('checkoutBasic_currency'))[0];
+
+        $this->getView()->set('checkout', $checkoutMapper->getEntries());
+        $this->getView()->set('checkoutdate', $ilchdate->toDb());
+        $this->getView()->set('amount', $checkoutMapper->getAmount());
+        $this->getView()->set('amountplus', $checkoutMapper->getAmountPlus());
+        $this->getView()->set('amountminus', $checkoutMapper->getAmountMinus());
+        $this->getView()->set('checkoutCurrency', $this->getConfig()->get('checkoutBasic_currency'));
+        $this->getView()->set('currency', $currency->getName());
+    }
+
+    public function settingsAction()
+    {
+        $currencyMapper = new CurrencyMapper();
+
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('checkout'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('settings'), ['action' => 'settings']);
+
+        if ($this->getRequest()->isPost()) {
+            $validation = Validation::create($this->getRequest()->getPost(), [
+                'checkoutContact' => 'required',
+                'checkoutCurrency' => 'required|numeric|integer|min:1'
+            ]);
+
+            if ($validation->isValid()) {
+                $this->getConfig()->set('checkoutBasic_contact', $this->getRequest()->getPost('checkoutContact'));
+                $this->getConfig()->set('checkoutBasic_currency', $this->getRequest()->getPost('checkoutCurrency'));
+                $this->addMessage('saveSuccess');
+            }
+
+            $this->redirect()
+                ->withInput()
+                ->withErrors($validation->getErrorBag())
+                ->to(['action' => 'settings']);
+        }
+
+        $this->getView()->set('currencies', $currencyMapper->getCurrencies());
+        $this->getView()->set('checkoutContact', $this->getConfig()->get('checkoutBasic_contact'));
+        $this->getView()->set('checkoutCurrency', $this->getConfig()->get('checkoutBasic_currency'));
+    }
+
+    public function treatPaymentAction()
+    {
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('checkout'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('treatpayment'), ['action' => 'treatpayment', 'id' => $this->getRequest()->getParam('id')]);
+
+        $checkoutMapper = new CheckoutMapper();
+        $id = $this->getRequest()->getParam('id');
+
+        $post = [
+            'name' => '',
+            'datetime' => '',
+            'usage' => '',
+            'amount' => '',
+            'id' => ''
+        ];
+
+        if ($this->getRequest()->isPost()) {
+            $post = [
+                'name' => $this->getRequest()->getPost('name'),
+                'datetime' => trim($this->getRequest()->getPost('datetime')),
+                'usage' => trim($this->getRequest()->getPost('usage')),
+                'amount' => trim($this->getRequest()->getPost('amount')),
+                'id' => trim($this->getRequest()->getPost('id'))
+            ];
+
+            $validation = Validation::create($post, [
+                'name' => 'required',
+                'datetime' => 'required',
+                'usage' => 'required',
+                'amount' => 'required|numeric',
+                'id' => 'required|numeric|integer|min:1'
+            ]);
+
+            if ($validation->isValid()) {
+                $model = new \Modules\CheckoutBasic\Models\Entry();
+                $model->setId($post['id']);
+                $model->setName($post['name']);
+                $model->setDatetime($post['datetime']);
+                $model->setUsage($post['usage']);
+                $model->setAmount($post['amount']);
+                $checkoutMapper->save($model);
+
+                $this->addMessage('saveSuccess');
+            }
+
+            $this->redirect()
+                ->withInput($post)
+                ->withErrors($validation->getErrorBag())
+                ->to(['action' => 'treatPayment', 'id' => $id]);
+        }
+
+        $this->getView()->set('checkout', $checkoutMapper->getEntryById($id));
+        $this->getView()->set('checkout_currency', $this->getConfig()->get('checkoutBasic_currency'));
+    }
+
+    public function delAction()
+    {
+        if ($this->getRequest()->isSecure()) {
+            $checkoutMapper = new CheckoutMapper();
+            $id = $this->getRequest()->getParam('id');
+            $checkoutMapper->deleteById($id);
+
+            $this->addMessage('deleteSuccess');
+            $this->redirect(['action' => 'index']);
+        }
+    }
+}

--- a/application/modules/checkoutBasic/mappers/Checkout.php
+++ b/application/modules/checkoutBasic/mappers/Checkout.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\CheckoutBasic\Mappers;
+
+use Modules\CheckoutBasic\Models\Entry as CheckoutModel;
+
+class Checkout extends \Ilch\Mapper
+{
+    /**
+     * Gets the Checkout entries.
+     *
+     * @param array $where
+     * @return CheckoutModel[]|array
+     */
+    public function getEntries($where = [])
+    {
+        $entryArray = $this->db()->select('*')
+            ->from('checkoutBasic')
+            ->where($where)
+            ->order(['id' => 'DESC'])
+            ->execute()
+            ->fetchRows();
+
+        if (empty($entryArray)) {
+            return [];
+        }
+
+        $entry = [];
+
+        foreach ($entryArray as $entries) {
+            $entryModel = new CheckoutModel();
+            $entryModel->setId($entries['id']);
+            $entryModel->setDatetime($entries['date_created']);
+            $entryModel->setName($entries['name']);
+            $entryModel->setUsage($entries['usage']);
+            $entryModel->setAmount($entries['amount']);
+            $entry[] = $entryModel;
+        }
+
+        return $entry;
+    }
+
+    public function getEntryById($id)
+    {
+        $entry = $this->getEntries(['id' => $id]);
+        return $entry;
+    }
+
+    public function getAmount()
+    {
+        return $this->db()->select('ROUND(SUM(amount),2)', 'checkoutBasic')
+            ->execute()
+            ->fetchCell();
+    }
+
+    public function getAmountPlus()
+    {
+        return $this->db()->select('ROUND(SUM(amount),2)', 'checkoutBasic', ['amount >' => 0])
+            ->execute()
+            ->fetchCell();
+    }
+
+    public function getAmountMinus()
+    {
+        return $this->db()->select('ROUND(SUM(amount),2)', 'checkoutBasic', ['amount <' => 0])
+            ->execute()
+            ->fetchCell();
+    }
+
+    /**
+     * Inserts or updates Checkout entry.
+     *
+     * @param CheckoutModel $model
+     */
+    public function save(CheckoutModel $model)
+    {
+        if ($model->getId()) {
+            $this->db()->update('checkoutBasic')
+                ->values(['name' => $model->getName(),'date_created' => $model->getDatetime(),'usage' => $model->getUsage(),'amount' => $model->getAmount()])
+                ->where(['id' => $model->getId()])
+                ->execute();
+        } else {
+            $this->db()->insert('checkoutBasic')
+                ->values(['name' => $model->getName(),'date_created' => $model->getDatetime(),'usage' => $model->getUsage(),'amount' => $model->getAmount()])
+                ->execute();
+        }
+    }
+
+    /**
+     * Deletes the Checkout entry.
+     *
+     * @param integer $id
+     */
+    public function deleteById($id)
+    {
+        return $this->db()->delete('checkoutBasic')
+            ->where(['id' => $id])
+            ->execute();
+    }
+}

--- a/application/modules/checkoutBasic/mappers/Currency.php
+++ b/application/modules/checkoutBasic/mappers/Currency.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\CheckoutBasic\Mappers;
+
+use Modules\CheckoutBasic\Models\Currency as CurrencyModel;
+
+class Currency extends \Ilch\Mapper
+{
+    /**
+     * Gets the currencies.
+     *
+     * @param array $where
+     * @return CurrencyModel[]|array
+     */
+    public function getCurrencies($where = [])
+    {
+        $currenciesArray = $this->db()->select('*')
+            ->from('checkoutBasic_currencies')
+            ->where($where)
+            ->order(['name' => 'ASC'])
+            ->execute()
+            ->fetchRows();
+
+        if (empty($currenciesArray)) {
+            return [];
+        }
+
+        $currencies = [];
+
+        foreach ($currenciesArray as $currency) {
+            $currencyModel = new CurrencyModel();
+            $currencyModel->setId($currency['id']);
+            $currencyModel->setName($currency['name']);
+            $currencies[] = $currencyModel;
+        }
+
+        return $currencies;
+    }
+
+    /**
+     * Gets the currencies by id.
+     *
+     * @param int $id
+     * @return CurrencyModel[]|array
+     */
+    public function getCurrencyById($id)
+    {
+        $currency = $this->getCurrencies(['id' => $id]);
+        return $currency;
+    }
+
+    /**
+     * Checks if a currency with a specific name exists.
+     *
+     * @param string $name
+     * @return boolean
+     */
+    public function currencyWithNameExists($name)
+    {
+        return (boolean) $this->db()->select('COUNT(*)', 'checkoutBasic_currencies', ['name' => $name])
+            ->execute()
+            ->fetchCell();
+    }
+
+    /**
+     * Insert or update currencies.
+     *
+     * @param CurrencyModel $model
+     */
+    public function save(CurrencyModel $model)
+    {
+        if ($model->getId()) {
+            $this->db()->update('checkoutBasic_currencies')
+                ->values(['name' => $model->getName()])
+                ->where(['id' => $model->getId()])
+                ->execute();
+        } else {
+            $this->db()->insert('checkoutBasic_currencies')
+                ->values(['name' => $model->getName()])
+                ->execute();
+        }
+    }
+
+    /**
+     * Deletes the currency by id.
+     *
+     * @param integer $id
+     */
+    public function deleteCurrencyById($id)
+    {
+        return $this->db()->delete('checkoutBasic_currencies')
+            ->where(['id' => $id])
+            ->execute();
+    }
+}

--- a/application/modules/checkoutBasic/models/Currency.php
+++ b/application/modules/checkoutBasic/models/Currency.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\CheckoutBasic\Models;
+
+class Currency extends \Ilch\Model
+{
+    /**
+     * The id of the currency.
+     *
+     * @var integer
+     */
+    protected $id;
+
+    /**
+     * The name of the currency.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Gets the id of the currency.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Gets the name of the currency.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Sets the id of the currency.
+     *
+     * @param integer $id
+     */
+    public function setId($id)
+    {
+        $this->id = (int)$id;
+    }
+
+    /**
+     * Sets the name of the currency.
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = (string)$name;
+    }
+}

--- a/application/modules/checkoutBasic/models/Entry.php
+++ b/application/modules/checkoutBasic/models/Entry.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+namespace Modules\CheckoutBasic\Models;
+
+class Entry extends \Ilch\Model
+{
+    /**
+     * The id of the entry.
+     *
+     * @var integer
+     */
+    protected $id;
+
+    /**
+     * The datetime of the entry.
+     *
+     * @var string
+     */
+    protected $datetime;
+
+    /**
+     * The name of the entry.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The usage of the entry.
+     *
+     * @var string
+     */
+    protected $usage;
+
+    /**
+     * The amount of the entry.
+     *
+     * @var string
+     */
+    protected $amount;
+
+    /**
+     * Gets the id of the entry.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Gets the datetime of the entry.
+     *
+     * @return string
+     */
+    public function getDatetime()
+    {
+        return $this->datetime;
+    }
+
+    /**
+     * Gets the name of the entry.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Gets the usage of the entry.
+     *
+     * @return string
+     */
+    public function getUsage()
+    {
+        return $this->usage;
+    }
+
+    /**
+     * Gets the amount of the entry.
+     *
+     * @return string
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * Sets the id of the entry.
+     *
+     * @param integer $id
+     */
+    public function setId($id)
+    {
+        $this->id = (int)$id;
+    }
+
+    /**
+     * Sets the datetime of the entry.
+     *
+     * @param string $datetime
+     */
+    public function setDatetime($datetime)
+    {
+        $this->datetime = (string)$datetime;
+    }
+
+    /**
+     * Sets the name of the entry.
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = (string)$name;
+    }
+
+    /**
+     * Sets the usage of the entry.
+     *
+     * @param string $usage
+     */
+    public function setUsage($usage)
+    {
+        $this->usage = (string)$usage;
+    }
+
+    /**
+     * Sets the amount of the entry.
+     *
+     * @param string $amount
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = (string)$amount;
+    }
+}

--- a/application/modules/checkoutBasic/translations/de.php
+++ b/application/modules/checkoutBasic/translations/de.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+return [
+    'checkout' => 'Kasse',
+    'manage' => 'Verwalten',
+    'name' => 'Name',
+    'datetime' => 'Datum',
+    'usage' => 'Verwendung',
+    'amount' => 'Betrag',
+    'bookings' => 'Buchungen',
+    'bankbalance' => 'Kontostand',
+    'settings' => 'Einstellungen',
+    'accountdata' => 'Kontodaten',
+    'book' => 'Buchen',
+    'for' => 'für',
+    'amountinfo' => 'z.B. -30.50 für eine Ausgabe oder +30 für eine Einnahme.',
+    'balancetotal' => 'Kontostand Gesamt',
+    'totalpaid' => 'Insgesamt eingezahlt',
+    'totalpaidout' => 'Insgesamt ausgezahlt',
+    'bookedpayments' => 'Gebuchte Zahlungen',
+    'treatpayment' => 'Buchung bearbeiten',
+    'checkoutContact' => 'Kontodaten',
+    'checkoutCurrency' => 'Währung der Kasse',
+    'currencies' => 'Währungen',
+    'currency' => 'Währung',
+    'noCurrenciesExist' => 'Keine Währungen vorhanden.',
+    'addCurrency' => 'Währung hinzufügen',
+    'treatCurrency' => 'Währung bearbeiten',
+    'currencyInUse' => 'Diese Währung wird zurzeit verwendet und kann daher nicht gelöscht werden.',
+    'alreadyExisting' => 'Es existiert bereits eine Währung mit diesem Namen.',
+];

--- a/application/modules/checkoutBasic/translations/en.php
+++ b/application/modules/checkoutBasic/translations/en.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ * @package ilch
+ */
+
+return [
+    'checkout' => 'Checkout',
+    'manage' => 'Manage',
+    'name' => 'Name',
+    'datetime' => 'Date',
+    'usage' => 'Usage',
+    'amount' => 'Amount',
+    'bookings' => 'Bookings',
+    'bankbalance' => 'Bankbalance',
+    'settings' => 'Settings',
+    'accountdata' => 'Account data',
+    'book' => 'Book',
+    'for' => 'for',
+    'amountinfo' => 'e.g. -30.50 for an expense or +30 for a revenue.',
+    'balancetotal' => 'Balance total',
+    'totalpaid' => 'Total paid',
+    'totalpaidout' => 'Total paid out',
+    'bookedpayments' => 'Booked payments',
+    'treatpayment' => 'Edit booking',
+    'checkoutContact' => 'Bank account',
+    'checkoutCurrency' => 'Currency of checkout',
+    'currencies' => 'Currencies',
+    'currency' => 'Currency',
+    'noCurrenciesExist' => 'No currencies exists.',
+    'addCurrency' => 'Add currency',
+    'treatCurrency' => 'Edit currency',
+    'currencyInUse' => 'This currency is currently in use and therefore can not be deleted.',
+    'alreadyExisting' => 'A currency with this name already exists.',
+];

--- a/application/modules/checkoutBasic/views/admin/currency/index.php
+++ b/application/modules/checkoutBasic/views/admin/currency/index.php
@@ -1,0 +1,39 @@
+<?php $currencies = $this->get('currencies'); ?>
+
+<legend><?=$this->getTrans('currencies') ?></legend>
+<form class="form-horizontal" method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
+    <?=$this->getTokenField() ?>
+    <table class="table table-hover table-striped">
+        <colgroup>
+            <col class="icon_width">
+            <col class="icon_width">
+            <col class="icon_width">
+            <col>
+        </colgroup>
+        <thead>
+            <tr>
+                <th><?=$this->getCheckAllCheckbox('check_currencies') ?></th>
+                <th></th>
+                <th></th>
+                <th><?=$this->getTrans('currency') ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (count($currencies) > 0): ?>
+                <?php foreach ($currencies as $currency) : ?>
+                    <tr>
+                        <td><?=$this->getDeleteCheckbox('check_currencies', $currency->getId()) ?></td>
+                        <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $currency->getId()]) ?></td>
+                        <td> <?=$this->getDeleteIcon(['action' => 'delete', 'id' => $currency->getId()]) ?></td>
+                        <td><?=$this->escape($currency->getName()) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php else: ?>
+                <tr>
+                    <td colspan="4"><?=$this->getTrans('noCurrenciesExist') ?></td>
+                </tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
+    <?=$this->getListBar(['delete' => 'delete']) ?>
+</form>

--- a/application/modules/checkoutBasic/views/admin/currency/treat.php
+++ b/application/modules/checkoutBasic/views/admin/currency/treat.php
@@ -1,0 +1,43 @@
+<?php $currency = $this->get('currency'); ?>
+
+<legend>
+    <?php if ($this->getRequest()->getParam("id")) {
+        echo $this->getTrans('edit');
+    } else {
+        echo $this->getTrans('add');
+    }
+    ?>
+</legend>
+<?php if (!empty($this->get('errors'))): ?>
+    <div class="alert alert-danger" role="alert">
+        <strong> <?=$this->getTrans('errorsOccured') ?>:</strong>
+        <ul>
+            <?php foreach ($this->get('errors') as $error): ?>
+                <li><?= $error; ?></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+<?php endif; ?>
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <div class="form-group <?=in_array('name', $this->get('errorFields')) ? 'has-error' : '' ?>">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="name"
+                   name="name"
+                   placeholder="<?=$this->getTrans('name') ?>"
+                   value="<?=$this->escape($currency->getName()) ?>" />
+        </div>
+    </div>
+    <div class="form-group hidden">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="id"
+                   name="id"
+                   value="<?=$this->escape($currency->getId()) ?>" />
+        </div>
+    </div>
+    <?=$this->getSaveBar() ?>
+</form>

--- a/application/modules/checkoutBasic/views/admin/index/index.php
+++ b/application/modules/checkoutBasic/views/admin/index/index.php
@@ -1,0 +1,111 @@
+<?php
+$currency = $this->escape($this->get('currency'));
+?>
+
+<legend><?=$this->getTrans('bookings') ?></legend>
+<?php if ($this->validation()->hasErrors()): ?>
+    <div class="alert alert-danger" role="alert">
+        <strong> <?=$this->getTrans('errorsOccured') ?>:</strong>
+        <ul>
+            <?php foreach ($this->validation()->getErrorMessages() as $error): ?>
+                <li><?= $error; ?></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+<?php endif; ?>
+<form class="form-horizontal" method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
+    <?=$this->getTokenField() ?>
+    <div class="form-group <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="name"
+                   name="name"
+                   placeholder="<?=$this->getTrans('name') ?>"
+                   value="<?=$this->escape($this->originalInput('name')) ?>" />
+        </div>
+    </div>
+    <div class="form-group <?=$this->validation()->hasError('checkoutdate') ? 'has-error' : '' ?>">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="datetime"
+                   name="datetime"
+                   placeholder="<?=$this->getTrans('datetime') ?>"
+                   value="<?php if ($this->get('checkoutdate') != '') { echo $this->get('checkoutdate'); } ?>" />
+        </div>
+    </div>
+    <div class="form-group <?=$this->validation()->hasError('usage') ? 'has-error' : '' ?>">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="usage"
+                   name="usage"
+                   placeholder="<?=$this->getTrans('usage') ?>"
+                   value="<?=$this->escape($this->originalInput('usage')) ?>" />
+        </div>
+    </div>
+    <div class="form-group <?=$this->validation()->hasError('amount') ? 'has-error' : '' ?>">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="amount"
+                   name="amount"
+                   placeholder="<?=$this->getTrans('amount') ?>"
+                   data-content="<?=$this->getTrans('amountinfo') ?>" 
+                   rel="popover" 
+                   data-placement="bottom" 
+                   data-original-title="<?=$this->getTrans('amount') ?>" 
+                   data-trigger="hover"
+                   value="<?=$this->escape($this->originalInput('amount')) ?>" />
+        </div>
+    </div>
+    <br>
+    <br>
+    <div class="col-lg-4">
+        <legend><?=$this->getTrans('bankbalance') ?></legend>
+        <div class="panel panel-default">
+            <div class="panel-body">
+                <strong>
+                    <?php if ($this->get('amount') != '') { echo $this->getTrans('balancetotal'),': ', $this->get('amount'), ' '.$currency ; } 
+                    else { echo $this->getTrans('balancetotal'), ': 0 ', $currency ;}
+                    ?>
+                </strong>
+                <br>
+                <?php if ($this->get('amountplus') != '') { echo $this->getTrans('totalpaid'),': ', $this->get('amountplus'), ' '.$currency ; } 
+                else { echo $this->getTrans('totalpaid'), ': 0 ', $currency ;}
+                ?>
+                <br>
+                <?php if ($this->get('amountminus') != '') { echo $this->getTrans('totalpaidout'),': ', $this->get('amountminus'), ' '.$currency ; }
+                else { echo $this->getTrans('totalpaidout'), ': 0 ', $currency ;}
+                ?>
+            </div>
+        </div>
+
+        <legend> <?=$this->getTrans('bookedpayments') ?></legend>
+        <div class="panel-default">
+            <ul class="list-group">
+                <?php foreach ($this->get('checkout') as $checkout): ?>
+                    <li class="list-group-item">
+                        <?=$this->escape($checkout->getName()) ?>: 
+                        <strong>
+                            <?=$this->escape($checkout->getAmount()) ?>
+                            <?=$currency ?>
+                        </strong> 
+                        <?=$this->getTrans('for') ?>: 
+                        <?=$this->escape($checkout->getUsage()) ?>
+                        <?=$this->getEditIcon(['action' => 'treatPayment', 'id' => $this->escape($checkout->getId())]) ?>
+                        <?=$this->getDeleteIcon(['action' => 'del', 'id' => $this->escape($checkout->getId())]) ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+        <br>
+        <br>
+    </div>
+    <?=$this->getSaveBar($this->getTrans('book')) ?>
+</form>
+
+<script>
+$('#amount').popover();
+</script>

--- a/application/modules/checkoutBasic/views/admin/index/settings.php
+++ b/application/modules/checkoutBasic/views/admin/index/settings.php
@@ -1,0 +1,37 @@
+<legend><?=$this->getTrans('accountdata') ?></legend>
+<?php if ($this->validation()->hasErrors()): ?>
+    <div class="alert alert-danger" role="alert">
+        <strong> <?=$this->getTrans('errorsOccured') ?>:</strong>
+        <ul>
+            <?php foreach ($this->validation()->getErrorMessages() as $error): ?>
+                <li><?= $error; ?></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+<?php endif; ?>
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <div class="form-group <?=$this->validation()->hasError('checkoutContact') ? 'has-error' : '' ?>">
+        <textarea class="form-control ckeditor"
+                  id="ck_1"
+                  toolbar="ilch_html"
+                  name="checkoutContact"><?php if ($this->get('checkoutContact') != '') { echo $this->get('checkoutContact') ; } ?></textarea>
+    </div>
+    <div class="form-group <?=$this->validation()->hasError('checkoutCurrency') ? 'has-error' : '' ?>">
+        <label for="checkoutCurrency" class="control-label">
+            <?=$this->getTrans('checkoutCurrency') ?>:
+        </label>
+        <select name="checkoutCurrency" id="checkoutCurrency">
+            <?php
+            foreach ($this->get('currencies') as $currency) {
+                if ($this->get('checkoutCurrency') != $currency->getId()) {
+                    echo '<option value="'.$currency->getId().'">'.$this->escape($currency->getName()).'</option>';
+                } else {
+                    echo '<option value="'.$currency->getId().'" selected>'.$this->escape($currency->getName()).'</option>';
+                }
+            }
+            ?>
+        </select>
+    </div>
+    <?=$this->getSaveBar('updateButton') ?>
+</form>

--- a/application/modules/checkoutBasic/views/admin/index/treatPayment.php
+++ b/application/modules/checkoutBasic/views/admin/index/treatPayment.php
@@ -1,0 +1,75 @@
+<legend><?=$this->getTrans('treatpayment') ?></legend>
+<?php if ($this->validation()->hasErrors()): ?>
+    <div class="alert alert-danger" role="alert">
+        <strong> <?=$this->getTrans('errorsOccured') ?>:</strong>
+        <ul>
+            <?php foreach ($this->validation()->getErrorMessages() as $error): ?>
+                <li><?= $error; ?></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+<?php endif; ?>
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <?php foreach ($this->get('checkout') as $checkout): ?>
+    <div class="form-group <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="name"
+                   name="name"
+                   placeholder="<?=$this->getTrans('name') ?>"
+                   value="<?=($this->originalInput('name') != '') ? $this->escape($this->originalInput('name')) : $this->escape($checkout->getName()) ?>" />
+        </div>
+    </div>
+    <div class="form-group <?=$this->validation()->hasError('datetime') ? 'has-error' : '' ?>">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="datetime"
+                   name="datetime"
+                   placeholder="<?=$this->getTrans('datetime') ?>"
+                   value="<?=($this->originalInput('datetime') != '') ? $this->escape($this->originalInput('datetime')) : $this->escape($checkout->getDateTime()) ?>" />
+        </div>
+    </div>
+    <div class="form-group <?=$this->validation()->hasError('usage') ? 'has-error' : '' ?>">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="usage"
+                   name="usage"
+                   placeholder="<?=$this->getTrans('usage') ?>"
+                   value="<?=($this->originalInput('usage') != '') ? $this->escape($this->originalInput('usage')) : $this->escape($checkout->getUsage()) ?>" />
+        </div>
+    </div>
+    <div class="form-group hidden">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="id"
+                   name="id"
+                   value="<?=$this->escape($checkout->getId()) ?>" />
+        </div>
+    </div>
+    <div class="form-group <?=$this->validation()->hasError('amount') ? 'has-error' : '' ?>">
+        <div class="col-lg-4">
+            <input type="text"
+                   class="form-control"
+                   id="amount"
+                   name="amount"
+                   placeholder="<?=$this->getTrans('amount') ?>"
+                   data-content="<?=$this->getTrans('amountinfo') ?>" 
+                   rel="popover" 
+                   data-placement="bottom" 
+                   data-original-title="<?=$this->getTrans('amount') ?>" 
+                   data-trigger="hover"
+                   value="<?=($this->originalInput('amount') != '') ? $this->escape($this->originalInput('amount')) : $this->escape($checkout->getAmount()) ?>" />
+        </div>
+    </div>
+    <?php endforeach; ?>
+    <?=$this->getSaveBar('updateButton') ?>
+</form>
+
+<script>
+$('#amount').popover();
+</script>

--- a/application/modules/checkoutBasic/views/index/index.php
+++ b/application/modules/checkoutBasic/views/index/index.php
@@ -1,0 +1,40 @@
+<?php
+$currency = $this->escape($this->get('currency'));
+?>
+
+<legend><?=$this->getTrans('accountdata') ?></legend>
+<?php if ($this->get('checkout_contact') != '') { echo $this->get('checkout_contact') ; } ?>
+<br>
+<br>
+<legend><?=$this->getTrans('bankbalance') ?></legend>
+<div>
+    <strong>
+        <?php if ($this->get('amount') != '') { echo $this->getTrans('balancetotal'),': ', $this->get('amount'), ' '.$currency ; } 
+        else { echo $this->getTrans('balancetotal'), ': 0 ', $currency ;}
+        ?>
+    </strong>
+    <br>
+    <?php if ($this->get('amountplus') != '') { echo $this->getTrans('totalpaid'),': ', $this->get('amountplus'), ' '.$currency ; } 
+    else { echo $this->getTrans('totalpaid'), ': 0 ', $currency ;}
+    ?>
+    <br>
+    <?php if ($this->get('amountminus') != '') { echo $this->getTrans('totalpaidout'),': ', $this->get('amountminus'), ' '.$currency ; }
+    else { echo $this->getTrans('totalpaidout'), ': 0 ', $currency ;}
+    ?>
+</div>
+<br>
+<br>
+<legend><?=$this->getTrans('bookedpayments') ?></legend>
+<ul>
+<?php foreach ($this->get('checkout') as $checkout): ?>
+    <li>
+        <?=$this->escape($checkout->getName()) ?>: 
+        <strong>
+            <?=$this->escape($checkout->getAmount()) ?>
+            <?=$currency ?>
+        </strong> 
+        <?=$this->getTrans('for') ?>: 
+        <?=$this->escape($checkout->getUsage()) ?>
+    </li>
+    <?php endforeach; ?>
+</ul>

--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -147,10 +147,6 @@ class Index extends \Ilch\Controller\Frontend
             $errors['writableCertificate'] = true;
         }
 
-        if (!extension_loaded('intl')) {
-            $errors['intlExtensionMissing'] = true;
-        }
-
         if (!extension_loaded('mbstring')) {
             $errors['mbstringExtensionMissing'] = true;
         }
@@ -501,7 +497,7 @@ class Index extends \Ilch\Controller\Frontend
         /*
          * Optional-Modules.
          */
-        $modules['checkout']['types'] = ['clan'];
+        $modules['checkoutBasic']['types'] = ['clan'];
         $modules['war']['types'] = ['clan'];
         $modules['history']['types'] = ['clan'];
         $modules['rule']['types'] = ['clan'];

--- a/application/modules/install/views/index/systemcheck.php
+++ b/application/modules/install/views/index/systemcheck.php
@@ -20,17 +20,6 @@
                 </td>
             </tr>
             <tr>
-                <td>PHP-<?=$this->getTrans('extension') ?> Internationalization support (intl)</td>
-                <td class="text-success"><?=$this->getTrans('existing') ?>
-                <td>
-                    <?php if (extension_loaded('intl')): ?>
-                        <span class="text-success"><?=$this->getTrans('existing') ?></span>
-                    <?php else: ?>
-                        <span class="text-danger"><?=$this->getTrans('missing') ?></span>
-                    <?php endif; ?>
-                </td>
-            </tr>
-            <tr>
                 <td>PHP-<?=$this->getTrans('extension') ?> Multibyte String (mbstring)</td>
                 <td class="text-success"><?=$this->getTrans('existing') ?>
                 <td>


### PR DESCRIPTION
Add a basic checkout module, which doesn't require the php intl extension. Use this one as default.

The checkout module, which needs the php intl extension will be an optional module, which can be installed from the servers.

Remove checks for php intl extension from the install module.