### PR TITLE
Add standardMail to From-MailHeader

### DIFF
--- a/application/modules/contact/controllers/Index.php
+++ b/application/modules/contact/controllers/Index.php
@@ -60,7 +60,7 @@ class Index extends \Ilch\Controller\Frontend
                         ->setFrom($this->getConfig()->get('standardMail'), $this->getConfig()->get('page_title'))
                         ->setMessage($post['message'])
                         ->addGeneralHeader('Content-Type', 'text/plain; charset="utf-8"');
-                $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));
+                $mail->setAdditionalParameters('-t '.'-f'.$this->getConfig()->get('standardMail'));
                 $mail->send();
 
                 $this->addMessage('sendSuccess');

--- a/application/modules/jobs/controllers/Index.php
+++ b/application/modules/jobs/controllers/Index.php
@@ -75,7 +75,7 @@ class Index extends \Ilch\Controller\Frontend
                         ->setFrom($user->getEmail(), $user->getName())
                         ->setMessage($message)
                         ->addGeneralHeader('Content-Type', 'text/html; charset="utf-8"');
-                $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));
+                $mail->setAdditionalParameters('-t '.'-f'.$this->getConfig()->get('standardMail'));
                 $mail->send();
 
                 $this->addMessage('sendSuccess');

--- a/application/modules/newsletter/controllers/admin/Index.php
+++ b/application/modules/newsletter/controllers/admin/Index.php
@@ -160,7 +160,7 @@ class Index extends \Ilch\Controller\Admin
                             ->setFrom($this->getConfig()->get('standardMail'), $this->getConfig()->get('page_title'))
                             ->setMessage($message)
                             ->addGeneralHeader('Content-Type', 'text/html; charset="utf-8"');
-                    $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));
+                    $mail->setAdditionalParameters('-t '.'-f'.$this->getConfig()->get('standardMail'));
                     $mail->send();
                 }
 

--- a/application/modules/user/controllers/Login.php
+++ b/application/modules/user/controllers/Login.php
@@ -202,7 +202,7 @@ class Login extends \Ilch\Controller\Frontend
                     $mail = new \Ilch\Mail();
                     $mail->setTo($email,$name)
                             ->setSubject($this->getTranslator()->trans('automaticEmail'))
-                            ->setFrom($this->getTranslator()->trans('automaticEmail'), $sitetitle)
+                            ->setFrom($this->getConfig()->get('standardMail'), $sitetitle)
                             ->setMessage($message)
                             ->addGeneralHeader('Content-Type', 'text/html; charset="utf-8"');
                     $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));

--- a/application/modules/user/controllers/Login.php
+++ b/application/modules/user/controllers/Login.php
@@ -205,7 +205,7 @@ class Login extends \Ilch\Controller\Frontend
                             ->setFrom($this->getConfig()->get('standardMail'), $sitetitle)
                             ->setMessage($message)
                             ->addGeneralHeader('Content-Type', 'text/html; charset="utf-8"');
-                    $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));
+                    $mail->setAdditionalParameters('-t '.'-f'.$this->getConfig()->get('standardMail'));
                     $mail->send();
 
                     $this->addMessage('newPasswordEMailSuccess');

--- a/application/modules/user/controllers/Mail.php
+++ b/application/modules/user/controllers/Mail.php
@@ -55,7 +55,7 @@ class Mail extends \Ilch\Controller\Frontend
                         ->setFrom($email, $name)
                         ->setMessage($message)
                         ->addGeneralHeader('Content-Type', 'text/html; charset="utf-8"');
-                $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));
+                $mail->setAdditionalParameters('-t '.'-f'.$this->getConfig()->get('standardMail'));
                 $mail->send();
 
                 $this->addMessage('emailSuccess');

--- a/application/modules/user/controllers/Regist.php
+++ b/application/modules/user/controllers/Regist.php
@@ -117,7 +117,7 @@ class Regist extends \Ilch\Controller\Frontend
                     $mail = new \Ilch\Mail();
                     $mail->setTo($this->getRequest()->getPost('email'), $this->getRequest()->getPost('name'))
                         ->setSubject($this->getTranslator()->trans('automaticEmail'))
-                        ->setFrom($this->getTranslator()->trans('automaticEmail'), $sitetitle)
+                        ->setFrom($this->getConfig()->get('standardMail'), $sitetitle)
                         ->setMessage($message)
                         ->addGeneralHeader('Content-Type', 'text/html; charset="utf-8"');
                     $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));

--- a/application/modules/user/controllers/Regist.php
+++ b/application/modules/user/controllers/Regist.php
@@ -120,7 +120,7 @@ class Regist extends \Ilch\Controller\Frontend
                         ->setFrom($this->getConfig()->get('standardMail'), $sitetitle)
                         ->setMessage($message)
                         ->addGeneralHeader('Content-Type', 'text/html; charset="utf-8"');
-                    $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));
+                    $mail->setAdditionalParameters('-t '.'-f'.$this->getConfig()->get('standardMail'));
                     $mail->send();
                 }
 

--- a/application/modules/user/controllers/admin/Index.php
+++ b/application/modules/user/controllers/admin/Index.php
@@ -154,7 +154,7 @@ class Index extends \Ilch\Controller\Admin
                     ->setFrom($this->getConfig()->get('standardMail'), $this->getConfig()->get('page_title'))
                     ->setMessage($message)
                     ->addGeneralHeader('Content-Type', 'text/html; charset="utf-8"');
-            $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));
+            $mail->setAdditionalParameters('-t '.'-f'.$this->getConfig()->get('standardMail'));
             $mail->send();
 
             $this->addMessage('freeSuccess');

--- a/application/modules/user/controllers/admin/Index.php
+++ b/application/modules/user/controllers/admin/Index.php
@@ -151,7 +151,7 @@ class Index extends \Ilch\Controller\Admin
             $mail = new \Ilch\Mail();
             $mail->setTo($user->getEmail(), $user->getName())
                     ->setSubject($this->getTranslator()->trans('automaticEmail'))
-                    ->setFrom($this->getTranslator()->trans('automaticEmail'), $this->getConfig()->get('page_title'))
+                    ->setFrom($this->getConfig()->get('standardMail'), $this->getConfig()->get('page_title'))
                     ->setMessage($message)
                     ->addGeneralHeader('Content-Type', 'text/html; charset="utf-8"');
             $mail->setAdditionalParameters('-f '.$this->getConfig()->get('standardMail'));


### PR DESCRIPTION
> Pflichtangabe nach RFC 5322. Eine oder mehrere durch Kommata getrennte E-Mail-Adressen, die den oder die Absender einer E-Mail bezeichnen. Die meisten E-Mail-Clients unterstützen nur einen einzelnen Absender.

https://de.wikipedia.org/wiki/Header_(E-Mail)#From:_Absender

Add -t and remove space between -f and the mail-adress
-t: Extract  recipients from message headers. These are added to any
recipients specified on the command line.