### PR TITLE
Exists validator

### DIFF
--- a/application/libraries/Ilch/Validation.php
+++ b/application/libraries/Ilch/Validation.php
@@ -17,6 +17,7 @@ use Ilch\Validation\Validators\Same;
 use Ilch\Validation\Validators\Size;
 use Ilch\Validation\Validators\Unique;
 use Ilch\Validation\Validators\Url;
+use Ilch\Validation\Validators\Exists;
 use stdClass;
 use Ilch\Validation\ErrorBag;
 
@@ -31,38 +32,18 @@ class Validation
      * @var array
      */
     protected static $builtInValidators = [
-        // Usage: required
-        'required' => Required::class,
-
-        // Usage: same:<field_name>[,strict]
-        'same' => Same::class,
-
-        // Usage: captcha
         'captcha' => Captcha::class,
-
-        // Usage: url
-        'url' => Url::class,
-
-        // Usage: email
         'email' => Email::class,
-
-        // Usage: unique:<table_name>[,<column_name>,<ignoreId>,<ignoreIdColumn>]
-        'unique' => Unique::class,
-
-        // Usage: numeric
-        'numeric' => Numeric::class,
-
-        // Usage: integer
+        'exists' => Exists::class,
         'integer' => Integer::class,
-
-        // Usage: size:<value>[,string]
-        'size' => Size::class,
-
-        // Usage: min:<value>[,string]
-        'min' => Min::class,
-
-        // Usage: max:<value>[,string]
         'max' => Max::class,
+        'min' => Min::class,
+        'numeric' => Numeric::class,
+        'required' => Required::class,
+        'same' => Same::class,
+        'size' => Size::class,
+        'unique' => Unique::class,
+        'url' => Url::class,
     ];
 
     /**

--- a/application/libraries/Ilch/Validation/Validators/Exists.php
+++ b/application/libraries/Ilch/Validation/Validators/Exists.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * @copyright Ilch 2.0
+ */
+
+namespace Ilch\Validation\Validators;
+
+use \Ilch\Registry;
+
+/**
+ * Exists validation class.
+ */
+class Exists extends Base
+{
+    /**
+     * Default error key for this validator.
+     *
+     * @var string
+     */
+    protected $errorKey = 'validation.errors.exists.resourceNotFound';
+
+    /**
+     * Minimum parameter count needed.
+     *
+     * @var int
+     */
+    protected $minParams = 1;
+
+    /**
+     * Select instance
+     *
+     * @var Ilch\Database\Mysql\Select
+     */
+    protected $query;
+
+    /**
+     * Runs the validation.
+     *
+     * @return self
+     */
+    public function run()
+    {
+        if (empty($this->getValue())) {
+            $this->setIsValid(true);
+
+            return $this;
+        }
+
+        $this->query = Registry::get('db')->select();
+
+        // exists:table,column,wherecolumn1,wherecolumn1value,...
+        $column = is_null($this->getParameter(1)) ? 'id' : $this->getParameter(1);
+
+        $this->query->fields($column);
+        $this->query->from($this->getParameter(0));
+        $this->query->andWhere([$column => $this->getValue()]);
+
+        if ($this->hasConditions()) {
+            $this->setConditions();
+        }
+
+        $result = $this->query->execute();
+
+        $this->setIsValid($result->getNumRows() > 0);
+
+        return $this;
+    }
+
+    /**
+     * Appends the conditions returned from getConditions() to the query
+     */
+    protected function setConditions()
+    {
+        $conditions = $this->getConditions();
+
+        if (count($conditions) % 2 !== 0) {
+            throw new \InvalidArgumentException(get_class($this).': Wrong parameter count.');
+        }
+
+        $chunks = array_chunk($conditions, 2);
+        $conditions = array();
+
+        foreach ($chunks as $chunk) {
+            $this->query->andWhere([$chunk[0] => $chunk[1]]);
+        }
+    }
+
+    /**
+     * Returns true if there are conditions in the rule definition
+     *
+     * @return boolean
+     */
+    protected function hasConditions()
+    {
+        return count($this->getParameters()) > 2;
+    }
+
+    /**
+     * Returns an array with all condition parameters.
+     *
+     * @return array
+     */
+    protected function getConditions()
+    {
+        return array_slice($this->getParameters(), 2);
+    }
+}

--- a/application/libraries/Ilch/Validation/Validators/Exists.php
+++ b/application/libraries/Ilch/Validation/Validators/Exists.php
@@ -40,7 +40,7 @@ class Exists extends Base
      */
     public function run()
     {
-        if (empty($this->getValue())) {
+        if (empty($this->getValue()) && $this->getValue() !== 0 && $this->getValue() !== "0") {
             $this->setIsValid(true);
 
             return $this;
@@ -48,7 +48,6 @@ class Exists extends Base
 
         $this->query = Registry::get('db')->select();
 
-        // exists:table,column,wherecolumn1,wherecolumn1value,...
         $column = is_null($this->getParameter(1)) ? 'id' : $this->getParameter(1);
 
         $this->query->fields($column);


### PR DESCRIPTION
Bitte mal noch testen.

Hab es testhalber mal beim War-Modul eingefügt:

```php
'warEnemy' => 'required',
'warGroup' => 'required',
```

zu

```php
'warEnemy' => 'required|exists:war_enemy',
'warGroup' => 'required|exists:war_groups',
```

**Anwendung:**
```
exists:tableName[,column, another_column, another_column_value, ...]

```

**Notwendig:**
**_tableName_:** Tabellenname ohne Prefix

**Optional:**
**_column_:** Standardmäßig wird hier die `id` column geprüft (d.h. `id` muss dem Wert des Formularfeldes entsprechen).

**_another_column_ und _another_column_value_:** Hier können nun beliebig viele WHERE-Conditions hinzugefügt werden. Alle Bedingungen werden mit AND verknüpft. Für komplexere Sachverhalte muss ein eigener Validator erstellt werden.

_Beispiele:_ 
`email,example@email.com` entspricht `email = 'example@email.com'`
`size >, 5` entspricht `size > 5`
`email !=,example@email.com` entspricht `email != 'example@email.com'`
