### PR TITLE
Try to use the most precise type (int to tinyint)

### DIFF
--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -116,7 +116,7 @@ class Config extends \Ilch\Config\Install
                   `page_id` INT(11) NOT NULL DEFAULT 0,
                   `box_id` INT(11) NOT NULL DEFAULT 0,
                   `box_key` VARCHAR(255) NULL DEFAULT NULL,
-                  `type` INT(11) NOT NULL,
+                  `type` TINYINT(1) NOT NULL,
                   `title` VARCHAR(255) NOT NULL,
                   `href` VARCHAR(255) NULL DEFAULT NULL,
                   `module_key` VARCHAR(255) NULL DEFAULT NULL,

--- a/application/modules/awards/config/config.php
+++ b/application/modules/awards/config/config.php
@@ -47,7 +47,7 @@ class Config extends \Ilch\Config\Install
                   `event` VARCHAR(100) NOT NULL,
                   `url` VARCHAR(150) NOT NULL,
                   `ut_id` INT(11) NOT NULL,
-                  `typ` INT(11) NOT NULL,
+                  `typ` TINYINT(1) NOT NULL,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;';
     }

--- a/application/modules/awards/controllers/admin/Index.php
+++ b/application/modules/awards/controllers/admin/Index.php
@@ -113,7 +113,7 @@ class Index extends \Ilch\Controller\Admin
                 'date'  => 'required',
                 'rank'  => 'required|numeric|integer|min:1',
                 'utId'  => 'required|numeric|integer|min:1',
-                'typ'  => 'required|numeric|integer|min:1',
+                'typ'  => 'required|numeric|integer|min:1|max:2',
                 'page' => 'url',
             ]);
 

--- a/application/modules/events/config/config.php
+++ b/application/modules/events/config/config.php
@@ -80,14 +80,14 @@ class Config extends \Ilch\Config\Install
                   `lat_long` VARCHAR(100) NULL DEFAULT NULL,
                   `image` VARCHAR(255) NULL DEFAULT NULL,
                   `text` LONGTEXT NOT NULL,
-                  `show` INT(11) NOT NULL,
+                  `show` TINYINT(1) NOT NULL,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
 
                 CREATE TABLE IF NOT EXISTS `[prefix]_events_entrants` (
                   `event_id` INT(11) NOT NULL,
                   `user_id` INT(11) NOT NULL,
-                  `status` INT(11) NOT NULL
+                  `status` TINYINT(1) NOT NULL
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
                 INSERT INTO `[prefix]_modules_folderrights` (`key`, `folder`) VALUES

--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -57,7 +57,7 @@ class Config extends \Ilch\Config\Install
                   `forum_id` INT(11) NOT NULL,
                   `sort` INT(11) NOT NULL DEFAULT 0,
                   `parent_id` INT(11) NOT NULL DEFAULT 0,
-                  `type` INT(11) NOT NULL,
+                  `type` TINYINT(1) NOT NULL,
                   `title` VARCHAR(255) NOT NULL,
                   `description` VARCHAR(255) NOT NULL,
                   `prefix` VARCHAR(255) NOT NULL,
@@ -76,8 +76,8 @@ class Config extends \Ilch\Config\Install
                   `creator_id` INT(10) NOT NULL,
                   `date_created` DATETIME NOT NULL,
                   `forum_id` INT(11) NOT NULL,
-                  `type` INT(11) NOT NULL DEFAULT 0,
-                  `status` INT(11) NOT NULL DEFAULT 0,
+                  `type` TINYINT(1) NOT NULL DEFAULT 0,
+                  `status` TINYINT(1) NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
 

--- a/application/modules/gallery/config/config.php
+++ b/application/modules/gallery/config/config.php
@@ -56,7 +56,7 @@ class Config extends \Ilch\Config\Install
                   `gallery_id` INT(11) NOT NULL DEFAULT 0,
                   `sort` INT(11) NULL DEFAULT 0,
                   `parent_id` INT(11) NULL DEFAULT 0,
-                  `type` INT(11) NOT NULL,
+                  `type` TINYINT(1) NOT NULL,
                   `title` VARCHAR(255) NOT NULL,
                   `description` VARCHAR(255) NOT NULL,
                   PRIMARY KEY (`id`)

--- a/application/modules/guestbook/config/config.php
+++ b/application/modules/guestbook/config/config.php
@@ -50,7 +50,7 @@ class Config extends \Ilch\Config\Install
                   `datetime` DATETIME NOT NULL,
                   `homepage` VARCHAR(32) NOT NULL,
                   `name` VARCHAR(255) NOT NULL,
-                  `setfree` INT(11) NOT NULL DEFAULT 0,
+                  `setfree` TINYINT(1) NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;';
     }

--- a/application/modules/jobs/config/config.php
+++ b/application/modules/jobs/config/config.php
@@ -55,7 +55,7 @@ class Config extends \Ilch\Config\Install
                   `title` VARCHAR(150) NOT NULL,
                   `text` MEDIUMTEXT NOT NULL,
                   `email` VARCHAR(100) NOT NULL,
-                  `show` INT(11) NOT NULL,
+                  `show` TINYINT(1) NOT NULL,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;';
     }

--- a/application/modules/jobs/controllers/admin/Index.php
+++ b/application/modules/jobs/controllers/admin/Index.php
@@ -95,7 +95,8 @@ class Index extends \Ilch\Controller\Admin
             $validation = Validation::create($post, [
                 'title' => 'required',
                 'text' => 'required',
-                'email' => 'required|email'
+                'email' => 'required|email',
+                'show' => 'required|numeric|integer|min:0|max:1'
             ]);
 
             if ($validation->isValid()) {

--- a/application/modules/partner/config/config.php
+++ b/application/modules/partner/config/config.php
@@ -64,7 +64,7 @@ class Config extends \Ilch\Config\Install
                   `name` VARCHAR(100) NOT NULL,
                   `banner` VARCHAR(255) NOT NULL,
                   `link` VARCHAR(255) NOT NULL,
-                  `setfree` INT(11) NOT NULL DEFAULT 0,
+                  `setfree` TINYINT(1) NOT NULL DEFAULT 0,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
         

--- a/application/modules/privacy/config/config.php
+++ b/application/modules/privacy/config/config.php
@@ -37,7 +37,7 @@ class Config extends \Ilch\Config\Install
                   `urltitle` VARCHAR(255) NOT NULL,
                   `url` VARCHAR(255) NOT NULL,
                   `text` MEDIUMTEXT NOT NULL,
-                  `show` INT(11) NOT NULL,
+                  `show` TINYINT(1) NOT NULL,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
 

--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -114,12 +114,12 @@ class Config extends \Ilch\Config\Install
                   `birthday` DATE NULL DEFAULT NULL,
                   `avatar` VARCHAR(255) NOT NULL DEFAULT "",
                   `signature` VARCHAR(255) NOT NULL DEFAULT "",
-                  `opt_mail` INT(11) DEFAULT 1,
-                  `opt_gallery` INT(11) DEFAULT 1,
+                  `opt_mail` TINYINT(1) DEFAULT 1,
+                  `opt_gallery` TINYINT(1) DEFAULT 1,
                   `date_created` DATETIME NOT NULL,
                   `date_confirmed` DATETIME NULL DEFAULT NULL,
                   `date_last_activity` DATETIME NULL DEFAULT NULL,
-                  `confirmed` INT(11) DEFAULT 1,
+                  `confirmed` TINYINT(1) DEFAULT 1,
                   `confirmed_code` VARCHAR(255) NULL DEFAULT NULL,
                   `selector` char(18),
                   PRIMARY KEY (`id`)
@@ -149,7 +149,7 @@ class Config extends \Ilch\Config\Install
                 CREATE TABLE IF NOT EXISTS `[prefix]_profile_fields` (
                   `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
                   `name` VARCHAR(255) NOT NULL,
-                  `type` INT(11) NOT NULL,
+                  `type` TINYINT(1) NOT NULL,
                   `position` INT(11) UNSIGNED NOT NULL,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
@@ -178,10 +178,10 @@ class Config extends \Ilch\Config\Install
                 CREATE TABLE IF NOT EXISTS `[prefix]_users_dialog_reply` (
                   `cr_id` INT(11) NOT NULL AUTO_INCREMENT,
                   `reply` TEXT,
-                  `user_id_fk` INT(11) unsigned NOT NULL,
+                  `user_id_fk` INT(11) UNSIGNED NOT NULL,
                   `c_id_fk` INT(11) NOT NULL,
                   `time` DATETIME NOT NULL,
-                  `read` INT(11) DEFAULT 0,
+                  `read` TINYINT(1) DEFAULT 0,
                   PRIMARY KEY (`cr_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
 
@@ -213,7 +213,7 @@ class Config extends \Ilch\Config\Install
                   `gallery_id` INT(11) NOT NULL DEFAULT 0,
                   `sort` INT(11) NOT NULL DEFAULT 0,
                   `parent_id` INT(11) NOT NULL DEFAULT 0,
-                  `type` INT(11) NOT NULL,
+                  `type` TINYINT(1) NOT NULL,
                   `title` VARCHAR(255) NOT NULL,
                   `description` VARCHAR(255) NOT NULL,
                   PRIMARY KEY (`id`)


### PR DESCRIPTION
"For optimum storage, you should try to use the most precise type in all
cases."
https://dev.mysql.com/doc/refman/5.7/en/choosing-types.html

awards
[prefix]_awards
Possible values: 1 or 2
`typ` TINYINT(1) NOT NULL,

events
[prefix]_events
Possible values: 0 or 1
`show` TINYINT(1) NOT NULL,
[prefix]_events_entrants
Possible values: 1 or 2
`status` TINYINT(1) NOT NULL

forum
[prefix]_forum_items
Possible values: 0 or 1
`type` TINYINT(1) NOT NULL,
[prefix]_forum_topics
`type` TINYINT(1) NOT NULL DEFAULT 0,
Possible values: 0 or 1
`status` TINYINT(1) NOT NULL DEFAULT 0,
Possible values: 0 or 1

gallery
[prefix]_gallery_items
Possible values: 0 or 1
`type` TINYINT(1) NOT NULL,

guestbook
[prefix]_gbook
Possible values: 0 or 1
`setfree` TINYINT(1) NOT NULL DEFAULT 0,

jobs
[prefix]_jobs
Possible values: 0 or 1
`show` TINYINT(1) NOT NULL,

admin
[prefix]_menu_items
Possible values: 0, 1, 2, 3 or 4
`type` TINYINT(1) NOT NULL,

partner
[prefix]_partners
Possible values: 0 or 1
`setfree` TINYINT(11) NOT NULL DEFAULT 0,

privacy
[prefix]_privacy
Possible values: 0 or 1
`show` TINYINT(1) NOT NULL,

user
[prefix]_users
Possible values: 0 or 1
`opt_mail` TINYINT(1) DEFAULT 1,
Possible values: 0 or 1
`opt_gallery` TINYINT(1) DEFAULT 1,
Possible values: 0 or 1
`confirmed` TINYINT(1) DEFAULT 1,
[prefix]_profile_fields
Possible values: 0 or 1
`type` TINYINT(1) NOT NULL,
[prefix]_users_dialog_reply
Possible values: 0 or 1
`read` TINYINT(1) DEFAULT 0,
[prefix]_users_gallery_items
Possible values: 0 or 1
`type` TINYINT(1) NOT NULL,