### PR TITLE
Warmodul: Fehler durch BBCode parsing

### DIFF
--- a/application/modules/war/views/index/show.php
+++ b/application/modules/war/views/index/show.php
@@ -179,7 +179,7 @@ $acceptCheckArray = $this->get('acceptCheck');
                 <h3 class="panel-title"><?=$this->getTrans('warReport') ?></h3>
             </div>
             <div class="panel-body">
-                <?=nl2br($this->getHtmlFromBBCode($war->getWarReport())) ?>
+                <?=$war->getWarReport() ?>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Dadurch das die Ausgabe über den BBCode parser läuft (im Admin aber der normale ckEditor genutzt wird), entstehen 2 Zeilenumbrüche zuviel in jedem p-tag.