### PR TITLE
Add replyTo to mail class and usage in contact module

### DIFF
--- a/application/libraries/Ilch/Mail.php
+++ b/application/libraries/Ilch/Mail.php
@@ -343,27 +343,27 @@ class Mail
 
         try {
             $mail->setFrom($this->getFromEmail(), $this->getFromName());
-            if ($this->getReplyTo() != '') {
+            if (!empty($this->getReplyTo())) {
                 $mail->addReplyTo($this->getReplyTo());
             }
-            if ($this->getToName() != '') {
+            if (!empty($this->getToName())) {
                 $mail->addAddress($to, $this->getToName());
             } else {
                 $mail->addAddress($to);
             }
-            if ($this->getBccEmail() != '') {
+            if (!empty($this->getBccEmail())) {
                 $indiBCC = explode(' ', $this->getBccEmail());
                 foreach ($indiBCC as $key => $value) {
                     $mail->addBCC($value);
                 }
             }
-            if ($this->getCcEmail() != '') {
+            if (!empty($this->getCcEmail())) {
                 $indiCC = explode(' ', $this->getCcEmail());
                 foreach ($indiCC as $key => $value) {
                     $mail->addCC($value);
                 }
             }
-            if ($this->getReplyTo() != '') {
+            if (!empty($this->getReplyTo())) {
                 $indiReplyTo = explode(' ', $this->getReplyTo());
                 foreach ($indiReplyTo as $key => $value) {
                     $mail->addReplyTo($value);
@@ -375,7 +375,7 @@ class Mail
         $mail->isHTML();
         $mail->CharSet = 'UTF-8';
         $mail->Subject = $this->getSubject();
-        if ($this->getMessage() == '') {
+        if (empty($this->getMessage())) {
             $body = '';
         } else {
             $body = $this->getMessage();

--- a/application/libraries/Ilch/Mail.php
+++ b/application/libraries/Ilch/Mail.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -11,42 +11,51 @@ use PHPMailer\PHPMailer\PHPMailer;
 class Mail
 {
     /**
-     * @var
+     * @var string
      */
     protected $fromName;
 
     /**
-     * @var
+     * @var string
      */
     protected $fromEmail;
 
     /**
-     * @var
+     * @var string
      */
     protected $toName;
 
     /**
-     * @var
+     * @var string
      */
     protected $toEmail;
 
     /**
-     * @var
+     * @var string
      */
     protected $ccEmail;
 
     /**
-     * @var
+     * @var string
      */
     protected $bccEmail;
 
     /**
-     * @var
+     * The "Reply-To:" field as described in RFC 5322 section 3.6.2
+     * The reply field indicates the address(es) to which the author of
+     * the message suggests that replies be sent.
+     *
+     * @var string
+     */
+    protected $replyTo;
+
+    /**
+     * @var string
      */
     protected $subject;
 
     /**
-     * @var
+     * @var string
      */
     protected $message;
 
@@ -61,7 +70,9 @@ class Mail
     }
 
     /**
-     * @return mixed
+     * Get the name of the author (from field)
+     *
+     * @return string
      */
     public function getFromName()
     {
@@ -69,7 +80,9 @@ class Mail
     }
 
     /**
-     * @param mixed $fromName
+     * Set the name of the author (from field)
+     *
+     * @param string $fromName
      * @return $this
      */
     public function setFromName($fromName)
@@ -79,7 +92,9 @@ class Mail
     }
 
     /**
-     * @return mixed
+     * Get the mail address of the author (from field)
+     *
+     * @return string
      */
     public function getFromEmail()
     {
@@ -87,7 +102,9 @@ class Mail
     }
 
     /**
-     * @param mixed $fromEmail
+     * Set the mail address of the author (from field)
+     *
+     * @param string $fromEmail
      * @return $this
      */
     public function setFromEmail($fromEmail)
@@ -97,7 +114,9 @@ class Mail
     }
 
     /**
-     * @return mixed
+     * Get the name of the receiver.
+     *
+     * @return string
      */
     public function getToName()
     {
@@ -105,7 +124,9 @@ class Mail
     }
 
     /**
-     * @param mixed $toName
+     * Set the name of the receiver.
+     *
+     * @param string $toName
      * @return $this
      */
     public function setToName($toName)
@@ -115,7 +136,9 @@ class Mail
     }
 
     /**
-     * @return mixed
+     * Get the mail address of the receiver.
+     *
+     * @return string
      */
     public function getToEmail()
     {
@@ -123,7 +146,9 @@ class Mail
     }
 
     /**
-     * @param mixed $toEmail
+     * Set the mail address of the receiver.
+     *
+     * @param string $toEmail
      * @return $this
      */
     public function setToEmail($toEmail)
@@ -133,7 +158,10 @@ class Mail
     }
 
     /**
-     * @return mixed
+     * Get the mail addresses of the cc field (carbon copy).
+     * It can contain multiply mail addresses seperated by whitespaces.
+     *
+     * @return string
      */
     public function getCcEmail()
     {
@@ -141,7 +169,10 @@ class Mail
     }
 
     /**
-     * @param mixed $ccEmail
+     * Set the mail addresses of the cc field (carbon copy).
+     * It can contain multiply mail addresses seperated by whitespaces.
+     *
+     * @param string $ccEmail
      * @return $this
      */
     public function setCcEmail($ccEmail)
@@ -151,7 +182,10 @@ class Mail
     }
 
     /**
-     * @return mixed
+     * Get the mail addresses of the bcc field (blank carbon copy).
+     * It can contain multiply mail addresses seperated by whitespaces.
+     *
+     * @return string
      */
     public function getBccEmail()
     {
@@ -159,7 +193,10 @@ class Mail
     }
 
     /**
-     * @param mixed $bccEmail
+     * Get the mail addresses of the bcc field (blank carbon copy).
+     * It can contain multiply mail addresses seperated by whitespaces.
+     *
+     * @param string $bccEmail
      * @return $this
      */
     public function setBccEmail($bccEmail)
@@ -169,7 +206,35 @@ class Mail
     }
 
     /**
-     * @return mixed
+     * Get the mail addresses of the "Reply-To:" field.
+     * It can contain multiply mail addresses seperated by whitespaces.
+     *
+     * @return string
+     * @since 2.1.32
+     */
+    public function getReplyTo()
+    {
+        return $this->replyTo;
+    }
+
+    /**
+     * Set the Get the mail addresses of the "Reply-To:" field.
+     * It can contain multiply mail addresses seperated by whitespaces.
+     *
+     * @param string $replyTo
+     * @return Mail
+     * @since 2.1.32
+     */
+    public function setReplyTo($replyTo)
+    {
+        $this->replyTo = $replyTo;
+        return $this;
+    }
+
+    /**
+     * Get the subject of the message.
+     *
+     * @return string
      */
     public function getSubject()
     {
@@ -177,7 +242,9 @@ class Mail
     }
 
     /**
-     * @param mixed $subject
+     * Set the subject of the message.
+     *
+     * @param string $subject
      * @return $this
      */
     public function setSubject($subject)
@@ -187,7 +254,9 @@ class Mail
     }
 
     /**
-     * @return mixed
+     * Get the body of the message.
+     *
+     * @return string
      */
     public function getMessage()
     {
@@ -195,7 +264,9 @@ class Mail
     }
 
     /**
-     * @param mixed $message
+     * Set the body of the message.
+     *
+     * @param string $message
      * @return $this
      */
     public function setMessage($message)
@@ -205,6 +276,9 @@ class Mail
     }
 
     /**
+     * Get the type of the message.
+     * This is phpmailer specific.
+     *
      * @return string
      */
     public function getType()
@@ -213,6 +287,9 @@ class Mail
     }
 
     /**
+     * Set the type of the message.
+     * This is phpmailer specific.
+     *
      * @param string $type
      * @return $this
      */
@@ -222,6 +299,12 @@ class Mail
         return $this;
     }
 
+    /**
+     * Send an email.
+     * Various fields of this class must be set for this to work.
+     *
+     * @throws \PHPMailer\PHPMailer\Exception
+     */
     public function sent()
     {
         $config = \Ilch\Registry::get('config');
@@ -259,12 +342,9 @@ class Mail
         }
 
         try {
-            if ($this->getFromName() != '') {
-                $mail->addReplyTo($this->getFromEmail(), $this->getFromName());
-                $mail->setFrom($this->getFromEmail(), $this->getFromName());
-            } else {
-                $mail->addReplyTo($this->getFromEmail());
-                $mail->setFrom($this->getFromEmail(), $this->getFromEmail());
+            $mail->setFrom($this->getFromEmail(), $this->getFromName());
+            if ($this->getReplyTo() != '') {
+                $mail->addReplyTo($this->getReplyTo());
             }
             if ($this->getToName() != '') {
                 $mail->addAddress($to, $this->getToName());
@@ -283,7 +363,13 @@ class Mail
                     $mail->addCC($value);
                 }
             }
-        } catch (\phpmailerException $e) { //Catch all kinds of bad addressing
+            if ($this->getReplyTo() != '') {
+                $indiReplyTo = explode(' ', $this->getReplyTo());
+                foreach ($indiReplyTo as $key => $value) {
+                    $mail->addReplyTo($value);
+                }
+            }
+        } catch (\phpmailerException $e) { // Catch all kinds of bad addressing
             throw new \phpmailerException($e->getMessage());
         }
         $mail->isHTML();
@@ -294,8 +380,8 @@ class Mail
         } else {
             $body = $this->getMessage();
         }
-        $mail->WordWrap = 78; // set word wrap to the RFC2822 limit
-        $mail->Body = $body; //Create message bodies and embed images
+        $mail->WordWrap = 78; // Set word wrap to the RFC2822 limit
+        $mail->Body = $body; // Create message bodies and embed images
         //$mail->addAttachment('images/phpmailer_mini.png', 'phpmailer_mini.png'); // optional name
         //$mail->addAttachment('images/phpmailer.png', 'phpmailer.png'); // optional name
         try {

--- a/application/modules/contact/controllers/Index.php
+++ b/application/modules/contact/controllers/Index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -60,18 +60,19 @@ class Index extends \Ilch\Controller\Frontend
                     $messageTemplate = file_get_contents(APPLICATION_PATH.'/modules/contact/layouts/mail/contact.php');
                 }
 
+                // $content gets encoded with rawurlencode() for "encodedContent" to later add it to the mailto URI.
                 $messageReplace = [
                     '{subject}' => $subject,
                     '{content}' => $content,
+                    '{encodedContent}' => rawurlencode($content),
                     '{sitetitle}' => $this->getConfig()->get('page_title'),
-                    '{date}' => $date->format("l, d. F Y", true),
+                    '{date}' => $date->format('l, d. F Y', true),
                     '{senderMail}' => $senderMail,
                     '{senderName}' => $senderName,
                     '{from}' => $this->getTranslator()->trans('mailFrom'),
                     '{writes}' => $this->getTranslator()->trans('writes'),
-                    '{writeBackLink}' => $this->getTranslator()->trans('mailWriteBackLink'),
+                    '{writeBackLink}' => $this->getTranslator()->trans('directOrReplyLink'),
                     '{reply}' => $this->getTranslator()->trans('reply'),
-                    '{footer}' => $this->getTranslator()->trans('noReplyMailFooter'),
                 ];
                 $message = str_replace(array_keys($messageReplace), array_values($messageReplace), $messageTemplate);
 
@@ -80,6 +81,7 @@ class Index extends \Ilch\Controller\Frontend
                     ->setFromEmail($this->getConfig()->get('standardMail'))
                     ->setToName($receiver->getName())
                     ->setToEmail($receiver->getEmail())
+                    ->setReplyTo($senderMail)
                     ->setSubject($subject)
                     ->setMessage($message)
                     ->sent();

--- a/application/modules/contact/controllers/admin/Index.php
+++ b/application/modules/contact/controllers/admin/Index.php
@@ -29,7 +29,7 @@ class Index extends \Ilch\Controller\Admin
             ]
         ];
 
-        if ($this->getRequest()->getActionName() == 'treat') {
+        if ($this->getRequest()->getActionName() === 'treat') {
             $items[0][0]['active'] = true;
         } else {
             $items[0]['active'] = true;
@@ -50,7 +50,7 @@ class Index extends \Ilch\Controller\Admin
                 ->add($this->getTranslator()->trans('menuContact'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('manage'), ['action' => 'index']);
 
-        if ($this->getRequest()->getPost('action') == 'delete' && $this->getRequest()->getPost('check_receivers')) {
+        if ($this->getRequest()->getPost('action') === 'delete' && $this->getRequest()->getPost('check_receivers')) {
             foreach ($this->getRequest()->getPost('check_receivers') as $receiveId) {
                 $receiverMapper->delete($receiveId);
             }

--- a/application/modules/contact/layouts/mail/contact.php
+++ b/application/modules/contact/layouts/mail/contact.php
@@ -58,24 +58,6 @@
         }
 
         /* -------------------------------------
-            FOOTER
-        ------------------------------------- */
-        table.footer-wrap {
-            width: 100%;
-            clear: both!important;
-        }
-
-        .footer-wrap .container p {
-            font-size: 12px;
-            color: #666;
-
-        }
-
-        table.footer-wrap a {
-            color: #999;
-        }
-
-        /* -------------------------------------
             TYPOGRAPHY
         ------------------------------------- */
         h1, h2, h3 {
@@ -158,7 +140,7 @@
                                     <p>{senderName} {writes}:</p>
                                     <p>{content}</p>
                                     <p>&nbsp;</p>
-                                    <p>{writeBackLink}: <a href="mailto:{senderMail}?subject=Re: {subject}" target="_top">{reply}</a></p>
+                                    <p>{writeBackLink}: <a href="mailto:{senderMail}?subject=Re: {subject}&body={encodedContent}" target="_top">{reply}</a></p>
                                 </td>
                             </tr>
                         </table>
@@ -169,19 +151,5 @@
             </tr>
         </table>
         <!-- /body -->
-
-        <!-- footer -->
-        <table class="footer-wrap">
-            <tr>
-                <td></td>
-                <td class="container">
-                    <div class="content" align="center">
-                        <p>{footer}</p>
-                    </div>
-                </td>
-                <td></td>
-            </tr>
-        </table>
-        <!-- /footer -->
     </body>
 </html>

--- a/application/modules/contact/translations/de.php
+++ b/application/modules/contact/translations/de.php
@@ -19,4 +19,5 @@ return [
     'writes' => 'schreibt',
     'privacy' => 'Datenschutzerklärung',
     'acceptPrivacy' => 'Ich hab die <a href="/index.php/privacy/index/index" title="Datenschutzerklärung" target="_blank">Datenschutzerklärung</a>  zur Kenntnis genommen.',
+    'directOrReplyLink' => 'Sie können direkt auf diese E-Mail antworten oder folgenden Link nutzen',
 ];

--- a/application/modules/contact/translations/en.php
+++ b/application/modules/contact/translations/en.php
@@ -19,4 +19,5 @@ return [
     'writes' => 'writes',
     'privacy' => 'Privacy',
     'acceptPrivacy' => 'I have read the <a href="/index.php/privacy/index/index" title="data protection information" target="_blank">data protection information</a>.',
+    'directOrReplyLink' => 'You can reply directly to this email or use the following link',
 ];


### PR DESCRIPTION
# Description

- Add replyTo to mail class
- Usage in the contact module to allow a direct reply to the email.
- Added the mail body to the mailto URI.

It was impossible to directly reply to an email received over the contact module. Further the mailto URI, which is added to the email, lacked the email body.

https://www.ilch.de/forum-showposts-55978.html

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [X] Opera
- [ ] Edge
- [ ] IE
