### PR TITLE
Advanced layout settings

### DIFF
--- a/application/libraries/Ilch/Controller/Frontend.php
+++ b/application/libraries/Ilch/Controller/Frontend.php
@@ -5,6 +5,8 @@
 
 namespace Ilch\Controller;
 
+use Ilch\Registry;
+
 class Frontend extends Base
 {
     public function __construct(\Ilch\Layout\Base $layout, \Ilch\View $view, \Ilch\Request $request, \Ilch\Router $router, \Ilch\Translator $translator)
@@ -88,7 +90,10 @@ class Frontend extends Base
 
             $this->getLayout()->setFile('layouts/'.$layoutKey.'/'.$layoutFile, $layoutKey);
 
-            $this->getLayout()->loadSettings();
+            if (Registry::has('db')) {
+                // CMS is installed. Load possibly existing layout settings.
+                $this->getLayout()->loadSettings();
+            }
         }
     }
 }

--- a/application/libraries/Ilch/Controller/Frontend.php
+++ b/application/libraries/Ilch/Controller/Frontend.php
@@ -53,10 +53,10 @@ class Frontend extends Base
                             $url[$paramKey] = '';
                         }
 
-                        if ($url['module'] == $this->getRequest()->getModuleName()) {
-                            if ($url['controller'] == $this->getRequest()->getControllerName()) {
-                                if ($url['action'] == $this->getRequest()->getActionName()) {
-                                    if ($url[$paramKey] == $this->getRequest()->getParam($paramKey)) {
+                        if ($url['module'] === $this->getRequest()->getModuleName()) {
+                            if ($url['controller'] === $this->getRequest()->getControllerName()) {
+                                if ($url['action'] === $this->getRequest()->getActionName()) {
+                                    if ($url[$paramKey] === $this->getRequest()->getParam($paramKey)) {
                                         $layoutFile = $layoutKeyConfig;
                                         break;
                                     }
@@ -87,6 +87,8 @@ class Frontend extends Base
             }
 
             $this->getLayout()->setFile('layouts/'.$layoutKey.'/'.$layoutFile, $layoutKey);
+
+            $this->getLayout()->loadSettings();
         }
     }
 }

--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -272,7 +272,22 @@ abstract class Base
     public function getTrans($key)
     {
       $args = func_get_args();
-      return call_user_func_array([$this->getTranslator(), 'trans'], $args);
+      return $this->getTranslator()->trans(...$args);
+    }
+
+    /**
+     * Returns the translated text for a specific key of a specific layout.
+     * Added for usage in the advanced layout settings feature.
+     *
+     * @param string $layoutKey
+     * @param string $key
+     * @param [, mixed $args [, mixed $... ]]
+     * @return string
+     */
+    public function getOtherLayoutTrans($layoutKey, $key)
+    {
+        $args = func_get_args();
+        return $this->getTranslator()->transOtherLayout(...$args);
     }
 
     /**
@@ -284,8 +299,7 @@ abstract class Base
      */
     public function getFormattedCurrency($amount, $currencyCode)
     {
-      $args = func_get_args();
-      return call_user_func_array([$this->getTranslator(), 'getFormattedCurrency'], $args);
+        return $this->getTranslator()->getFormattedCurrency($amount, $currencyCode);
     }
 
     /**

--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -283,6 +283,7 @@ abstract class Base
      * @param string $key
      * @param [, mixed $args [, mixed $... ]]
      * @return string
+     * @since 2.1.32
      */
     public function getOtherLayoutTrans($layoutKey, $key)
     {

--- a/application/libraries/Ilch/Layout/Frontend.php
+++ b/application/libraries/Ilch/Layout/Frontend.php
@@ -6,7 +6,6 @@
 
 namespace Ilch\Layout;
 
-use http\Exception\RuntimeException;
 use Ilch\Request;
 use Ilch\Router;
 use Ilch\Translator;
@@ -375,6 +374,8 @@ class Frontend extends Base
 
     /**
      * Load settings made by an administrator if they exist or load default ones from layout.
+     *
+     * @since 2.1.31
      */
     public function loadSettings()
     {
@@ -405,6 +406,7 @@ class Frontend extends Base
      *
      * @param string $key name of setting
      * @return string
+     * @since 2.1.31
      */
     public function getLayoutSetting($key)
     {

--- a/application/libraries/Ilch/Layout/Frontend.php
+++ b/application/libraries/Ilch/Layout/Frontend.php
@@ -379,7 +379,6 @@ class Frontend extends Base
      */
     public function loadSettings()
     {
-        file_put_contents('php://stderr', print_r('Call of loadSettings'.PHP_EOL, TRUE));
         $advSettingsMapper = new LayoutAdvSettings();
 
         $settings = $advSettingsMapper->getSettings($this->getLayoutKey());
@@ -390,7 +389,6 @@ class Frontend extends Base
                 $configClass = '\\Layouts\\' . ucfirst(basename($layoutPath)) . '\\Config\\Config';
                 $config = new $configClass($this->getTranslator());
                 if (!empty($config->config['settings'])) {
-                    file_put_contents('php://stderr', print_r('Expensive call of loadSettings'.PHP_EOL, TRUE));
                     foreach($config->config['settings'] as $key => $value) {
                         $this->settings[$key] = $value['default'];
                     }

--- a/application/libraries/Ilch/Layout/Frontend.php
+++ b/application/libraries/Ilch/Layout/Frontend.php
@@ -375,7 +375,7 @@ class Frontend extends Base
     /**
      * Load settings made by an administrator if they exist or load default ones from layout.
      *
-     * @since 2.1.31
+     * @since 2.1.32
      */
     public function loadSettings()
     {
@@ -406,7 +406,7 @@ class Frontend extends Base
      *
      * @param string $key name of setting
      * @return string
-     * @since 2.1.31
+     * @since 2.1.32
      */
     public function getLayoutSetting($key)
     {

--- a/application/libraries/Ilch/Translator.php
+++ b/application/libraries/Ilch/Translator.php
@@ -100,7 +100,7 @@ class Translator
      * Works with an argument list like sprintf does
      * to replace placholders in the translated text.
      *
-     * @param string  $key
+     * @param string $key
      * @param [, mixed $args [, mixed $... ]]
      * @return string
      */
@@ -114,12 +114,39 @@ class Translator
             }
         } elseif (isset($this->translationsLayout[$key])) {
             $translatedText = $this->translationsLayout[$key];
-        } else {
+        } elseif (isset($this->translations[$key])) {
             // Call from layout, but no translation found. Fallback to other translations.
             $translatedText = $this->translations[$key];
         }
 
         $arguments = func_get_args();
+        $arguments[0] = $translatedText;
+        $translatedText = sprintf(...$arguments);
+
+        return $translatedText;
+    }
+
+    /**
+     * Returns the translated text for a specific key of a specific layout.
+     * Added for usage in the advanced layout settings feature.
+     *
+     * Works with an argument list like sprintf does
+     * to replace placholders in the translated text.
+     *
+     * @param string $layoutKey
+     * @param string $key
+     * @param [, mixed $args [, mixed $... ]]
+     * @return string
+     */
+    public function transOtherLayout($layoutKey, $key)
+    {
+        $translatedText = $key;
+
+        if (isset($this->translationsLayout[$key])) {
+            $translatedText = $this->translationsLayout[$key];
+        }
+
+        $arguments = array_slice(func_get_args(), 1);
         $arguments[0] = $translatedText;
         $translatedText = sprintf(...$arguments);
 
@@ -225,7 +252,7 @@ class Translator
      */
     private function isCallFromLayout()
     {
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS,4);
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4);
 
         foreach ($backtrace as $entry) {
             if ($entry['function'] === 'getTrans' && (strpos($entry['file'], 'application'.DIRECTORY_SEPARATOR.'layouts') !== false)) {

--- a/application/libraries/Ilch/Translator.php
+++ b/application/libraries/Ilch/Translator.php
@@ -137,6 +137,7 @@ class Translator
      * @param string $key
      * @param [, mixed $args [, mixed $... ]]
      * @return string
+     * @since 2.1.32
      */
     public function transOtherLayout($layoutKey, $key)
     {
@@ -249,6 +250,7 @@ class Translator
      * Check if called from a layout.
      *
      * @return bool
+     * @since 2.1.31
      */
     private function isCallFromLayout()
     {

--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -178,6 +178,14 @@ class Config extends \Ilch\Config\Install
                 `info` VARCHAR(255) NOT NULL
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
             
+            CREATE TABLE IF NOT EXISTS `[prefix]_admin_layoutAdvSettings` (
+                `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+                `layoutKey` VARCHAR(255) NOT NULL,
+                `key` VARCHAR(255) NOT NULL,
+                `value` TEXT NOT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
+            
             CREATE TABLE IF NOT EXISTS `[prefix]_admin_notifications` (
                 `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
                 `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -644,6 +652,14 @@ class Config extends \Ilch\Config\Install
 
                 // Remove no longer needed file
                 unlink(APPLICATION_PATH.'/libraries/Ilch/Session.php');
+            case "2.1.30":
+                $this->db()->query('CREATE TABLE IF NOT EXISTS `[prefix]_admin_layoutAdvSettings` (
+                    `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+                    `layoutKey` VARCHAR(255) NOT NULL,
+                    `key` VARCHAR(255) NOT NULL,
+                    `value` TEXT NOT NULL,
+                    PRIMARY KEY (`id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;');
         }
 
         return 'Update function executed.';

--- a/application/modules/admin/controllers/admin/Layouts.php
+++ b/application/modules/admin/controllers/admin/Layouts.php
@@ -307,7 +307,6 @@ class Layouts extends \Ilch\Controller\Admin
                 $settings = $config->config['settings'];
             }
 
-            // TODO: Translations won't be used as isCallFromLayout() returns false?
             $this->getLayout()->getTranslator()->load($layoutPath.'/translations/');
         }
 
@@ -334,6 +333,7 @@ class Layouts extends \Ilch\Controller\Admin
             $settingsValues = $layoutAdvSettingsMapper->getSettings($layoutKey);
         }
 
+        $this->getView()->set('layoutKey', $layoutKey);
         $this->getView()->set('settings', $settings);
         $this->getView()->set('settingsValues', $settingsValues);
     }

--- a/application/modules/admin/mappers/LayoutAdvSettings.php
+++ b/application/modules/admin/mappers/LayoutAdvSettings.php
@@ -125,10 +125,11 @@ class LayoutAdvSettings extends \Ilch\Mapper
      * Update an existing setting.
      *
      * @param LayoutAdvSettingsModel $model
+     * @return int affected rows
      */
     private function updateSetting($model)
     {
-        $affectedRows = $this->db()->update('admin_layoutAdvSettings')
+        return $this->db()->update('admin_layoutAdvSettings')
             ->values([
                 'layoutKey' => $model->getLayoutKey(),
                 'key' => $model->getKey(),

--- a/application/modules/admin/mappers/LayoutAdvSettings.php
+++ b/application/modules/admin/mappers/LayoutAdvSettings.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Admin\Mappers;
+
+use Modules\Admin\Models\LayoutAdvSettings as LayoutAdvSettingsModel;
+
+class LayoutAdvSettings extends \Ilch\Mapper
+{
+    /**
+     * Get specific setting of a layout.
+     *
+     * @param $layoutKey
+     * @param $key
+     * @return LayoutAdvSettingsModel|null
+     */
+    public function getSetting($layoutKey, $key)
+    {
+        $result = $this->db()->select('*')
+            ->from('admin_layoutAdvSettings')
+            ->where(['layoutKey' => $layoutKey, 'key' => $key])
+            ->execute()
+            ->fetchAssoc();
+
+        if (empty($result)) {
+            return null;
+        }
+
+        $layoutAdvSettingsModel = new LayoutAdvSettingsModel();
+        $layoutAdvSettingsModel->setId($result['id']);
+        $layoutAdvSettingsModel->setLayoutKey($result['layoutKey']);
+        $layoutAdvSettingsModel->setKey($result['key']);
+        $layoutAdvSettingsModel->setValue($result['value']);
+
+        return $layoutAdvSettingsModel;
+    }
+
+    /**
+     * Get all settings of a layout.
+     *
+     * @param $layoutKey
+     * @return array
+     */
+    public function getSettings($layoutKey)
+    {
+        $array = $this->db()->select('*')
+            ->from('admin_layoutAdvSettings')
+            ->where(['layoutKey' => $layoutKey])
+            ->execute()
+            ->fetchRows();
+
+        if (empty($array)) {
+            return [];
+        }
+
+        $layoutAdvSettings = [];
+        foreach ($array as $result) {
+            $layoutAdvSettingsModel = new LayoutAdvSettingsModel();
+            $layoutAdvSettingsModel->setId($result['id']);
+            $layoutAdvSettingsModel->setLayoutKey($result['layoutKey']);
+            $layoutAdvSettingsModel->setKey($result['key']);
+            $layoutAdvSettingsModel->setValue($result['value']);
+            $layoutAdvSettings[$result['key']] = $layoutAdvSettingsModel;
+        }
+
+        return $layoutAdvSettings;
+    }
+
+    /**
+     * Save settings.
+     *
+     * @param LayoutAdvSettingsModel[] $model
+     */
+    public function save($models)
+    {
+        if (!empty($models) && $this->hasSettings($models[0]->getLayoutKey())) {
+            foreach($models as $model) {
+                $this->db()->update('admin_layoutAdvSettings')
+                    ->values([
+                        'layoutKey' => $model->getLayoutKey(),
+                        'key' => $model->getKey(),
+                        'value' => $model->getValue(),
+                        ])
+                    ->where(['layoutKey' => $model->getLayoutKey(), 'key' => $model->getKey()])
+                    ->execute();
+            }
+        } else {
+            foreach($models as $model) {
+                if ($model->getKey() === 'ilch_token' || $model->getKey() === 'save') {
+                    continue;
+                }
+                $this->db()->insert('admin_layoutAdvSettings')
+                    ->values([
+                        'layoutKey' => $model->getLayoutKey(),
+                        'key' => $model->getKey(),
+                        'value' => $model->getValue(),
+                    ])
+                    ->execute();
+            }
+        }
+    }
+
+    /**
+     * Check if there are settings for a specific layout.
+     *
+     * @param string $layoutKey
+     * @return bool
+     */
+    public function hasSettings($layoutKey)
+    {
+        return (bool)$this->db()->select('COUNT(*)')
+            ->from('admin_layoutAdvSettings')
+            ->where(['layoutKey' => $layoutKey])
+            ->execute()
+            ->fetchCell();
+    }
+
+    /**
+     * Delete specific setting of a layout.
+     *
+     * @param $layoutKey
+     * @param $key
+     */
+    public function deleteSetting($layoutKey, $key)
+    {
+        $this->db()->delete('admin_layoutAdvSettings')
+            ->where(['layoutKey' => $layoutKey, 'key' => $key])
+            ->execute();
+    }
+
+    /**
+     * Delete all settings of a layout.
+     * Call this when the layout gets deleted.
+     *
+     * @param $layoutKey
+     */
+    public function deleteSettings($layoutKey)
+    {
+        $this->db()->delete('admin_layoutAdvSettings')
+            ->where(['layoutKey' => $layoutKey])
+            ->execute();
+    }
+}

--- a/application/modules/admin/mappers/LayoutAdvSettings.php
+++ b/application/modules/admin/mappers/LayoutAdvSettings.php
@@ -70,6 +70,25 @@ class LayoutAdvSettings extends \Ilch\Mapper
     }
 
     /**
+     * Get list of existing layout keys.
+     *
+     * @return array|string[]
+     */
+    public function getListOfLayoutKeys()
+    {
+        $layoutKeys = $this->db()->select('DISTINCT layoutKey')
+            ->from('admin_layoutAdvSettings')
+            ->execute()
+            ->fetchList();
+
+        if (empty($layoutKeys)) {
+            return [];
+        }
+
+        return $layoutKeys;
+    }
+
+    /**
      * Save settings.
      *
      * @param LayoutAdvSettingsModel[] $model

--- a/application/modules/admin/mappers/LayoutAdvSettings.php
+++ b/application/modules/admin/mappers/LayoutAdvSettings.php
@@ -126,9 +126,17 @@ class LayoutAdvSettings extends \Ilch\Mapper
      */
     public function deleteSetting($layoutKey, $key)
     {
-        $this->db()->delete('admin_layoutAdvSettings')
-            ->where(['layoutKey' => $layoutKey, 'key' => $key])
-            ->execute();
+        $this->deleteBy(['layoutKey' => $layoutKey, 'key' => $key]);
+    }
+
+    /**
+     * Delete setting by it's id.
+     *
+     * @param int $id
+     */
+    public function deleteSettingById($id)
+    {
+        $this->deleteBy(['id' => $id]);
     }
 
     /**
@@ -139,8 +147,18 @@ class LayoutAdvSettings extends \Ilch\Mapper
      */
     public function deleteSettings($layoutKey)
     {
+        $this->deleteBy(['layoutKey' => $layoutKey]);
+    }
+
+    /**
+     * Delete setting/settings by specified where clause.
+     *
+     * @param array $where
+     */
+    private function deleteBy($where)
+    {
         $this->db()->delete('admin_layoutAdvSettings')
-            ->where(['layoutKey' => $layoutKey])
+            ->where($where)
             ->execute();
     }
 }

--- a/application/modules/admin/models/Layout.php
+++ b/application/modules/admin/models/Layout.php
@@ -65,6 +65,13 @@ class Layout extends \Ilch\Model
     protected $modulekey;
 
     /**
+     * Settings of the layout.
+     *
+     * @var array
+     */
+    protected $settings;
+
+    /**
      * Gets the key.
      *
      * @return string
@@ -222,5 +229,27 @@ class Layout extends \Ilch\Model
     public function setModulekey($modulekey)
     {
         $this->modulekey = (string)$modulekey;
+    }
+
+    /**
+     * Get the settings.
+     *
+     * @return array
+     */
+    public function getSettings()
+    {
+        return $this->settings;
+    }
+
+    /**
+     * Set the settings.
+     *
+     * @param array $settings
+     * @return Layout
+     */
+    public function setSettings($settings)
+    {
+        $this->settings = $settings;
+        return $this;
     }
 }

--- a/application/modules/admin/models/LayoutAdvSettings.php
+++ b/application/modules/admin/models/LayoutAdvSettings.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Admin\Models;
+
+class LayoutAdvSettings extends \Ilch\Model
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $layoutKey;
+
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return LayoutAdvSettings
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLayoutKey()
+    {
+        return $this->layoutKey;
+    }
+
+    /**
+     * @param string $layoutKey
+     * @return LayoutAdvSettings
+     */
+    public function setLayoutKey($layoutKey)
+    {
+        $this->layoutKey = $layoutKey;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * @param string $key
+     * @return LayoutAdvSettings
+     */
+    public function setKey($key)
+    {
+        $this->key = $key;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value
+     * @return LayoutAdvSettings
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+        return $this;
+    }
+}

--- a/application/modules/admin/models/LayoutAdvSettings.php
+++ b/application/modules/admin/models/LayoutAdvSettings.php
@@ -29,6 +29,8 @@ class LayoutAdvSettings extends \Ilch\Model
     private $value;
 
     /**
+     * Get the id.
+     *
      * @return int
      */
     public function getId()
@@ -37,6 +39,8 @@ class LayoutAdvSettings extends \Ilch\Model
     }
 
     /**
+     * Set the id.
+     * 
      * @param int $id
      * @return LayoutAdvSettings
      */
@@ -47,6 +51,8 @@ class LayoutAdvSettings extends \Ilch\Model
     }
 
     /**
+     * Get the layout key.
+     *
      * @return string
      */
     public function getLayoutKey()
@@ -55,6 +61,8 @@ class LayoutAdvSettings extends \Ilch\Model
     }
 
     /**
+     * Set the layout key.
+     *
      * @param string $layoutKey
      * @return LayoutAdvSettings
      */
@@ -65,6 +73,8 @@ class LayoutAdvSettings extends \Ilch\Model
     }
 
     /**
+     * Get the key.
+     *
      * @return string
      */
     public function getKey()
@@ -73,6 +83,8 @@ class LayoutAdvSettings extends \Ilch\Model
     }
 
     /**
+     * Set the key.
+     *
      * @param string $key
      * @return LayoutAdvSettings
      */
@@ -83,6 +95,8 @@ class LayoutAdvSettings extends \Ilch\Model
     }
 
     /**
+     * Get the value.
+     *
      * @return string
      */
     public function getValue()
@@ -91,6 +105,8 @@ class LayoutAdvSettings extends \Ilch\Model
     }
 
     /**
+     * Set the value.
+     *
      * @param string $value
      * @return LayoutAdvSettings
      */

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -367,4 +367,8 @@ return [
     'smtp_pass' => 'Passwort',
     'emailBlacklist' => 'E-Mail Sperrliste',
     'editEmailBlacklist' => 'E-Mail Sperrliste bearbeiten',
+
+    'menuAdvSettings' => 'Erweiterte Einstellungen',
+    'menuAdvSettingsShow' => 'Anzeige',
+    'noLayouts' => 'Keine Layouts mit erweiterten Einstellungen gefunden.',
 ];

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -371,4 +371,6 @@ return [
     'menuAdvSettings' => 'Erweiterte Einstellungen',
     'menuAdvSettingsShow' => 'Anzeige',
     'noLayouts' => 'Keine Layouts mit erweiterten Einstellungen gefunden.',
+    'orphanedSettings' => 'Es wurden Einstellungen für nicht vorhandene Layouts gefunden. Diese können unten gelöscht werden.',
+    'deleteOrphanedSettings' => 'Lösche verwaiste Einstellungen',
 ];

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -371,4 +371,6 @@ return [
     'menuAdvSettings' => 'Advanced Settings',
     'menuAdvSettingsShow' => 'Show',
     'noLayouts' => 'No layouts with advanced settings found.',
+    'orphanedSettings' => 'Settings have been found for not existing layouts. These can be deleted below.',
+    'deleteOrphanedSettings' => 'Delete orphaned settings',
 ];

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -367,4 +367,8 @@ return [
     'smtp_pass' => 'Password',
     'emailBlacklist' => 'E-mail blacklist',
     'editEmailBlacklist' => 'Edit e-mail blacklist',
+
+    'menuAdvSettings' => 'Advanced Settings',
+    'menuAdvSettingsShow' => 'Show',
+    'noLayouts' => 'No layouts with advanced settings found.',
 ];

--- a/application/modules/admin/views/admin/layouts/advsettings.php
+++ b/application/modules/admin/views/admin/layouts/advsettings.php
@@ -33,7 +33,23 @@
                 </tbody>
             </table>
         </div>
-        <?=$this->getListBar(['delete' => 'delete']) ?>
+
+        <div class="content_savebox">
+            <input type="hidden" class="content_savebox_hidden" name="action" value="delete" />
+            <div class="btn-group dropup">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                    <?=$this->getTrans('selected') ?> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu listChooser" role="menu">
+                    <li><a href="#" data-hiddenkey="delete"><?=$this->getTrans('delete') ?></a></li>
+                </ul>
+            </div>
+            <?php if ($this->get('orphanedSettingsExist')) : ?>
+                <button type="submit" class="save_button btn btn-default" name="deleteOrphanedSettings" value="deleteOrphanedSettings">
+                    <?=$this->getTrans('deleteOrphanedSettings') ?>
+                </button>
+            <?php endif; ?>
+        </div>
     </form>
 <?php else: ?>
     <?=$this->getTrans('noLayouts') ?>

--- a/application/modules/admin/views/admin/layouts/advsettings.php
+++ b/application/modules/admin/views/admin/layouts/advsettings.php
@@ -1,0 +1,40 @@
+<h1><?=$this->getTrans('manage') ?></h1>
+<?php if (!empty($this->get('layouts'))): ?>
+    <form class="form-horizontal" method="POST">
+        <?=$this->getTokenField() ?>
+        <div class="table-responsive">
+            <table class="table table-hover table-striped">
+                <colgroup>
+                    <col class="icon_width" />
+                    <col class="icon_width" />
+                    <col class="icon_width" />
+                    <col />
+                    <col />
+                </colgroup>
+                <thead>
+                <tr>
+                    <th><?=$this->getCheckAllCheckbox('check_layouts') ?></th>
+                    <th></th>
+                    <th></th>
+                    <th><?=$this->getTrans('name') ?></th>
+                    <th><?=$this->getTrans('author') ?></th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($this->get('layouts') as $layout): ?>
+                    <tr>
+                        <td><?=$this->getDeleteCheckbox('check_layouts', $layout->getKey()) ?></td>
+                        <td><?=$this->getDeleteIcon(['action' => 'deleteAdvSettings', 'layoutKey' => $layout->getKey()]) ?></td>
+                        <td><?=$this->getEditIcon(['action' => 'advSettingsShow', 'layoutKey' => $layout->getKey()]) ?></td>
+                        <td><a href="<?=$this->getUrl(['action' => 'advSettingsShow', 'layoutKey' => $layout->getKey()]) ?>"><?=$this->escape($layout->getName()) ?></a></td>
+                        <td><?=$this->escape($layout->getAuthor()) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?=$this->getListBar(['delete' => 'delete']) ?>
+    </form>
+<?php else: ?>
+    <?=$this->getTrans('noLayouts') ?>
+<?php endif; ?>

--- a/application/modules/admin/views/admin/layouts/advsettingsshow.php
+++ b/application/modules/admin/views/admin/layouts/advsettingsshow.php
@@ -67,7 +67,7 @@ function getInput($name, $value, $settingsValues, $obj)
     <?php foreach ($this->get('settings') as $key => $value) : ?>
         <div class="form-group">
             <label for="<?=$key ?>>" class="col-lg-2 control-label">
-                <?=$this->getTrans($key) ?>:
+                <?=$this->getOtherLayoutTrans($this->get('layoutKey'), $key) ?>:
             </label>
             <div class="col-lg-10">
                 <?=getInput($key, $value, $this->get('settingsValues'), $this) ?>

--- a/application/modules/admin/views/admin/layouts/advsettingsshow.php
+++ b/application/modules/admin/views/admin/layouts/advsettingsshow.php
@@ -6,6 +6,12 @@ function getInput($name, $value, $settingsValues, $obj)
     $input = '';
     switch($value['type'])
     {
+        case 'bscolorpicker':
+            $input = sprintf('<input class="form-control color {hash:true}"
+                               id="%s"
+                               name="%s"
+                               value="%s">', $name, $name, $settingsValue);
+            break;
         case 'ckeditorbbcode':
             $input = sprintf('<textarea class="form-control ckeditor"
                                name="%s"
@@ -80,3 +86,4 @@ function getInput($name, $value, $settingsValues, $obj)
         ->addUploadController($this->getUrl('admin/media/index/upload'))
     ?>
 </script>
+<script src="<?=$this->getStaticUrl('js/jscolor/jscolor.js') ?>"></script>

--- a/application/modules/admin/views/admin/layouts/advsettingsshow.php
+++ b/application/modules/admin/views/admin/layouts/advsettingsshow.php
@@ -1,0 +1,82 @@
+<?php
+function getInput($name, $value, $settingsValues, $obj)
+{
+    $settingsValue = (empty($settingsValues[$name]) ? $obj->escape($value['default']) : $obj->escape($settingsValues[$name]->getValue()));
+    $name = $obj->escape($name);
+    $input = '';
+    switch($value['type'])
+    {
+        case 'ckeditorbbcode':
+            $input = sprintf('<textarea class="form-control ckeditor"
+                               name="%s"
+                               id="%s"
+                               toolbar="ilch_bbcode">%s</textarea>', $name, $name, $settingsValue);
+            break;
+        case 'ckeditorhtml':
+            $input = sprintf('<textarea class="form-control ckeditor"
+                               name="%s"
+                               id="%s"
+                               toolbar="ilch_html">%s</textarea>', $name, $name, $settingsValue);
+            break;
+        case 'colorpicker':
+            $input = sprintf('<input type="color" id="%s" name="%s" value="%s">', $name, $name, $settingsValue);
+            break;
+        case 'flipswitch':
+            $input = '<div class="flipswitch"><input type="radio" class="flipswitch-input" id="%s-on" name="%s" value="1" '.(empty($settingsValue) ? '' : 'checked="checked"').'/>
+                      <label for="%s-on" class="flipswitch-label flipswitch-label-on">%s</label>';
+            $input = sprintf($input, $name, $name, $name, $obj->getTrans('on'));
+            $input .= '<input type="radio" class="flipswitch-input" id="%s-off" name="%s" value="0" '.(!empty($settingsValue) ? '' : 'checked="checked"').' />
+                       <label for="%s-off" class="flipswitch-label flipswitch-label-off">%s</label><span class="flipswitch-selection"></span></div>';
+            $input = sprintf($input, $name, $name, $name, $obj->getTrans('off'));
+            break;
+        case 'mediaselection':
+            $input = sprintf('<div class="input-group">
+                                        <input class="form-control"
+                                               type="text"
+                                               name="%s"
+                                               id="%s"
+                                               value="%s" />
+                                        <span class="input-group-addon"><a id="media" href="javascript:media()"><i class="fa fa-picture-o"></i></a></span>
+                                    </div>', $name, $name, $settingsValue);
+            break;
+        case 'text':
+            $input = sprintf('<input class="form-control"
+                               type="text"
+                               name="%s"
+                               id="%s"
+                               maxlength="40" 
+                               value="%s" />', $name, $name, $settingsValue);
+            break;
+        default:
+    }
+
+    return $input;
+}
+?>
+
+<h1><?=$this->getTrans('menuAdvSettings') ?></h1>
+<form id="advsettings_form" class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <?php foreach ($this->get('settings') as $key => $value) : ?>
+        <div class="form-group">
+            <label for="<?=$key ?>>" class="col-lg-2 control-label">
+                <?=$this->getTrans($key) ?>:
+            </label>
+            <div class="col-lg-10">
+                <?=getInput($key, $value, $this->get('settingsValues'), $this) ?>
+                <?php if (!empty($value['description'])) : ?>
+                    <div class="text-right"><small><?=$this->escape($value['description']) ?></small><p></p></div>
+                <?php endif; ?>
+            </div>
+        </div>
+    <?php endforeach; ?>
+
+    <?=$this->getSaveBar() ?>
+</form>
+<?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>'); ?>
+<script>
+    <?=$this->getMedia()
+        ->addMediaButton($this->getUrl('admin/media/iframe/index/type/single/'))
+        ->addUploadController($this->getUrl('admin/media/index/upload'))
+    ?>
+</script>

--- a/application/modules/admin/views/admin/layouts/advsettingsshow.php
+++ b/application/modules/admin/views/admin/layouts/advsettingsshow.php
@@ -41,7 +41,8 @@ function getInput($name, $value, $settingsValues, $obj)
                                                type="text"
                                                name="%s"
                                                id="%s"
-                                               value="%s" />
+                                               value="%s"
+                                               readonly />
                                         <span class="input-group-addon"><a id="media" href="javascript:media()"><i class="fa fa-picture-o"></i></a></span>
                                     </div>', $name, $name, $settingsValue);
             break;
@@ -71,7 +72,7 @@ function getInput($name, $value, $settingsValues, $obj)
             <div class="col-lg-10">
                 <?=getInput($key, $value, $this->get('settingsValues'), $this) ?>
                 <?php if (!empty($value['description'])) : ?>
-                    <div class="text-right"><small><?=$this->escape($value['description']) ?></small><p></p></div>
+                    <div class="text-right"><small><?=$this->getTrans($value['description']) ?></small><p></p></div>
                 <?php endif; ?>
             </div>
         </div>
@@ -79,7 +80,7 @@ function getInput($name, $value, $settingsValues, $obj)
 
     <?=$this->getSaveBar() ?>
 </form>
-<?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>'); ?>
+<?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>') ?>
 <script>
     <?=$this->getMedia()
         ->addMediaButton($this->getUrl('admin/media/iframe/index/type/single/'))

--- a/application/modules/admin/views/admin/layouts/advsettingsshow.php
+++ b/application/modules/admin/views/admin/layouts/advsettingsshow.php
@@ -62,17 +62,17 @@ function getInput($name, $value, $settingsValues, $obj)
 ?>
 
 <h1><?=$this->getTrans('menuAdvSettings') ?></h1>
-<form id="advsettings_form" class="form-horizontal" method="POST" action="">
+<form id="advsettings_form" class="form-horizontal" method="POST">
     <?=$this->getTokenField() ?>
     <?php foreach ($this->get('settings') as $key => $value) : ?>
         <div class="form-group">
-            <label for="<?=$key ?>>" class="col-lg-2 control-label">
+            <label for="<?=$key ?>" class="col-lg-2 control-label">
                 <?=$this->getOtherLayoutTrans($this->get('layoutKey'), $key) ?>:
             </label>
             <div class="col-lg-10">
                 <?=getInput($key, $value, $this->get('settingsValues'), $this) ?>
                 <?php if (!empty($value['description'])) : ?>
-                    <div class="text-right"><small><?=$this->getTrans($value['description']) ?></small><p></p></div>
+                    <div class="text-right"><small><?=$this->getOtherLayoutTrans($this->get('layoutKey'), $value['description']) ?></small><p></p></div>
                 <?php endif; ?>
             </div>
         </div>

--- a/application/modules/admin/views/admin/layouts/index.php
+++ b/application/modules/admin/views/admin/layouts/index.php
@@ -75,6 +75,10 @@ $cacheFileDate = new \Ilch\Date(date('Y-m-d H:i:s.', filemtime($cacheFilename)))
                         <a href="<?=$this->getUrl(['module' => $layout->getModulekey(),'controller' => 'index', 'action' => 'index']) ?>" class="btn btn-default" title="<?=$this->getTrans('settings') ?>">
                             <i class="fa fa-cogs"></i>
                         </a>
+                    <?php elseif (!empty($layout->getSettings())): ?>
+                        <a href="<?=$this->getUrl(['action' => 'advSettingsShow', 'layoutKey' => $layout->getKey()]) ?>" class="btn btn-default" title="<?=$this->getTrans('settings') ?>">
+                            <i class="fa fa-cogs"></i>
+                        </a>
                     <?php endif; ?>
                     </div>
                     <div class="pull-right">

--- a/tests/modules/admin/_files/mysql_database.yml
+++ b/tests/modules/admin/_files/mysql_database.yml
@@ -23,3 +23,25 @@ admin_notifications_permission:
     module: "awards"
     granted: 1
     limit: 5
+
+admin_layoutAdvSettings:
+  -
+    id: 1
+    layoutKey: 'testLayoutKey1'
+    key: 'testKey1'
+    value: 'testValue1'
+  -
+    id: 2
+    layoutKey: 'testLayoutKey1'
+    key: 'testKey2'
+    value: 'testValue2'
+  -
+    id: 3
+    layoutKey: 'testLayoutKey2'
+    key: 'testKey3'
+    value: 'testValue3'
+  -
+    id: 4
+    layoutKey: 'testLayoutKey2'
+    key: 'testKey4'
+    value: 'testValue4'

--- a/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
+++ b/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Modules\Admin\Mappers;
+
+use PHPUnit\Ilch\DatabaseTestCase;
+use Modules\Admin\Config\Config as ModuleConfig;
+use Modules\Admin\Mappers\LayoutAdvSettings;
+use Modules\Admin\Models\LayoutAdvSettings as LayoutAdvSettingsModel;
+
+/**
+ * Tests the LayoutAdvSettings mapper class.
+ *
+ * @package ilch_phpunit
+ */
+class LayoutAdvSettingsTest extends DatabaseTestCase
+{
+    /**
+     * @var LayoutAdvSettings
+     */
+    protected $out;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->out = new LayoutAdvSettings();
+    }
+
+    /**
+     * Creates and returns a dataset object.
+     *
+     * @return \PHPUnit_Extensions_Database_DataSet_AbstractDataSet
+     */
+    protected function getDataSet()
+    {
+        return new \PHPUnit_Extensions_Database_DataSet_YamlDataSet(__DIR__ . '/../_files/mysql_database.yml');
+    }
+
+    /**
+     * Returns database schema sql statements to initialize database
+     *
+     * @return string
+     */
+    protected static function getSchemaSQLQueries()
+    {
+        $config = new ModuleConfig();
+        return $config->getInstallSql();
+    }
+
+    /**
+     * Test if getSetting() returns the expected setting.
+     *
+     */
+    public function testGetSetting()
+    {
+        $layoutSetting = $this->out->getSetting('testLayoutKey1', 'testKey1');
+
+        $this->assertEquals($layoutSetting->getId(), 1);
+        $this->assertSame($layoutSetting->getLayoutKey(), 'testLayoutKey1');
+        $this->assertSame($layoutSetting->getKey(), 'testKey1');
+        $this->assertSame($layoutSetting->getValue(), 'testValue1');
+    }
+
+    /**
+     * Test if getSettings() returns the expected settings.
+     *
+     */
+    public function testGetSettings()
+    {
+        $layoutSetting = $this->out->getSettings('testLayoutKey1');
+
+        $this->assertEquals($layoutSetting['testKey1']->getId(), 1);
+        $this->assertSame($layoutSetting['testKey1']->getLayoutKey(), 'testLayoutKey1');
+        $this->assertSame($layoutSetting['testKey1']->getKey(), 'testKey1');
+        $this->assertSame($layoutSetting['testKey1']->getValue(), 'testValue1');
+
+        $this->assertEquals($layoutSetting['testKey2']->getId(), 2);
+        $this->assertSame($layoutSetting['testKey2']->getLayoutKey(), 'testLayoutKey1');
+        $this->assertSame($layoutSetting['testKey2']->getKey(), 'testKey2');
+        $this->assertSame($layoutSetting['testKey2']->getValue(), 'testValue2');
+    }
+
+
+    /**
+     * Test if hasSettings() returns true for existing settings.
+     *
+     */
+    public function testHasSettings()
+    {
+        $this->assertTrue($this->out->hasSettings('testLayoutKey1'));
+    }
+
+    /**
+     * Test if hasSettings() returns false for non existing settings.
+     *
+     */
+    public function testHasSettingsNotExisting()
+    {
+        $this->assertFalse($this->out->hasSettings('notExistingLayoutKey'));
+    }
+
+    /**
+     * Test if save() saves the setting correctly.
+     *
+     */
+    public function testSave()
+    {
+        $layoutSettingModel = new LayoutAdvSettingsModel();
+        $layoutSettingModel->setLayoutKey('testLayoutKey3');
+        $layoutSettingModel->setKey('testKey5');
+        $layoutSettingModel->setValue('testValue5');
+        $layoutSettingsArray[] = $layoutSettingModel;
+        $this->out->save($layoutSettingsArray);
+
+        $layoutSetting = $this->out->getSetting('testLayoutKey3','testKey5');
+        $this->assertEquals($layoutSetting->getId(), 5);
+        $this->assertSame($layoutSetting->getLayoutKey(), 'testLayoutKey3');
+        $this->assertSame($layoutSetting->getKey(), 'testKey5');
+        $this->assertSame($layoutSetting->getValue(), 'testValue5');
+    }
+
+    /**
+     * Test if deleteSetting() successfully deletes a specific setting.
+     *
+     */
+    public function testDeleteSetting()
+    {
+        $this->out->deleteSetting('testLayoutKey1','testKey1');
+        $this->assertEmpty($this->out->getSetting('testLayoutKey1','testKey1'));
+    }
+
+    /**
+     * Test if deleteSettings() successfully deletes all settings with a specific layoutKey.
+     *
+     */
+    public function testDeleteSettings()
+    {
+        $this->out->deleteSettings('testLayoutKey2');
+        $this->assertEmpty($this->out->getSettings('testLayoutKey2'));
+    }
+}

--- a/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
+++ b/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
@@ -52,7 +52,6 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
 
     /**
      * Test if getSetting() returns the expected setting.
-     *
      */
     public function testGetSetting()
     {
@@ -66,7 +65,6 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
 
     /**
      * Test if getSettings() returns the expected settings.
-     *
      */
     public function testGetSettings()
     {
@@ -86,7 +84,6 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
 
     /**
      * Test if hasSettings() returns true for existing settings.
-     *
      */
     public function testHasSettings()
     {
@@ -95,7 +92,6 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
 
     /**
      * Test if hasSettings() returns false for non existing settings.
-     *
      */
     public function testHasSettingsNotExisting()
     {
@@ -104,9 +100,8 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
 
     /**
      * Test if save() saves the setting correctly.
-     *
      */
-    public function testSave()
+    public function testSaveSingleOne()
     {
         $layoutSettingModel = new LayoutAdvSettingsModel();
         $layoutSettingModel->setLayoutKey('testLayoutKey3');
@@ -123,8 +118,38 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
     }
 
     /**
+     * Test if save() saves the settings correctly.
+     */
+    public function testSaveMultiple()
+    {
+        $layoutSettingModel = new LayoutAdvSettingsModel();
+        $layoutSettingModel->setLayoutKey('testLayoutKey3');
+        $layoutSettingModel->setKey('testKey5');
+        $layoutSettingModel->setValue('testValue5');
+        $layoutSettingsArray[] = $layoutSettingModel;
+
+        $layoutSettingModel = new LayoutAdvSettingsModel();
+        $layoutSettingModel->setLayoutKey('testLayoutKey3');
+        $layoutSettingModel->setKey('testKey6');
+        $layoutSettingModel->setValue('testValue6');
+        $layoutSettingsArray[] = $layoutSettingModel;
+
+        $this->out->save($layoutSettingsArray);
+
+        $layoutSetting = $this->out->getSettings('testLayoutKey3');
+        $this->assertEquals($layoutSetting['testKey5']->getId(), 5);
+        $this->assertSame($layoutSetting['testKey5']->getLayoutKey(), 'testLayoutKey3');
+        $this->assertSame($layoutSetting['testKey5']->getKey(), 'testKey5');
+        $this->assertSame($layoutSetting['testKey5']->getValue(), 'testValue5');
+
+        $this->assertEquals($layoutSetting['testKey6']->getId(), 6);
+        $this->assertSame($layoutSetting['testKey6']->getLayoutKey(), 'testLayoutKey3');
+        $this->assertSame($layoutSetting['testKey6']->getKey(), 'testKey6');
+        $this->assertSame($layoutSetting['testKey6']->getValue(), 'testValue6');
+    }
+
+    /**
      * Test if deleteSetting() successfully deletes a specific setting.
-     *
      */
     public function testDeleteSetting()
     {
@@ -133,8 +158,16 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
     }
 
     /**
+     * Test if deleteSettingById() successfully deletes the setting with a specific id.
+     */
+    public function testDeleteSettingById()
+    {
+        $this->out->deleteSettingById(2);
+        $this->assertEmpty($this->out->getSetting('testLayoutKey1','testKey2'));
+    }
+
+    /**
      * Test if deleteSettings() successfully deletes all settings with a specific layoutKey.
-     *
      */
     public function testDeleteSettings()
     {

--- a/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
+++ b/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
@@ -81,6 +81,17 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
         $this->assertSame($layoutSetting['testKey2']->getValue(), 'testValue2');
     }
 
+    /**
+     * Test if getListOfLayoutKeys() returns the expected layout keys.
+     */
+    public function testGetListOfLayoutKeys()
+    {
+        $layoutKeyList = $this->out->getListOfLayoutKeys();
+
+        $this->assertCount(2, $layoutKeyList);
+        $this->assertSame($layoutKeyList[0], 'testLayoutKey1');
+        $this->assertSame($layoutKeyList[1], 'testLayoutKey2');
+    }
 
     /**
      * Test if hasSettings() returns true for existing settings.


### PR DESCRIPTION
This is still work in progress. The "design" of the settings is not polished.

# Description

The goal is that layouts can specify settings in their config.php and Ilch provides a central place for the administrator to change those settings. Previously a layout that wanted to provide settings would have to come with an module, which handles these. This should no longer be needed with these changes.

Layouts can use the set values for the settings like this:
`$this->getLayoutSetting('title')`

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# This PR has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [X] Opera
- [ ] Edge
- [ ] IE
