### PR TITLE
Use version number from database if possible

### DIFF
--- a/application/modules/admin/controllers/admin/Index.php
+++ b/application/modules/admin/controllers/admin/Index.php
@@ -66,5 +66,6 @@ class Index extends \Ilch\Controller\Admin
         $this->getView()->set('usersNotConfirmed', $userMapper->getUserList(['confirmed' => 0]));
 
         $this->getView()->set('moduleLocales', $moduleLocales);
+        $this->getView()->set('version', $this->getConfig()->get('version'));
     }
 }

--- a/application/modules/admin/controllers/admin/Modules.php
+++ b/application/modules/admin/controllers/admin/Modules.php
@@ -61,6 +61,7 @@ class Modules extends \Ilch\Controller\Admin
 
         $this->getView()->set('modules', $moduleMapper->getModules());
         $this->getView()->set('versionsOfModules', $moduleMapper->getVersionsOfModules());
+        $this->getView()->set('coreVersion', $this->getConfig()->get('version'));
     }
 
     public function notinstalledAction()
@@ -118,6 +119,7 @@ class Modules extends \Ilch\Controller\Admin
 
         $this->getView()->set('versionsOfModules', $moduleMapper->getVersionsOfModules());
         $this->getView()->set('modules', $modulesDir);
+        $this->getView()->set('coreVersion', $this->getConfig()->get('version'));
     }
     
     public function updateAction()

--- a/application/modules/admin/layouts/index.php
+++ b/application/modules/admin/layouts/index.php
@@ -78,7 +78,7 @@
                             </a>
                         </div>
                     <?php endif; ?>
-                    <img title="Version <?=VERSION ?>" class="pull-left logo hidden-sm" src="<?=$this->getStaticUrl('img/ilch_logo_2.png') ?>" />
+                    <img title="Version <?=$config->get('version') ?>" class="pull-left logo hidden-sm" src="<?=$this->getStaticUrl('img/ilch_logo_2.png') ?>" />
                     <div class="hidden-md hidden-lg hidden-sm">
                         <a class="<?php if ($this->getRequest()->getModuleName() == 'admin' && $this->getRequest()->getControllerName() == 'index') { echo 'active'; }?> home" href="<?=$this->getUrl(['module' => 'admin', 'controller' => 'index', 'action' => 'index']) ?>">
                             <i class="fa fa-home"></i>

--- a/application/modules/admin/views/admin/index/index.php
+++ b/application/modules/admin/views/admin/index/index.php
@@ -7,6 +7,7 @@ if ($this->getUser()->getFirstName() != '') {
 
 $ilchNewsList = url_get_contents('http://ilch2.de/ilchNews.php');
 $ilchNews = json_decode($ilchNewsList);
+$version = $this->get('version');
 ?>
 
 <h3><?=$this->getTrans('welcomeBack', $this->escape($name)) ?> !</h3>
@@ -74,7 +75,7 @@ $ilchNews = json_decode($ilchNewsList);
                 <tbody>
                     <tr>
                         <td><?=$this->getTrans('installedVersion') ?></td>
-                        <td><?=VERSION ?></td>
+                        <td><?=$version ?></td>
                     </tr>
                     <tr>
                         <td><?=$this->getTrans('serverVersion') ?></td>
@@ -84,7 +85,7 @@ $ilchNews = json_decode($ilchNewsList);
                             <?php elseif ($this->get('curlErrorOccured')): ?>
                                 <?=$this->getTrans('versionNA') ?>
                             <?php else: ?>
-                                <?=VERSION ?>
+                                <?=$version ?>
                             <?php endif; ?>
                         </td>
                     </tr>

--- a/application/modules/admin/views/admin/modules/index.php
+++ b/application/modules/admin/views/admin/modules/index.php
@@ -2,6 +2,7 @@
 $modulesList = url_get_contents('http://ilch2.de/downloads/modules/list.php');
 $modulesOnUpdateServer = json_decode($modulesList);
 $versionsOfModules = $this->get('versionsOfModules');
+$coreVersion = $this->get('coreVersion');
 ?>
 
 <link href="<?=$this->getModuleUrl('static/css/extsearch.css') ?>" rel="stylesheet">
@@ -80,7 +81,7 @@ $versionsOfModules = $this->get('versionsOfModules');
                                             title="<?=$this->getTrans('phpVersionError') ?>">
                                         <i class="fa fa-refresh"></i>
                                     </button>
-                                <?php elseif (version_compare(VERSION, $moduleOnUpdateServerFound->ilchCore, '<')): ?>
+                                <?php elseif (version_compare($coreVersion, $moduleOnUpdateServerFound->ilchCore, '<')): ?>
                                     <button class="btn disabled"
                                             title="<?=$this->getTrans('ilchCoreError') ?>">
                                         <i class="fa fa-refresh"></i>

--- a/application/modules/admin/views/admin/modules/search.php
+++ b/application/modules/admin/views/admin/modules/search.php
@@ -2,6 +2,7 @@
 $modulesList = url_get_contents('http://ilch2.de/downloads/modules/list.php');
 $modulesOnUpdateServer = json_decode($modulesList);
 $versionsOfModules = $this->get('versionsOfModules');
+$coreVersion = $this->get('coreVersion');
 ?>
 
 <link href="<?=$this->getModuleUrl('static/css/extsearch.css') ?>" rel="stylesheet">
@@ -62,7 +63,7 @@ if (empty($modulesOnUpdateServer)) {
                                     title="<?=$this->getTrans('phpVersionError') ?>">
                                 <i class="fa fa-download"></i>
                             </button>
-                        <?php elseif (version_compare(VERSION, $moduleOnUpdateServer->ilchCore, '<')): ?>
+                        <?php elseif (version_compare($coreVersion, $moduleOnUpdateServer->ilchCore, '<')): ?>
                             <button class="btn disabled"
                                     title="<?=$this->getTrans('ilchCoreError') ?>">
                                 <i class="fa fa-download"></i>


### PR DESCRIPTION
Use the version number from the database if possible instead of the VERSION constante, which is now only used in the install module.