### PR TITLE
Ticket 501: Back to startpage after registration

### DIFF
--- a/application/libraries/Ilch/Controller/Base.php
+++ b/application/libraries/Ilch/Controller/Base.php
@@ -167,4 +167,30 @@ class Base
             $_SESSION['messages'][] = ['text' => $this->getTranslator()->trans($message), 'type' => $type];
         }
     }
+
+    /**
+     * Gets the default URL.
+     *
+     * @param string|null $page
+     * @return string
+     * @since 2.1.43
+     */
+    public function getDefaultUrl($page = null)
+    {
+        if (!$page) {
+            $page = $this->getConfig()->get('start_page');
+        }
+
+        $newRouter = new \Ilch\Router(new \Ilch\Request());
+        $newRouter->defineStartPage($page, $this->getTranslator());
+
+        $newRedirect = new \Ilch\Redirect($newRouter->getRequest());
+        if ($newRouter->getRequest()->getControllerName() === 'page') {
+            $pageMapper = new \Modules\Admin\Mappers\Page();
+            $pageModel = $pageMapper->getPageByIdLocale($newRouter->getRequest()->getParam('id'), $newRouter->getRequest()->getParam('locale'));
+            return $newRedirect->getUrl($pageModel->getPerma());
+        } else {
+            return substr($newRedirect->getUrl(['#']), 0, -4);
+        }
+    }
 }

--- a/application/libraries/Ilch/Controller/Base.php
+++ b/application/libraries/Ilch/Controller/Base.php
@@ -167,22 +167,4 @@ class Base
             $_SESSION['messages'][] = ['text' => $this->getTranslator()->trans($message), 'type' => $type];
         }
     }
-
-    /**
-     * Gets the Default Url.
-     *
-     * @param string|null $page
-     * @return string
-     * @since 2.1.43
-     */
-    public function getDefaultUrl($page = null)
-    {
-        if (!$page) {
-            $page = $this->getConfig()->get('start_page');
-        }
-        $newRouter = new \Ilch\Router(new \Ilch\Request());
-        $newRouter->defineStartPage($page, $this->getTranslator());
-        $newRedirect = new \Ilch\Redirect($newRouter->getRequest());
-        return substr($newRedirect->getUrl(['#']), 0, -4);
-    }
 }

--- a/application/libraries/Ilch/Database/Mysql.php
+++ b/application/libraries/Ilch/Database/Mysql.php
@@ -335,21 +335,6 @@ class Mysql
     }
 
     /**
-     * Create Create Query Builder
-     * @todo add Option?
-     *
-     * @param string|null $table table without prefix
-     * @param array|null $column conditions
-     * @param bool $checkExists
-     *
-     * @return \Ilch\Database\Mysql\Delete
-     */
-    //public function create($table = null, $column = null, $checkExists = false)
-    //{
-    //    return new Mysql\Create($this, $table, $column, $checkExists);
-    //}
-
-    /**
      * Drops the table from database.
      *
      * @param string $table table without prefix

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -76,6 +76,7 @@ return [
     'country' => 'Land',
     'navigation' => 'Menüs',
     'modules' => 'Module',
+    'layouts' => 'Layouts',
     'module' => 'Modul',
     'address' => 'Adresse',
     'page' => 'Seite',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -76,6 +76,7 @@ return [
     'country' => 'Country',
     'navigation' => 'Navigation',
     'modules' => 'Modules',
+    'layouts' => 'Layouts',
     'module' => 'Module',
     'address' => 'Address',
     'page' => 'Page',

--- a/application/modules/user/controllers/Regist.php
+++ b/application/modules/user/controllers/Regist.php
@@ -187,8 +187,7 @@ class Regist extends \Ilch\Controller\Frontend
             ->add($this->getTranslator()->trans('step3to3'), ['action' => 'finish']);
 
         $this->getView()->set('regist_confirm', $this->getConfig()->get('regist_confirm'))
-            ->set('regist_setfree', $this->getConfig()->get('regist_setfree'))
-            ->set('finish_url', $this->getDefaultUrl());
+            ->set('regist_setfree', $this->getConfig()->get('regist_setfree'));
     }
 
     public function confirmAction()

--- a/application/modules/user/views/regist/finish.php
+++ b/application/modules/user/views/regist/finish.php
@@ -22,7 +22,7 @@
     </div>
     <div class="panel-footer clearfix">
         <div class="pull-right">
-            <a href="<?=$this->get('finish_url') ?>" class="btn btn-success" role="button"><?=$this->getTrans('nextButton') ?></a>
+            <a href="<?=$this->getUrl() ?>" class="btn btn-success" role="button"><?=$this->getTrans('back') ?></a>
         </div>
     </div>
 </div>

--- a/application/modules/user/views/regist/index.php
+++ b/application/modules/user/views/regist/index.php
@@ -11,7 +11,7 @@
             </div>
             <div class="panel-footer clearfix">
                 <div class="pull-left checkbox inline <?=$this->validation()->hasError('acceptRule') ? 'has-error' : '' ?>">
-                    <input type="checkbox" style="margin-left: 0px;" id="acceptRule" name="acceptRule"value="1"> <label for="acceptRule"><?=$this->getTrans('acceptRule') ?></label>
+                    <input type="checkbox" style="margin-left: 0px;" id="acceptRule" name="acceptRule" value="1"> <label for="acceptRule"><?=$this->getTrans('acceptRule') ?></label>
                 </div>
                 <div class="pull-right">
                     <?=$this->getSaveBar('nextButton', 'Regist') ?>


### PR DESCRIPTION
Fixes #501

The previous solution didn't worked with a page as startpage instead of a module.

https://github.com/IlchCMS/Ilch-2.0/pull/524

# Description

The previous solution didn't worked with a page as startpage instead of a module.
See comments in previous pull request:
https://github.com/IlchCMS/Ilch-2.0/pull/524

Make use of the normal code path to get back to the configured startpage.

Fixes #501

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [X] Opera
- [ ] Edge
- [ ] IE
