### PR TITLE
Check dependencies in install-module

### DIFF
--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -532,6 +532,7 @@ class Index extends \Ilch\Controller\Frontend
             $configClass = '\\Modules\\'.ucfirst($key).'\\Config\\Config';
             $config = new $configClass($this->getTranslator());
             $modules[$key]['config'] = $config;
+            $dependencies[$key] = $config->config['depends'];
 
             if (in_array($type, $module['types'])) {
                 $modules[$key]['checked'] = true;
@@ -545,6 +546,7 @@ class Index extends \Ilch\Controller\Frontend
 
         $this->getView()->set('modulesToInstall', $modulesToInstall);
         $this->getView()->set('modules', $modules);
+        $this->getView()->set('dependencies', $dependencies);
     }
 
     public function finishAction()

--- a/application/modules/install/translations/de.php
+++ b/application/modules/install/translations/de.php
@@ -61,4 +61,5 @@ return [
     'optionalModules' => 'Optionale Module',
     'private' => 'Private Seite',
     'clan' => 'Clan Seite',
+    'dependencyMessage' => 'Es wurden weitere Module ausgewählt, um Abhängigkeiten zu erfüllen.',
 ];

--- a/application/modules/install/translations/en.php
+++ b/application/modules/install/translations/en.php
@@ -61,4 +61,5 @@ return [
     'optionalModules' => 'optionally modules',
     'private' => 'private site',
     'clan' => 'clan site',
+    'dependencyMessage' => 'Other modules were selected to fullfill dependencies.',
 ];

--- a/application/modules/install/views/index/ajaxconfig.php
+++ b/application/modules/install/views/index/ajaxconfig.php
@@ -12,6 +12,7 @@
     <?php endforeach; ?>
     <span class="clearfix"></span>
     <br><b><i><?=$this->getTrans('optionalModules') ?>:</i></b><br><br>
+    <div class="alert alert-info hidden" id="dependencyMessage"></div>
     <?php foreach ($this->get('modules') as $key => $module): ?>
         <?php if (!isset($module['config']->config['system_module'])): ?>
             <div class="col-lg-4 col-md-3 col-sm-3">
@@ -26,3 +27,28 @@
         <?php endif; ?>
     <?php endforeach; ?>
 </div>
+
+<script>
+var dependencies = <?=json_encode($this->get('dependencies')) ?>;
+
+$(function() {
+    var dependencyFound = false;
+    // Go through all dependencies when any checkbox is clicked
+    $("input:checkbox").change(function() {
+        $.each(dependencies, function(k, v) {
+            $.each(v, function(i, e) {
+                // If any dependency is checked, then the current item needs to be checked, too
+                if ($("#module_"+k + ":checked").length) {
+                    dependencyFound = true;
+                    $("#module_"+i).prop('checked', true);
+                }
+            });
+        });
+
+        if (dependencyFound) {
+            document.getElementById('dependencyMessage').innerHTML = "<?=$this->getTrans('dependencyMessage') ?>";
+            $("#dependencyMessage").removeClass("hidden");
+        }
+    });
+});
+</script>


### PR DESCRIPTION
**Example:**
Module A depends on module B.
If module A gets selected then select module B, too.
It is impossible to deselect module B if module A is still selected.

Currently the detailed dependency (like the version of the war-module must be >=,1.0) is not checked.
