### PR TITLE
Remove unnecessary js language attributes

### DIFF
--- a/application/layouts/clan3columns/index.php
+++ b/application/layouts/clan3columns/index.php
@@ -6,7 +6,7 @@
         <link href="<?=$this->getVendorUrl('twbs/bootstrap/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getLayoutUrl('style.css') ?>" rel="stylesheet">
         <?=$this->getCustomCSS() ?>
-        <script type="text/javascript" src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
+        <script src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
     </head>
     <body>
         <header>

--- a/application/layouts/clan3columns/index_full.php
+++ b/application/layouts/clan3columns/index_full.php
@@ -6,7 +6,7 @@
         <link href="<?=$this->getVendorUrl('twbs/bootstrap/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getLayoutUrl('style.css') ?>" rel="stylesheet">
         <?=$this->getCustomCSS() ?>
-        <script type="text/javascript" src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
+        <script src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
     </head>
     <body>
         <header>

--- a/application/libraries/Ilch/Layout/Frontend.php
+++ b/application/libraries/Ilch/Layout/Frontend.php
@@ -181,12 +181,12 @@ class Frontend extends Base
                 <link href="'.$this->getVendorUrl('fortawesome/font-awesome/css/font-awesome.min.css').'" rel="stylesheet">
                 <link href="'.$this->getStaticUrl('css/ilch.css').'" rel="stylesheet">
                 <link href="'.$this->getVendorUrl('components/jqueryui/themes/ui-lightness/jquery-ui.min.css').'" rel="stylesheet">
-                <script type="text/javascript" src="'.$this->getVendorUrl('components/jquery/jquery.min.js').'"></script>
-                <script type="text/javascript" src="'.$this->getVendorUrl('components/jqueryui/jquery-ui.min.js').'"></script>
-                <script type="text/javascript" src="'.$this->getVendorUrl('ckeditor/ckeditor/ckeditor.js').'"></script>
-                <script type="text/javascript" src="'.$this->getStaticUrl('js/ilch.js').'"></script>
-                <script type="text/javascript" src="'.$this->getStaticUrl('js/jquery.mjs.nestedSortable.js').'"></script>
-                <script type="text/javascript" src="'.$this->getStaticUrl('../application/modules/admin/static/js/functions.js').'"></script>';
+                <script src="'.$this->getVendorUrl('components/jquery/jquery.min.js').'"></script>
+                <script src="'.$this->getVendorUrl('components/jqueryui/jquery-ui.min.js').'"></script>
+                <script src="'.$this->getVendorUrl('ckeditor/ckeditor/ckeditor.js').'"></script>
+                <script src="'.$this->getStaticUrl('js/ilch.js').'"></script>
+                <script src="'.$this->getStaticUrl('js/jquery.mjs.nestedSortable.js').'"></script>
+                <script src="'.$this->getStaticUrl('../application/modules/admin/static/js/functions.js').'"></script>';
 
         $html .= $this->header();
 
@@ -219,7 +219,7 @@ class Frontend extends Base
                         })});
                         </script>
                         <link rel="stylesheet" type="text/css" href="'.$this->getStaticUrl('js/cookieconsent/cookieconsent.min.css').'" />
-                        <script type="text/javascript" src="'.$this->getStaticUrl('js/cookieconsent/cookieconsent.min.js').'"></script>';
+                        <script src="'.$this->getStaticUrl('js/cookieconsent/cookieconsent.min.js').'"></script>';
         }
 
         return $html;

--- a/application/libraries/Ilch/Layout/Helper/Header/Model.php
+++ b/application/libraries/Ilch/Layout/Helper/Header/Model.php
@@ -51,7 +51,7 @@ class Model
      */
     public function js($value)
     {
-        $this->data[] = '<script type="text/javascript" src="'.$this->layout->getModuleUrl($value).'"></script>';
+        $this->data[] = '<script src="'.$this->layout->getModuleUrl($value).'"></script>';
 
         return $this;
     }

--- a/application/modules/admin/layouts/index.php
+++ b/application/modules/admin/layouts/index.php
@@ -43,7 +43,7 @@
         <script src="<?=$this->getVendorUrl('ckeditor/ckeditor/ckeditor.js') ?>"></script>
         <script src="<?=$this->getStaticUrl('js/ilch.js') ?>"></script>
         <script src="<?=$this->getStaticUrl('js/jquery.key.js') ?>"></script>
-	<script type="text/javascript">
+	<script>
         $.key('alt+a', function() { window.location.href ='<?=$this->getUrl(['module' => 'article', 'controller' => 'index', 'action' => 'index']) ?>'; });
         $.key('alt+u', function() { window.location.href ='<?=$this->getUrl(['module' => 'user', 'controller' => 'index', 'action' => 'index']) ?>'; });
         $.key('alt+s', function() { window.location.href ='<?=$this->getUrl(['module' => 'admin', 'controller' => 'settings', 'action' => 'index']) ?>'; });

--- a/application/modules/admin/views/admin/layouts/show.php
+++ b/application/modules/admin/views/admin/layouts/show.php
@@ -147,8 +147,8 @@ foreach ($layouts as $layout): ?>
     <?php endif; ?>
 <?php endforeach; ?>
 
-<script src="<?=$this->getVendorUrl('kartik-v/bootstrap-star-rating/js/star-rating.min.js') ?>" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="<?=$this->getVendorUrl('kartik-v/bootstrap-star-rating/js/star-rating.min.js') ?>"></script>
+<script>
 $(document).ready(function(){
     $('#layout-search-carousel').carousel();
 });

--- a/application/modules/admin/views/admin/modules/show.php
+++ b/application/modules/admin/views/admin/modules/show.php
@@ -246,8 +246,8 @@ foreach ($modules as $module): ?>
     <?php endif; ?>
 <?php endforeach; ?>
 
-<script src="<?=$this->getVendorUrl('kartik-v/bootstrap-star-rating/js/star-rating.min.js') ?>" type="text/javascript"></script>
-<script type="text/javascript">
+<script src="<?=$this->getVendorUrl('kartik-v/bootstrap-star-rating/js/star-rating.min.js') ?>"></script>
+<script>
 $(document).ready(function(){
     $('#module-search-carousel').carousel();
 });

--- a/application/modules/admin/views/admin/settings/customcss.php
+++ b/application/modules/admin/views/admin/settings/customcss.php
@@ -19,24 +19,24 @@
     <?=$this->getSaveBar() ?>
 </form>
 
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/codemirror.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/mode/css/css.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/keymap/sublime.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/selection/active-line.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/comment/comment.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/comment/continuecomment.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/hint/show-hint.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/hint/css-hint.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/edit/closebrackets.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/edit/matchbrackets.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/display/placeholder.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/display/fullscreen.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/display/palette.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/fold/foldgutter.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/fold/foldcode.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/fold/brace-fold.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getModuleUrl('static/js/codemirror/addon/fold/comment-fold.js') ?>"></script>
-<script type="text/javascript">
+<script src="<?=$this->getModuleUrl('static/js/codemirror/codemirror.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/mode/css/css.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/keymap/sublime.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/selection/active-line.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/comment/comment.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/comment/continuecomment.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/hint/show-hint.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/hint/css-hint.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/edit/closebrackets.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/edit/matchbrackets.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/display/placeholder.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/display/fullscreen.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/display/palette.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/fold/foldgutter.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/fold/foldcode.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/fold/brace-fold.js') ?>"></script>
+<script src="<?=$this->getModuleUrl('static/js/codemirror/addon/fold/comment-fold.js') ?>"></script>
+<script>
 var editor = CodeMirror.fromTextArea(document.getElementById("customCSS"), {
     lineNumbers: true,
     autoCloseBrackets: true,

--- a/application/modules/admin/views/admin/settings/maintenance.php
+++ b/application/modules/admin/views/admin/settings/maintenance.php
@@ -59,11 +59,11 @@
 </form>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>'); ?>
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
 <?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
-    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
+    <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     $(".form_datetime").datetimepicker({
         format: 'dd.mm.yyyy hh:ii',

--- a/application/modules/awards/views/admin/index/treat.php
+++ b/application/modules/awards/views/admin/index/treat.php
@@ -143,11 +143,11 @@ if ($awards != '') {
     <?php endif; ?>
 </form>
 
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
 <?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
-    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
+    <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     $(".form_datetime").datetimepicker({
         format: "dd.mm.yyyy",

--- a/application/modules/away/views/index/index.php
+++ b/application/modules/away/views/index/index.php
@@ -186,11 +186,11 @@ if ($this->getUser()) {
     </form>
 <?php endif; ?>
 
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
 <?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
-    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
+    <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     $(".form_datetime").datetimepicker({
         format: "dd.mm.yyyy",

--- a/application/modules/calendar/views/admin/index/treat.php
+++ b/application/modules/calendar/views/admin/index/treat.php
@@ -99,12 +99,12 @@
 </form>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>'); ?>
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/jscolor/jscolor.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/jscolor/jscolor.js') ?>"></script>
+<script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
 <?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
-    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
+    <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
-<script type="text/javascript">
+<script>
 <?=$this->getMedia()
     ->addMediaButton($this->getUrl('admin/media/iframe/index/type/single/'))
     ->addUploadController($this->getUrl('admin/media/index/upload'))

--- a/application/modules/cookieconsent/views/admin/settings/index.php
+++ b/application/modules/cookieconsent/views/admin/settings/index.php
@@ -103,4 +103,4 @@
     <?=$this->getSaveBar() ?>
 </form>
 
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/jscolor/jscolor.js') ?>"></script>
+<script src="<?=$this->getStaticUrl('js/jscolor/jscolor.js') ?>"></script>

--- a/application/modules/events/views/index/treat.php
+++ b/application/modules/events/views/index/treat.php
@@ -183,14 +183,14 @@
 </form>
 
 <?=$this->getDialog("smiliesModal", $this->getTrans('smilies'), "<iframe frameborder='0'></iframe>"); ?>
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
 <?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
-    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
+    <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
 <?php if ($this->get('event_google_maps_api_key') != ''): ?>
     <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=<?=$this->get('event_google_maps_api_key') ?>&libraries=places&region=<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>"></script>
 <?php endif; ?>
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     $(".form_datetime").datetimepicker({
         format: "dd.mm.yyyy hh:ii",

--- a/application/modules/events/views/show/event.php
+++ b/application/modules/events/views/show/event.php
@@ -233,7 +233,7 @@ $user = $userMapper->getUserById($event->getUserId());
     <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=<?=$this->get('event_google_maps_api_key') ?>" async defer></script>
 <?php endif; ?>
 
-<script type="text/javascript">
+<script>
 // Textarea AutoResize
 $('textarea').on('keyup', function() {
     $(this).css('height', 'auto');

--- a/application/modules/forum/views/showtopics/index.php
+++ b/application/modules/forum/views/showtopics/index.php
@@ -181,7 +181,7 @@ if ($this->getUser()) {
                     <button class="btn btn-primary" name="topicMove" value="topicMove" OnClick="SetAction2()"><?=$this->getTrans('topicMove') ?></button>
                     <button class="btn btn-primary" name="topicChangeStatus" value="topicChangeStatus" OnClick="SetAction3()"><?=$this->getTrans('topicChangeStatus') ?></button>
 
-                    <script type="text/javascript">
+                    <script>
                         function SetAction1() {
                             document.forms["editForm"].action = "<?=$this->getUrl(['controller' => 'showtopics', 'action' => 'delete', 'forumid' => $forum->getId()]) ?>";
                         }

--- a/application/modules/history/views/admin/index/treat.php
+++ b/application/modules/history/views/admin/index/treat.php
@@ -110,12 +110,12 @@ if ($history != '') {
 </form>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>'); ?>
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/jscolor/jscolor.js') ?>"></script>
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/jscolor/jscolor.js') ?>"></script>
+<script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
 <?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
-    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
+    <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     $(".form_datetime").datetimepicker({
         format: "dd.mm.yyyy",

--- a/application/modules/install/views/index/connect.php
+++ b/application/modules/install/views/index/connect.php
@@ -55,7 +55,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 $(function () {
     $("[rel='tooltip']").tooltip({
         'placement': 'bottom',

--- a/application/modules/media/views/admin/iframe/index.php
+++ b/application/modules/media/views/admin/iframe/index.php
@@ -99,7 +99,7 @@
     </script>
 <?php endif; ?>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function()
 {
     function media_loader() 

--- a/application/modules/media/views/admin/iframe/indexckeditor.php
+++ b/application/modules/media/views/admin/iframe/indexckeditor.php
@@ -89,7 +89,7 @@
     </script>
 <?php endif; ?>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function()
 {
     function media_loader() 

--- a/application/modules/media/views/admin/iframe/multi.php
+++ b/application/modules/media/views/admin/iframe/multi.php
@@ -137,7 +137,7 @@
     </script>
 <?php endif; ?>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     function media_loader() { 
         var ID=$(".media_loader:last").attr("id");

--- a/application/modules/partner/boxes/views/partner.php
+++ b/application/modules/partner/boxes/views/partner.php
@@ -49,7 +49,7 @@
     <?php endif; ?>
 <?php endif; ?>
 
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/jquery.bxslider/jquery.bxslider.min.js') ?>"></script>
+<script src="<?=$this->getStaticUrl('js/jquery.bxslider/jquery.bxslider.min.js') ?>"></script>
 <script>
 $('.bxslider').bxSlider({
     mode: 'vertical',

--- a/application/modules/shoutbox/boxes/views/shoutbox.php
+++ b/application/modules/shoutbox/boxes/views/shoutbox.php
@@ -1,4 +1,4 @@
-<script type="text/javascript" >
+<script >
 $(function() {
     var $shoutboxContainer = $('#shoutbox-container'),
         showForm = function() {

--- a/application/modules/smilies/views/admin/iframe/smilies.php
+++ b/application/modules/smilies/views/admin/iframe/smilies.php
@@ -17,7 +17,7 @@
     <?=$this->getTrans('noSmilies') ?>
 <?php endif; ?>
 
-<script type="text/javascript">
+<script>
 $(".image").click(function() {
     window.top.$('#selectedImage<?=$this->getRequest()->getParam('input') ?>').val($(this).data('url'));
     window.top.$('#mediaModal').modal('hide');

--- a/application/modules/statistic/views/index/index.php
+++ b/application/modules/statistic/views/index/index.php
@@ -445,8 +445,8 @@ $osStatistic = $this->get('osStatistic');
 </div>
 <?php endif; ?>
 
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/bootstrap-progressbar.js') ?>"></script>
-<script type="text/javascript">
+<script src="<?=$this->getStaticUrl('js/bootstrap-progressbar.js') ?>"></script>
+<script>
 $(document).ready(function() {
     $('.progress .progress-bar').progressbar();
 });

--- a/application/modules/statistic/views/index/show.php
+++ b/application/modules/statistic/views/index/show.php
@@ -482,8 +482,8 @@ $browser = $this->getRequest()->getParam('browser');
     </div>
 <?php endif; ?>
 
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/bootstrap-progressbar.js') ?>"></script>
-<script type="text/javascript">
+<script src="<?=$this->getStaticUrl('js/bootstrap-progressbar.js') ?>"></script>
+<script>
 $(document).ready(function() {
     $('.progress .progress-bar').progressbar();
 });

--- a/application/modules/training/views/admin/index/treat.php
+++ b/application/modules/training/views/admin/index/treat.php
@@ -209,11 +209,11 @@
 </form>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>'); ?>
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
 <?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
-    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
+    <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     $(".form_datetime").datetimepicker({
         format: "dd.mm.yyyy hh:ii",

--- a/application/modules/user/boxes/views/login.php
+++ b/application/modules/user/boxes/views/login.php
@@ -63,7 +63,7 @@
     <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'login', 'action' => 'forgotpassword']) ?>"><?=$this->getTrans('forgotPassword') ?></a>
 <?php endif; ?>
 
-<script type="text/javascript" >
+<script>
 $(document).ready(function () {
     var messageDiv = $(".ilch--new-message"),
         messageCheckLink = "<?=$this->getUrl(['module' => 'user', 'controller' => 'ajax','action' => 'checknewmessage']); ?>";

--- a/application/modules/user/views/iframe/multi.php
+++ b/application/modules/user/views/iframe/multi.php
@@ -56,7 +56,7 @@
     <?php endif; ?>
 </form>
 
-<script type="text/javascript">
+<script>
 $(".btn").click(function() {
     window.top.$('#mediaModal').modal('hide');
     window.top.reload();

--- a/application/modules/user/views/panel/dialog.php
+++ b/application/modules/user/views/panel/dialog.php
@@ -137,7 +137,7 @@
 </div>
 
 <script src="<?=$this->getModuleUrl('static/js/jquery.nicescroll.js') ?>"></script>
-<script type="text/javascript">
+<script>
     $(function(){
         $(".chat-list-wrapper, .message-list-wrapper").niceScroll();
     });

--- a/application/modules/user/views/panel/navi.php
+++ b/application/modules/user/views/panel/navi.php
@@ -44,7 +44,7 @@ function getTransKey($usermenuId) {
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function(){
     $(".push-menu").click(function(){
         $(".profile-sidebar").toggleClass("active");

--- a/application/modules/user/views/panel/profile.php
+++ b/application/modules/user/views/panel/profile.php
@@ -201,11 +201,11 @@ $birthday = new \Ilch\Date($profil->getBirthday());
     </div>
 </div>
 
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
 <?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
-    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
+    <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     $(".form_datetime").datetimepicker({
         endDate: new Date(),

--- a/application/modules/war/views/admin/index/treat.php
+++ b/application/modules/war/views/admin/index/treat.php
@@ -267,11 +267,11 @@
 <?php endif; ?>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>'); ?>
-<script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
 <?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
-    <script type="text/javascript" src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
+    <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
-<script type="text/javascript">
+<script>
 $(document).ready(function()
 {
     $(".form_datetime").datetimepicker({

--- a/license.html
+++ b/license.html
@@ -4,7 +4,7 @@
  
  <title>GNU General Public License v3.0 - GNU Project - Free Software Foundation (FSF)</title>
  <link rel="alternate" type="application/rdf+xml" href="http://www.gnu.org/licenses/gpl-3.0.rdf"> 
-<script type="text/javascript">try {
+<script>try {
 window.AG_onLoad = function(func) { if (window.addEventListener) { window.addEventListener('DOMContentLoaded', func); } };
 window.AG_removeElementById = function(id) { var element = document.getElementById(id); if (element && element.parentNode) { element.parentNode.removeChild(element); }};
 window.AG_removeElementBySelector = function(selector) { if (!document.querySelectorAll) { return; } var nodes = document.querySelectorAll(selector); if (nodes) { for (var i = 0; i < nodes.length; i++) { if (nodes[i] && nodes[i].parentNode) { nodes[i].parentNode.removeChild(nodes[i]); } } } };

--- a/static/js/datetimepicker/README.md
+++ b/static/js/datetimepicker/README.md
@@ -652,5 +652,5 @@ Right-to-left languages may also include `rtl: true` to make the calendar displa
 If your browser (or those of your users) is displaying characters wrong, chances are the browser is loading the javascript file with a non-unicode encoding.  Simply add `charset="UTF-8"` to your `script` tag:
 
 ```html
-<script type="text/javascript" src="bootstrap-datetimepicker.de.js" charset="UTF-8"></script>
+<script src="bootstrap-datetimepicker.de.js" charset="UTF-8"></script>
 ```


### PR DESCRIPTION
„W3C did not adopt the language attribute, favoring instead a type
attribute which takes a MIME type. Unfortunately, the MIME type was not
standardized, so it is sometimes "text/javascript" or
"application/ecmascript" or something else. Fortunately, all browsers
will always choose JavaScript as the default programming language, so
it is always best to simply write <script>. It is smallest, and it
works on the most browsers.“