### PR TITLE
Destroy instance if it already exists

### DIFF
--- a/static/js/ilch.js
+++ b/static/js/ilch.js
@@ -3,6 +3,10 @@ $(document).ready(function(){
         var id = $(this).attr('id');
         var toolbar = $(this).attr('toolbar');
 
+        if (CKEDITOR.instances[id]) {
+            CKEDITOR.instances[id].destroy();
+        }
+
         if (toolbar === 'ilch_html') {
             CKEDITOR.env.isCompatible = true;
             CKEDITOR.replace( id , {


### PR DESCRIPTION
Uncaught The editor instance "ck_1" is already attached to the provided
element.

http://redmine.ilch2.de/issues/413