### PR TITLE
Add some layout requirements

### DIFF
--- a/application/modules/admin/controllers/admin/Index.php
+++ b/application/modules/admin/controllers/admin/Index.php
@@ -88,7 +88,7 @@ class Index extends \Ilch\Controller\Admin
             }
         }
 
-        if ($update->newVersionFound() === true) {
+        if ($update->newVersionFound() == true) {
             $newVersion = $update->getNewVersion();
             $this->getView()->set('foundNewVersions', true);
             $this->getView()->set('newVersion', $newVersion);

--- a/application/modules/admin/controllers/admin/Layouts.php
+++ b/application/modules/admin/controllers/admin/Layouts.php
@@ -378,14 +378,17 @@ class Layouts extends \Ilch\Controller\Admin
                 }
                 removeDir(APPLICATION_PATH.'/layouts/'.$this->getRequest()->getParam('key'));
 
-                // Call uninstall() of module related to the layout
+                // Call uninstall() of module related to the layout if it is installed. Delete folder of module.
                 if (is_dir(APPLICATION_PATH.'/modules/'.$this->getRequest()->getParam('key'))) {
                     $modules = new ModuleMapper();
 
-                    $configClass = '\\Modules\\'.ucfirst($this->getRequest()->getParam('key')).'\\Config\\Config';
-                    $config = new $configClass();
-                    $config->uninstall();
-                    $modules->delete($this->getRequest()->getParam('key'));
+                    $isInstalled = $modules->getModuleByKey($this->getRequest()->getParam('key'));
+                    if ($isInstalled) {
+                        $configClass = '\\Modules\\'.ucfirst($this->getRequest()->getParam('key')).'\\Config\\Config';
+                        $config = new $configClass();
+                        $config->uninstall();
+                        $modules->delete($this->getRequest()->getParam('key'));
+                    }
 
                     removeDir(APPLICATION_PATH.'/modules/'.$this->getRequest()->getParam('key'));
                 }

--- a/application/modules/admin/mappers/Module.php
+++ b/application/modules/admin/mappers/Module.php
@@ -47,6 +47,8 @@ class Module extends \Ilch\Mapper
 
     /**
      * Gets all not installed modules.
+     *
+     * @return ModuleModel[]|Array[]
      */
     public function getModulesNotInstalled()
     {
@@ -140,8 +142,7 @@ class Module extends \Ilch\Mapper
      * Get module with given key.
      *
      * @param string $key
-     *
-     * @return ModuleModel
+     * @return ModuleModel|null
      */
     public function getModuleByKey($key) {
         $moduleRow = $this->db()->select('*')
@@ -151,7 +152,7 @@ class Module extends \Ilch\Mapper
             ->fetchAssoc();
 
         if (empty($moduleRow)) {
-            return;
+            return null;
         }
 
         $moduleModel = new ModuleModel();
@@ -169,6 +170,8 @@ class Module extends \Ilch\Mapper
 
     /**
      * Gets an array of keys of the installed modules.
+     *
+     * @return array|string[]
      */
     public function getKeysInstalledModules()
     {
@@ -222,7 +225,6 @@ class Module extends \Ilch\Mapper
      * Inserts a module model in the database.
      *
      * @param ModuleModel $module
-     *
      * @return int
      */
     public function save(ModuleModel $module)

--- a/application/modules/admin/models/Layout.php
+++ b/application/modules/admin/models/Layout.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -70,6 +70,14 @@ class Layout extends \Ilch\Model
      * @var array
      */
     protected $settings;
+
+
+    /**
+     * The required ilch version if needed.
+     *
+     * @var string
+     */
+    protected $ilchCore;
 
     /**
      * Gets the key.
@@ -252,4 +260,28 @@ class Layout extends \Ilch\Model
         $this->settings = $settings;
         return $this;
     }
+
+    /**
+     * Get the required ilch version if needed.
+     *
+     * @return string
+     */
+    public function getIlchCore()
+    {
+        return $this->ilchCore;
+    }
+
+    /**
+     * Set the required ilch version if needed.
+     *
+     * @param string $ilchCore
+     * @return Layout
+     */
+    public function setIlchCore($ilchCore)
+    {
+        $this->ilchCore = $ilchCore;
+        return $this;
+    }
+
+
 }

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -210,6 +210,7 @@ return [
     'noPages' => 'Keine Seiten vorhanden',
     'choose' => 'Auswählen',
     'lastUpdateOn' => 'Zuletzt geprüft am',
+    'layoutModuleNotInstalled' => 'Das dazugehörige Modul ist nicht installiert.',
 
     'menuInfos' => 'Informationen',
     'menuPHPInfo' => 'PHP Info',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -210,6 +210,7 @@ return [
     'noPages' => 'No pages available',
     'choose' => 'Choose',
     'lastUpdateOn' => 'Last checked on',
+    'layoutModuleNotInstalled' => 'The associated module is not installed.',
 
     'menuInfos' => 'Information',
     'menuPHPInfo' => 'PHP Info',

--- a/application/modules/admin/views/admin/layouts/search.php
+++ b/application/modules/admin/views/admin/layouts/search.php
@@ -7,6 +7,7 @@ $layoutsOnUpdateServer = json_decode($layoutsList);
 $versionsOfLayouts = $this->get('versionsOfLayouts');
 $cacheFilename = ROOT_PATH.'/cache/'.md5($this->get('updateserver').'layouts.php').'.cache';
 $cacheFileDate = new \Ilch\Date(date('Y-m-d H:i:s.', filemtime($cacheFilename)));
+$coreVersion = $this->get('coreVersion');
 
 if (empty($layoutsOnUpdateServer)) {
     echo $this->getTrans('noLayoutsAvailable');
@@ -42,26 +43,41 @@ if (empty($layoutsOnUpdateServer)) {
                 <div class="clearfix">
                     <div class="pull-left">
                         <?php
-                        if (in_array($layoutOnUpdateServer->key, $this->get('layouts')) && version_compare($versionsOfLayouts[$layoutOnUpdateServer->key], $layoutOnUpdateServer->version, '>=')): ?>
+                        $layoutExists = in_array($layoutOnUpdateServer->key, $this->get('layouts'));
+                        $ilchCoreRequirement = empty($layoutOnUpdateServer->ilchCore) ? $coreVersion : $layoutOnUpdateServer->ilchCore;
+                        $ilchCoreTooOld = version_compare($coreVersion, $ilchCoreRequirement, '<');
+                        if ($layoutExists && version_compare($versionsOfLayouts[$layoutOnUpdateServer->key], $layoutOnUpdateServer->version, '>=')): ?>
                             <span class="btn disabled" title="<?=$this->getTrans('alreadyExists') ?>">
-                                <i class="fa fa-check text-success"></i>
+                                <i class="fas fa-check text-success"></i>
                             </span>
-                        <?php elseif (in_array($layoutOnUpdateServer->key, $this->get('layouts')) && version_compare($versionsOfLayouts[$layoutOnUpdateServer->key], $layoutOnUpdateServer->version, '<')): ?>
-                            <form method="POST" action="<?=$this->getUrl(['action' => 'update', 'key' => $layoutOnUpdateServer->key, 'version' => $versionsOfLayouts[$layoutOnUpdateServer->key], 'newVersion' => $layoutOnUpdateServer->version, 'from' => 'search']) ?>">
-                                <?=$this->getTokenField() ?>
-                                <button type="submit"
-                                        class="btn btn-default"
-                                        title="<?=$this->getTrans('layoutUpdate') ?>">
-                                    <i class="fa fa-refresh"></i>
+                        <?php elseif ($layoutExists && version_compare($versionsOfLayouts[$layoutOnUpdateServer->key], $layoutOnUpdateServer->version, '<')): ?>
+                            <?php if ($ilchCoreTooOld): ?>
+                                <button class="btn disabled"
+                                        title="<?=$this->getTrans('ilchCoreError') ?>">
+                                    <i class="fas fa-sync"></i>
                                 </button>
-                            </form>
+                            <?php else: ?>
+                                <form method="POST" action="<?=$this->getUrl(['action' => 'update', 'key' => $layoutOnUpdateServer->key, 'version' => $versionsOfLayouts[$layoutOnUpdateServer->key], 'newVersion' => $layoutOnUpdateServer->version, 'from' => 'search']) ?>">
+                                    <?=$this->getTokenField() ?>
+                                    <button type="submit"
+                                            class="btn btn-default"
+                                            title="<?=$this->getTrans('layoutUpdate') ?>">
+                                        <i class="fas fa-sync"></i>
+                                    </button>
+                                </form>
+                            <?php endif; ?>
+                        <?php elseif ($ilchCoreTooOld): ?>
+                            <button class="btn disabled"
+                                    title="<?=$this->getTrans('ilchCoreError') ?>">
+                                <i class="fas fa-download"></i>
+                            </button>
                         <?php else: ?>
                             <form method="POST" action="<?=$this->getUrl(['action' => 'search', 'key' => $layoutOnUpdateServer->key, 'version' => $layoutOnUpdateServer->version]) ?>">
                                 <?=$this->getTokenField() ?>
                                 <button type="submit"
                                         class="btn btn-default"
                                         title="<?=$this->getTrans('layoutDownload') ?>">
-                                    <i class="fa fa-download"></i>
+                                    <i class="fas fa-download"></i>
                                 </button>
                             </form>
                         <?php endif; ?>
@@ -69,7 +85,7 @@ if (empty($layoutsOnUpdateServer)) {
                     <div class="pull-right">
                         <a href="<?=$this->getUrl(['action' => 'show', 'id' => $layoutOnUpdateServer->id]) ?>" title="<?=$this->getTrans('info') ?>">
                             <span class="btn btn-default">
-                                <i class="fa fa-info text-info"></i>
+                                <i class="fas fa-info text-info"></i>
                             </span>
                         </a>
                     </div>

--- a/application/modules/admin/views/admin/layouts/show.php
+++ b/application/modules/admin/views/admin/layouts/show.php
@@ -109,7 +109,7 @@ foreach ($layouts as $layout): ?>
                         </div>
                     </div>
                     <br />
-                    <?php if (!empty($module->ilchCore)): ?>
+                    <?php if (!empty($layout->ilchCore)): ?>
                         <div class="row">
                             <div class="col-xs-12">
                                 <b><?=$this->getTrans('requirements') ?>:</b>

--- a/application/modules/admin/views/admin/layouts/show.php
+++ b/application/modules/admin/views/admin/layouts/show.php
@@ -109,6 +109,20 @@ foreach ($layouts as $layout): ?>
                         </div>
                     </div>
                     <br />
+                    <?php if (!empty($module->ilchCore)): ?>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <b><?=$this->getTrans('requirements') ?>:</b>
+                            </div>
+                            <div class="col-sm-3 col-xs-6">
+                                <b><?=$this->getTrans('ilchCoreVersion') ?>:</b>
+                            </div>
+                            <div class="col-sm-9 col-xs-6">
+                                <?=$this->escape($layout->ilchCore) ?>
+                            </div>
+                        </div>
+                        <br />
+                    <?php endif; ?>
                     <div class="row">
                         <div class="col-xs-12">
                             <b><?=$this->getTrans('desc') ?>:</b>


### PR DESCRIPTION
This is still work in progress and a few cases need testing and further work:

- [X] Layout and it's module get properly "installed" when downloaded from the updateserver.
- [ ] No fatal error occurs when the module gets uninstalled or prevent uninstall if layout is in use.
- [X] ilchCore requirement is shown in the info windows (index and search view)
- [X] Download disabled if the ilch version is too old.
- [X] Set as default and settings disabled if ilch version is too old.
- [X] Uninstalling the layout removes the associated module too.

# Description

A layout can now specify the minimum needed Ilch version and further it is now checked if the module associated with the layout is installed.

This is needed as older versions of Ilch obviously don't support the advanced layout settings and language files in layouts.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:

- [ ] Chrome
- [X] Firefox
- [X] Opera
- [x] Edge
- [ ] IE
