### PR TITLE
Fix: Add fallback to other translations

### DIFF
--- a/application/libraries/Ilch/Translator.php
+++ b/application/libraries/Ilch/Translator.php
@@ -114,6 +114,9 @@ class Translator
             }
         } elseif (isset($this->translationsLayout[$key])) {
             $translatedText = $this->translationsLayout[$key];
+        } else {
+            // Call from layout, but no translation found. Fallback to other translations.
+            $translatedText = $this->translations[$key];
         }
 
         $arguments = func_get_args();
@@ -225,7 +228,7 @@ class Translator
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS,4);
 
         foreach ($backtrace as $entry) {
-            if ($entry['function'] === 'getTrans' && (strpos($entry['file'], 'application/layouts') !== false || strpos($entry['file'], 'application\layouts') !== false)) {
+            if ($entry['function'] === 'getTrans' && (strpos($entry['file'], 'application'.DIRECTORY_SEPARATOR.'layouts') !== false)) {
                 return true;
             }
         }


### PR DESCRIPTION
# Description

Previously if a layout would have used translations the translations of the module/ilch would have been used.

This should restore the previous behaviour in case the translation in the layout is missing.

In addition to this add the recommendation of Mairu regarding DIRECTORY_SEPARATOR
https://github.com/IlchCMS/Ilch-2.0/pull/466#discussion_r381369304

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
- [ ] IE
