### PR TITLE
Check if the mysqli extension is loaded

### DIFF
--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -151,6 +151,10 @@ class Index extends \Ilch\Controller\Frontend
             $errors['writableCertificate'] = true;
         }
 
+        if (!extension_loaded('mysqli')) {
+            $errors['mysqliExtensionMissing'] = true;
+        }
+
         if (!extension_loaded('mbstring')) {
             $errors['mbstringExtensionMissing'] = true;
         }

--- a/application/modules/install/translations/de.php
+++ b/application/modules/install/translations/de.php
@@ -37,7 +37,7 @@ return [
     'dbDatabaseCouldNotConnect' => 'Konnte keine Verbindung zum Server herstellen.',
     'dbHostInfo' => 'Die Adresse des Datenbankservers meistens localhost',
     'dbUserInfo' => 'Dein MySQL Benutzername',
-    'writable' => 'Beschreibbar',
+    'writable' => 'beschreibbar',
     'notWritable' => 'nicht beschreibbar',
     'usage' => 'Benutzung',
     'successInstalled' => 'Ilch CMS wurde erfolgreich installiert',

--- a/application/modules/install/views/index/systemcheck.php
+++ b/application/modules/install/views/index/systemcheck.php
@@ -20,6 +20,17 @@
                 </td>
             </tr>
             <tr>
+                <td>PHP-<?=$this->getTrans('extension') ?> MySQLi (mysqli)</td>
+                <td class="text-success"><?=$this->getTrans('existing') ?>
+                <td>
+                    <?php if (extension_loaded('mysqli')): ?>
+                        <span class="text-success"><?=$this->getTrans('existing') ?></span>
+                    <?php else: ?>
+                        <span class="text-danger"><?=$this->getTrans('missing') ?></span>
+                    <?php endif; ?>
+                </td>
+            </tr>
+            <tr>
                 <td>PHP-<?=$this->getTrans('extension') ?> Multibyte String (mbstring)</td>
                 <td class="text-success"><?=$this->getTrans('existing') ?>
                 <td>


### PR DESCRIPTION
Check if the mysqli extension is loaded.

> Depending on the version of PHP, there are either two or three PHP APIs for accessing the MySQL database. PHP 5 users can choose between the deprecated mysql extension, mysqli, or PDO_MySQL. PHP 7 removes the mysql extension, leaving only the latter two options.

> This extension is deprecated as of PHP 5.5.0, and has been removed as of PHP 7.0.0. Instead, either the mysqli or PDO_MySQL extension should be used.

http://php.net/manual/en/intro.mysql.php 
http://php.net/manual/en/mysql.php 