### PR TITLE
Forbid leader and co-leader to be identical

### DIFF
--- a/application/modules/admin/views/admin/infos/logs.php
+++ b/application/modules/admin/views/admin/infos/logs.php
@@ -7,7 +7,7 @@ $userMapper = $this->get('userMapper');
 
 <form class="form-horizontal" method="POST" action="">
     <?=$this->getTokenField() ?>
-    <button type="submit" name="clearLog"><?=$this->getTrans('clearLog') ?></button>
+    <button type="submit" class="btn" name="clearLog"><?=$this->getTrans('clearLog') ?></button>
 </form><br>
 <?php if ($this->get('logsDate') != ''): ?>
     <?php foreach ($this->get('logsDate') as $logDate): ?>

--- a/application/modules/teams/controllers/admin/Index.php
+++ b/application/modules/teams/controllers/admin/Index.php
@@ -95,6 +95,10 @@ class Index extends \Ilch\Controller\Admin
                 'groupId' => 'required|numeric|integer|min:1'
             ]);
 
+            if ($this->getRequest()->getPost('leader') == $this->getRequest()->getPost('coLeader')) {
+                $validation->getErrorBag()->addError('coLeader', $this->getTranslator()->trans('leaderCoLeaderIdentic'));
+            }
+
             if ($validation->isValid()) {
                 $model = new TeamsModel();
 
@@ -156,6 +160,8 @@ class Index extends \Ilch\Controller\Admin
                     ->setCoLeader($this->getRequest()->getPost('coLeader'))
                     ->setGroupId($this->getRequest()->getPost('groupId'));
                 $teamsMapper->save($model);
+
+                $this->addMessage('saveSuccess');
             }
 
             if ($this->getRequest()->getParam('id')) {

--- a/application/modules/teams/translations/de.php
+++ b/application/modules/teams/translations/de.php
@@ -23,4 +23,5 @@ return [
     'allowedFileExtensions' => 'Erlaubte Dateiendungen',
     'failedFiletypes' => 'Bild enthält kein erlaubtes Dateiformat.',
     'failedFilesize' => 'Bild hat unerlaubte Breite, Höhe oder ist zu groß.',
+    'leaderCoLeaderIdentic' => 'Der Leader und CoLeader sind identisch.',
 ];

--- a/application/modules/teams/translations/en.php
+++ b/application/modules/teams/translations/en.php
@@ -23,4 +23,5 @@ return [
     'allowedFileExtensions' => 'Allowed file extensions',
     'failedFiletypes' => 'Image does not contain allowed file format.',
     'failedFilesize' => 'Image has unauthorized width, height or is too big.',
+    'leaderCoLeaderIdentic' => 'The leader and co-leader are identic.',
 ];


### PR DESCRIPTION
- Forbid leader and co-leader to be identical
- Add saveSuccess-message
- Add class btn to "clear log"-button