### PR TITLE
Remove dependency on the deprecated DbUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "maximebf/debugbar": "^1.15",
         "phpunit/phpunit": "6.*",
-        "phpunit/dbunit": ">=3.0"
+        "symfony/yaml": "^3.3.6"
     },
     "autoload": {
         "psr-0": { "": "application/libraries/" },

--- a/tests/PHPUnit/Ilch/DatabaseTestCase.php
+++ b/tests/PHPUnit/Ilch/DatabaseTestCase.php
@@ -58,10 +58,8 @@ abstract class DatabaseTestCase extends \PHPUnit\Framework\TestCase
 
     /**
      * This method is called before the first test of this test class is run.
-     *
-     * @return void
      */
-    public static function setUpBeforeClass(): void
+    public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
         TestHelper::setConfigInRegistry(static::$configData);
@@ -104,17 +102,6 @@ abstract class DatabaseTestCase extends \PHPUnit\Framework\TestCase
         }
 
         parent::setUp();
-    }
-
-    /**
-     * This method is called after the last test of this test class is run.
-     *
-     * @return void
-     */
-    public static function tearDownAfterClass(): void
-    {
-        $db = Registry::get('db');
-        static::dropTables($db);
     }
 
     /**

--- a/tests/PHPUnit/Ilch/PhpunitDataset.php
+++ b/tests/PHPUnit/Ilch/PhpunitDataset.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace PHPUnit\Ilch;
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Class PhpunitDataset
+ * @package PHPUnit\Ilch
+ */
+class PhpunitDataset extends DatabaseTestCase
+{
+    public function __construct($db)
+    {
+        parent::__construct();
+        $this->db = $db;
+    }
+
+    /**
+     * Load information from multiple files (yml).
+     *
+     * @param array $fullpaths full paths to yml files to load.
+     */
+    public function loadFromFiles(array $fullpaths): void
+    {
+        foreach ($fullpaths as $table => $fullpath) {
+            // Only a table when it's an associative array.
+            $table = \is_int($table) ? null : $table;
+            $this->loadFromFile($fullpath, $table);
+        }
+    }
+
+    /**
+     * Load information from one file (yml).
+     *
+     * @param string $fullpath full path to yml file to load.
+     */
+    public function loadFromFile(string $fullpath): void
+    {
+        if (!file_exists($fullpath)) {
+            throw new coding_exception('File not found: ' . $fullpath);
+        }
+
+        if (!is_readable($fullpath)) {
+            throw new coding_exception('File not readable: ' . $fullpath);
+        }
+
+        $extension = strtolower(pathinfo($fullpath, PATHINFO_EXTENSION));
+        if ($extension !== 'yml') {
+            throw new coding_exception('Cannot handle files with extension: ' . $extension);
+        }
+
+        $this->loadFromString(file_get_contents($fullpath));
+    }
+
+    /**
+     * Load information from a string (yaml).
+     *
+     * @param string $content contents of yaml file to load.
+     */
+    public function loadFromString(string $content): void
+    {
+        try {
+            $parsedYaml = Yaml::parse($content);
+            $this->sendToDatabase($parsedYaml);
+        } catch (ParseException $exception) {
+            printf('Unable to parse the YAML string: %s', $exception->getMessage());
+        }
+    }
+
+    /**
+     * Send all the information to the database.
+     *
+     * @param array $tables
+     */
+    public function sendToDatabase(array $tables): void
+    {
+        foreach($tables as $table => $rows) {
+            $tableNotEmpty = (bool) $this->db->select('*')
+                ->from($table)
+                ->execute()
+                ->fetchCell();
+
+            if ($tableNotEmpty) {
+                $this->db->truncate($table);
+            }
+
+            foreach($rows as $row => $columns) {
+                    $this->db->insert($table)
+                        ->values($columns)
+                        ->execute();
+            }
+        }
+    }
+}

--- a/tests/PHPUnit/Ilch/PhpunitDataset.php
+++ b/tests/PHPUnit/Ilch/PhpunitDataset.php
@@ -21,7 +21,7 @@ class PhpunitDataset extends DatabaseTestCase
      *
      * @param array $fullpaths full paths to yml files to load.
      */
-    public function loadFromFiles(array $fullpaths): void
+    public function loadFromFiles(array $fullpaths)
     {
         foreach ($fullpaths as $table => $fullpath) {
             // Only a table when it's an associative array.
@@ -35,7 +35,7 @@ class PhpunitDataset extends DatabaseTestCase
      *
      * @param string $fullpath full path to yml file to load.
      */
-    public function loadFromFile(string $fullpath): void
+    public function loadFromFile(string $fullpath)
     {
         if (!file_exists($fullpath)) {
             throw new coding_exception('File not found: ' . $fullpath);
@@ -58,7 +58,7 @@ class PhpunitDataset extends DatabaseTestCase
      *
      * @param string $content contents of yaml file to load.
      */
-    public function loadFromString(string $content): void
+    public function loadFromString(string $content)
     {
         try {
             $parsedYaml = Yaml::parse($content);
@@ -73,7 +73,7 @@ class PhpunitDataset extends DatabaseTestCase
      *
      * @param array $tables
      */
-    public function sendToDatabase(array $tables): void
+    public function sendToDatabase(array $tables)
     {
         foreach($tables as $table => $rows) {
             $tableNotEmpty = (bool) $this->db->select('*')

--- a/tests/PHPUnit/Ilch/TestCase.php
+++ b/tests/PHPUnit/Ilch/TestCase.php
@@ -39,7 +39,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         parent::tearDown();
 
         foreach ($this->tearDownCallbacks as $callback) {
-            if (is_callable($callback)) {
+            if (\is_callable($callback)) {
                 $callback();
             }
         }

--- a/tests/PHPUnit/Ilch/TestHelper.php
+++ b/tests/PHPUnit/Ilch/TestHelper.php
@@ -5,7 +5,7 @@
 
 namespace PHPUnit\Ilch;
 
-use Ilch\Registry as Registry;
+use Ilch\Registry;
 use Ilch\Config\File as Config;
 
 /**
@@ -29,14 +29,12 @@ class TestHelper
      */
     public static function setConfigInRegistry(array $configData)
     {
-        if (static::$config === null) {
-            if (!Registry::has('config') && file_exists(CONFIG_PATH . '/config.php')) {
-                static::$config = new Config();
-                static::$config->loadConfigFromFile(CONFIG_PATH . '/config.php');
+        if ((static::$config === null) && !Registry::has('config') && file_exists(CONFIG_PATH . '/config.php')) {
+            static::$config = new Config();
+            static::$config->loadConfigFromFile(CONFIG_PATH . '/config.php');
 
-                foreach ($configData as $configKey => $configValue) {
-                    static::$config->set($configKey, $configValue);
-                }
+            foreach ($configData as $configKey => $configValue) {
+                static::$config->set($configKey, $configValue);
             }
         }
 

--- a/tests/libraries/ilch/AccessesTest.php
+++ b/tests/libraries/ilch/AccessesTest.php
@@ -9,6 +9,7 @@ namespace libraries\ilch;
 use Ilch\Request;
 use Ilch\Accesses;
 use PHPUnit\Ilch\DatabaseTestCase;
+use PHPUnit\Ilch\PhpunitDataset;
 
 class AccessesTest extends DatabaseTestCase
 {
@@ -20,6 +21,8 @@ class AccessesTest extends DatabaseTestCase
     protected $request;
 
     protected $_SESSION;
+
+    protected $phpunitDataset;
 
     protected static function getSchemaSQLQueries()
     {
@@ -80,19 +83,10 @@ class AccessesTest extends DatabaseTestCase
     public function setUp()
     {
         parent::setUp();
-
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/_files/mysql_accesses.yml');
         $this->request = new Request();
         $_SESSION = [];
-    }
-
-    /**
-     * Returns the test dataset.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet()
-    {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/_files/mysql_accesses.yml');
     }
 
     public function testHasAccessModule()
@@ -101,7 +95,7 @@ class AccessesTest extends DatabaseTestCase
         $accesses = new Accesses($this->request);
 
         $result = $accesses->hasAccess('Module');
-        $this->assertTrue($result, 'User 1 should have access.');
+        self::assertTrue($result, 'User 1 should have access.');
     }
 
     /**
@@ -114,7 +108,7 @@ class AccessesTest extends DatabaseTestCase
         $accesses = new Accesses($this->request);
 
         $result = $accesses->hasAccess('Module');
-        $this->assertTrue($result, 'User 2 should have access to the article module.');
+        self::assertTrue($result, 'User 2 should have access to the article module.');
     }
 
     /**
@@ -127,7 +121,7 @@ class AccessesTest extends DatabaseTestCase
         $accesses = new Accesses($this->request);
 
         $result = $accesses->hasAccess('Module');
-        $this->assertTrue($result, 'User 2 should have access to the checkout module.');
+        self::assertTrue($result, 'User 2 should have access to the checkout module.');
     }
 
     /**
@@ -140,7 +134,7 @@ class AccessesTest extends DatabaseTestCase
         $accesses = new Accesses($this->request);
 
         $result = $accesses->hasAccess('Module');
-        $this->assertFalse($result, 'User 2 should not have access to the forum module.');
+        self::assertFalse($result, 'User 2 should not have access to the forum module.');
     }
 
     public function testHasAccessAdmin()
@@ -149,7 +143,7 @@ class AccessesTest extends DatabaseTestCase
         $accesses = new Accesses($this->request);
 
         $result = $accesses->hasAccess('Admin');
-        $this->assertTrue($result, 'An admin should have access.');
+        self::assertTrue($result, 'An admin should have access.');
     }
 
     /**
@@ -164,7 +158,7 @@ class AccessesTest extends DatabaseTestCase
         $accesses = new Accesses($this->request);
 
         $result = $accesses->hasAccess('Module');
-        $this->assertTrue($result, 'User 2 should have access to the page.');
+        self::assertTrue($result, 'User 2 should have access to the page.');
     }
 
     /**
@@ -180,6 +174,6 @@ class AccessesTest extends DatabaseTestCase
         $accesses = new Accesses($this->request);
 
         $result = $accesses->hasAccess('Module');
-        $this->assertFalse($result, 'User 2 should not have access to the page.');
+        self::assertFalse($result, 'User 2 should not have access to the page.');
     }
 }

--- a/tests/libraries/ilch/ConfigTest.php
+++ b/tests/libraries/ilch/ConfigTest.php
@@ -36,7 +36,7 @@ class ConfigTest extends TestCase
     public function testSetAndGetConfig()
     {
         $this->config->set('email', 'testuser@testmail.com');
-        $this->assertEquals(
+        self::assertEquals(
             'testuser@testmail.com',
             $this->config->get('email'),
             'Config value got manipulated unexpectedly.'
@@ -57,7 +57,7 @@ class ConfigTest extends TestCase
 
         $this->config->loadConfigFromFile(__DIR__ . '/_files/config.php');
 
-        $this->assertEquals(
+        self::assertEquals(
             $configArray,
             [
                 'dbHost'     => $this->config->get('dbHost'),

--- a/tests/libraries/ilch/Database/Mysql/InsertTest.php
+++ b/tests/libraries/ilch/Database/Mysql/InsertTest.php
@@ -25,17 +25,15 @@ class InsertTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->setMethods(['escape', 'getLastInsertId'])
             ->getMockForAbstractClass();
-        $db->expects($this->any())
-            ->method('escape')
-            ->will($this->returnCallback(function ($value, $addQuotes = false) {
+        $db->method('escape')
+            ->willReturnCallback(function ($value, $addQuotes = false) {
                 if ($addQuotes) {
                     $value = '"' . $value . '"';
                 }
                 return $value;
-            }));
-        $db->expects($this->any())
-            ->method('getLastInsertId')
-            ->will($this->returnValue($this->lastInsetId));
+            });
+        $db->method('getLastInsertId')
+            ->willReturn($this->lastInsetId);
 
         $this->out = new Insert($db);
     }
@@ -66,6 +64,6 @@ class InsertTest extends \PHPUnit\Framework\TestCase
         $expected = 'INSERT INTO `[prefix]_Test` '
             . '(`super`,`next`) VALUES ("data","fieldData")';
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 }

--- a/tests/libraries/ilch/Database/Mysql/ResultTest.php
+++ b/tests/libraries/ilch/Database/Mysql/ResultTest.php
@@ -1,26 +1,26 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
 namespace Ilch\Database\Mysql;
 
 use PHPUnit\Ilch\DatabaseTestCase;
+use PHPUnit\Ilch\PhpunitDataset;
 use PHPUnit_Extensions_Database_DataSet_IDataSet;
 
 class ResultTest extends DatabaseTestCase
 {
     static protected $fillDbOnSetUp = self::PROVISION_ON_SETUP_BEFORE_CLASS;
 
-    /**
-     * Returns the test dataset.
-     *
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet()
+    protected $phpunitDataset;
+
+    public function setUp()
     {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/../../_files/mysql_database.yml');
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../../_files/mysql_database.yml');
     }
 
     /**
@@ -32,7 +32,7 @@ class ResultTest extends DatabaseTestCase
     public function testFetchCell($cellParam, $expected)
     {
         $result = $this->db->select('*', 'groups')->execute();
-        $this->assertEquals($expected, $result->fetchCell($cellParam));
+        self::assertEquals($expected, $result->fetchCell($cellParam));
     }
 
     /**
@@ -73,7 +73,7 @@ class ResultTest extends DatabaseTestCase
     public function testFetchArray($type, $expected)
     {
         $result = $this->db->select('*', 'groups')->execute();
-        $this->assertEquals($expected, $result->fetchArray($type));
+        self::assertEquals($expected, $result->fetchArray($type));
     }
 
     /**
@@ -110,7 +110,7 @@ class ResultTest extends DatabaseTestCase
             ->execute();
 
         foreach ($expectedRows as $expectedRow) {
-            $this->assertSame($expectedRow, $result->fetchRow());
+            self::assertSame($expectedRow, $result->fetchRow());
         }
     }
 
@@ -127,7 +127,7 @@ class ResultTest extends DatabaseTestCase
             ->execute();
 
         foreach ($expectedRows as $expectedRow) {
-            $this->assertSame($expectedRow, $result->fetchAssoc());
+            self::assertSame($expectedRow, $result->fetchAssoc());
         }
     }
 
@@ -144,7 +144,7 @@ class ResultTest extends DatabaseTestCase
             ->limit(2)
             ->execute();
 
-        $this->assertEquals($expectedRows, $result->fetchRows($keyField, $type));
+        self::assertEquals($expectedRows, $result->fetchRows($keyField, $type));
     }
 
     /**
@@ -210,7 +210,7 @@ class ResultTest extends DatabaseTestCase
             ->limit(2)
             ->execute();
 
-        $this->assertEquals($expectedList, $result->fetchList($field, $keyField));
+        self::assertEquals($expectedList, $result->fetchList($field, $keyField));
     }
 
     /**
@@ -257,7 +257,7 @@ class ResultTest extends DatabaseTestCase
             ->limit($limit)
             ->execute();
 
-        $this->assertSame($limit, $result->getFoundRows());
+        self::assertSame($limit, $result->getFoundRows());
     }
 
     /**
@@ -280,7 +280,7 @@ class ResultTest extends DatabaseTestCase
             ->limit(1)
             ->execute();
 
-        $this->assertSame($expected, $result->getFieldCount());
+        self::assertSame($expected, $result->getFieldCount());
     }
 
     /**
@@ -309,7 +309,7 @@ class ResultTest extends DatabaseTestCase
             ->useFoundRows()
             ->execute();
 
-        $this->assertSame($expected, $result->getFoundRows());
+        self::assertSame($expected, $result->getFoundRows());
     }
 
     public function testSetCurrentRow()
@@ -320,7 +320,7 @@ class ResultTest extends DatabaseTestCase
 
         $result->setCurrentRow(1);
 
-        $this->assertSame('Guest', $result->fetchCell());
+        self::assertSame('Guest', $result->fetchCell());
     }
 
     public function testGetMysqliResult()
@@ -337,7 +337,7 @@ class ResultTest extends DatabaseTestCase
         ];
 
         foreach ($mysqliResult as $key => $row) {
-            $this->assertSame($expectedRows[$key], $row);
+            self::assertSame($expectedRows[$key], $row);
         }
     }
 } 

--- a/tests/libraries/ilch/Database/Mysql/SelectTest.php
+++ b/tests/libraries/ilch/Database/Mysql/SelectTest.php
@@ -24,14 +24,13 @@ class SelectTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->setMethods(['escape'])
             ->getMockForAbstractClass();
-        $db->expects($this->any())
-            ->method('escape')
-            ->will($this->returnCallback(function ($value, $addQuotes = false) {
+        $db->method('escape')
+            ->willReturnCallback(function ($value, $addQuotes = false) {
                 if ($addQuotes) {
                     $value = '"' . $value . '"';
                 }
                 return $value;
-            }));
+            });
 
         $this->out = new Select($db);
     }
@@ -56,7 +55,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
 
         $expected = 'SELECT * FROM ' . $expectedSqlPart;
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -93,7 +92,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
 
         $expected = 'SELECT ' . $expectedSqlPart . ' FROM `[prefix]_Test`';
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -149,7 +148,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      */
     public function testGenerateSqlForWhere($where, $expectedSqlPart, $type = null)
     {
-        if (is_callable($where)) {
+        if (\is_callable($where)) {
             $where = $where($this->out);
         }
 
@@ -163,7 +162,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
         $expected = 'SELECT * FROM `[prefix]_Test`'
             . ' WHERE ' . $expectedSqlPart;
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -252,7 +251,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
         $expected = 'SELECT * FROM `[prefix]_Test`'
             . ' WHERE `field1` ' . $operator . ' "5"';
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -283,7 +282,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
         $expected = 'SELECT * FROM `[prefix]_Test`'
             . ' WHERE ' . $expectedSqlPart;
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -332,7 +331,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
 
         $expected = 'SELECT * FROM `[prefix]_Test` ' . $expectedSqlPart;
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -366,7 +365,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
         $expected = 'SELECT * FROM `[prefix]_Test`'
             . ' LIMIT ' . $expectedSqlPart;
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -395,7 +394,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
         $expected = 'SELECT * FROM `[prefix]_Test`'
             . ' LIMIT 5, 10';
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -413,7 +412,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
         $expected = 'SELECT * FROM `[prefix]_Test`'
             . ' LIMIT ' . $expectedOffset . ', 10';
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -447,7 +446,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
         $expected = 'SELECT * FROM `[prefix]_Test`'
             . ' GROUP BY ' . $expectedSqlPart;
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     /**
@@ -485,7 +484,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
         $expectedSql = 'SELECT * FROM `[prefix]_Test` AS `a`'
             . ' INNER JOIN `[prefix]_Table2` AS `b` ON ' . $expectedSqlPart;
 
-        $this->assertEquals($expectedSql, $this->out->generateSql());
+        self::assertEquals($expectedSql, $this->out->generateSql());
     }
 
     /**

--- a/tests/libraries/ilch/Database/Mysql/UpdateTest.php
+++ b/tests/libraries/ilch/Database/Mysql/UpdateTest.php
@@ -1,11 +1,10 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
 namespace Ilch\Database\Mysql;
-
 
 class UpdateTest extends \PHPUnit\Framework\TestCase
 {
@@ -24,14 +23,13 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->setMethods(['escape'])
             ->getMockForAbstractClass();
-        $db->expects($this->any())
-            ->method('escape')
-            ->will($this->returnCallback(function ($value, $addQuotes = false) {
+        $db->method('escape')
+            ->willReturnCallback(function ($value, $addQuotes = false) {
                 if ($addQuotes) {
                     $value = '"' . $value . '"';
                 }
                 return $value;
-            }));
+            });
 
         $this->out = new Update($db);
     }
@@ -61,7 +59,7 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
         $expected = 'UPDATE `[prefix]_Test` SET '
             . '`super` = "data",`next` = "fieldData"';
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 
     public function testGenerateSqlForValuesAndSimpleWhere()
@@ -74,6 +72,6 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
             . '`super` = "data",`next` = "fieldData"'
             . ' WHERE `id` = "5"';
 
-        $this->assertEquals($expected, $this->out->generateSql());
+        self::assertEquals($expected, $this->out->generateSql());
     }
 }

--- a/tests/libraries/ilch/Database/MysqlTest.php
+++ b/tests/libraries/ilch/Database/MysqlTest.php
@@ -1,12 +1,13 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
 namespace Ilch\Database;
 
 use Ilch\Database\Mysql as MySQL;
+use PHPUnit\Ilch\PhpunitDataset;
 
 /**
  * Tests the MySQL database object.
@@ -16,16 +17,13 @@ use Ilch\Database\Mysql as MySQL;
  */
 class MysqlTest extends \PHPUnit\Ilch\DatabaseTestCase
 {
-    /**
-     * Returns the8 initial dataset for the db.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_YamlDataSet
-     */
-    protected function getDataSet()
+    protected $phpunitDataset;
+
+    public function setUp()
     {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(
-            __DIR__ . '/../_files/mysql_database.yml'
-        );
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
     }
 
     /**
@@ -39,7 +37,7 @@ class MysqlTest extends \PHPUnit\Ilch\DatabaseTestCase
             ->execute()
             ->fetchCell();
 
-        $this->assertEquals('2', $result, 'Wrong cell value was returned.');
+        self::assertEquals('2', $result, 'Wrong cell value was returned.');
     }
 
     /**
@@ -53,7 +51,7 @@ class MysqlTest extends \PHPUnit\Ilch\DatabaseTestCase
             ->execute()
             ->fetchCell();
 
-        $this->assertEquals('2', $result, 'Wrong cell value was returned.');
+        self::assertEquals('2', $result, 'Wrong cell value was returned.');
     }
 
     /**
@@ -72,7 +70,7 @@ class MysqlTest extends \PHPUnit\Ilch\DatabaseTestCase
             ->execute()
             ->fetchCell();
 
-        $this->assertEquals('', $result, 'The db entry has not being updated with an empty string.');
+        self::assertEquals('', $result, 'The db entry has not being updated with an empty string.');
     }
 
     /**
@@ -88,6 +86,6 @@ class MysqlTest extends \PHPUnit\Ilch\DatabaseTestCase
             ->execute()
             ->fetchCell();
 
-        $this->assertEquals(1, $result, 'The db entry has not being inserted with an empty string.');
+        self::assertEquals(1, $result, 'The db entry has not being inserted with an empty string.');
     }
 }

--- a/tests/libraries/ilch/DateTest.php
+++ b/tests/libraries/ilch/DateTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -32,7 +32,7 @@ class DateTest extends TestCase
     {
         Registry::remove('timezone');
         $date = new \Ilch\Date();
-        $this->assertEquals(
+        self::assertEquals(
             'UTC',
             $date->getTimeZone()->getName(),
             'Timezone is not UTC as expected when creating Ilch_Date without a paramter.'
@@ -46,7 +46,7 @@ class DateTest extends TestCase
     {
         $ilchDate = new \Ilch\Date('2013-09-24 13:44:53');
 
-        $this->assertInstanceOf('DateTime', $ilchDate, 'No DateTime object was created by the constructor.');
+        self::assertInstanceOf('DateTime', $ilchDate, 'No DateTime object was created by the constructor.');
     }
 
     /**
@@ -56,7 +56,7 @@ class DateTest extends TestCase
     {
         $ilchDate = new \Ilch\Date('2013-09-24 15:44:53');
 
-        $this->assertEquals('2013-09-24 15:44:53', $ilchDate->toDb(), 'The date was not returned in UTC.');
+        self::assertEquals('2013-09-24 15:44:53', $ilchDate->toDb(), 'The date was not returned in UTC.');
     }
 
     /**
@@ -66,7 +66,7 @@ class DateTest extends TestCase
     {
         $ilchDate = new \Ilch\Date('2013-09-24 15:44:53');
 
-        $this->assertEquals(
+        self::assertEquals(
             '2013-09-24 17:44:53',
             $ilchDate->toDb(true),
             'The date was not in the local timezone returned.'
@@ -81,7 +81,7 @@ class DateTest extends TestCase
         $ilchDate = new \Ilch\Date('2013-09-24 15:44:53');
         $ilchDate->setDbFormat('d.m.Y H:i:s');
 
-        $this->assertEquals(
+        self::assertEquals(
             '24.09.2013 15:44:53',
             $ilchDate->toDb(),
             'The date was not returned with the correct format.'
@@ -98,7 +98,7 @@ class DateTest extends TestCase
         $ilchDate = new \Ilch\Date('2013-09-24 22:32:46');
         $ilchDate->toDb();
 
-        $this->assertEquals(
+        self::assertEquals(
             '2013-09-24 22:32:46',
             $ilchDate->format('Y-m-d H:i:s'),
             'A time with the wrong timezone was returned.'
@@ -112,7 +112,7 @@ class DateTest extends TestCase
     {
         $ilchDate = new \Ilch\Date('2013-09-24 22:32:46');
 
-        $this->assertEquals(
+        self::assertEquals(
             '2013-09-24 22:32:46',
             (string)$ilchDate,
             'The object could not be typecasted correctly to string.'
@@ -127,7 +127,7 @@ class DateTest extends TestCase
         $ilchDate = new \Ilch\Date('2013-09-24 22:32:46');
         $ilchDate->setDefaultFormat('d.m.Y H:i:s');
 
-        $this->assertEquals(
+        self::assertEquals(
             '24.09.2013 22:32:46',
             (string)$ilchDate,
             'The object could not be typecasted correctly to string using a custom format.'
@@ -142,9 +142,9 @@ class DateTest extends TestCase
         $date = new \Ilch\Date();
         $date->setTimestamp(1379521501);
 
-        $this->assertEquals(1379521501, $date->getTimestamp(), 'The timestamp was not returned in UTC.');
-        $this->assertEquals(1379521501, $date->format('U', true), 'The timestamp was not returned in UTC.');
-        $this->assertEquals(1379521501, $date->format('U', false), 'The timestamp was not returned in UTC.');
+        self::assertEquals(1379521501, $date->getTimestamp(), 'The timestamp was not returned in UTC.');
+        self::assertEquals(1379521501, $date->format('U', true), 'The timestamp was not returned in UTC.');
+        self::assertEquals(1379521501, $date->format('U'), 'The timestamp was not returned in UTC.');
     }
 
     /**
@@ -155,7 +155,7 @@ class DateTest extends TestCase
         $date = new \Ilch\Date();
         $date->setTimestamp(1379521501);
 
-        $this->assertEquals(
+        self::assertEquals(
             '2013-09-18 18:25:01',
             $date->format('Y-m-d H:i:s', true),
             'The time was not returned in local time.'
@@ -170,7 +170,7 @@ class DateTest extends TestCase
         $date = new \Ilch\Date();
         $date->setTimestamp(1379521501);
 
-        $this->assertEquals('2013-09-18 16:25:01', $date->format('Y-m-d H:i:s'), 'The time was not returned in UTC.');
+        self::assertEquals('2013-09-18 16:25:01', $date->format('Y-m-d H:i:s'), 'The time was not returned in UTC.');
     }
 
     /**
@@ -180,7 +180,7 @@ class DateTest extends TestCase
     {
         $date = new \Ilch\Date('2013-09-18 18:25:01', 'Europe/Berlin');
 
-        $this->assertEquals(
+        self::assertEquals(
             '2013-09-18 18:25:01',
             $date->format('Y-m-d H:i:s', true),
             'The time was not returned in local time.'

--- a/tests/libraries/ilch/Layout/Helper/GetMenuTest.php
+++ b/tests/libraries/ilch/Layout/Helper/GetMenuTest.php
@@ -11,25 +11,25 @@ use Ilch\Request;
 use Ilch\Router;
 use Ilch\Translator;
 use PHPUnit\Ilch\DatabaseTestCase;
+use PHPUnit\Ilch\PhpunitDataset;
 
 class GetMenuTest extends DatabaseTestCase
 {
     static protected $fillDbOnSetUp = self::PROVISION_ON_SETUP_BEFORE_CLASS;
 
+    protected $phpunitDataset;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../../_files/mysql_menu.yml');
+    }
+
     protected static function getSchemaSQLQueries()
     {
         $adminConfig = new \Modules\Admin\Config\Config();
         return $adminConfig->getInstallSql();
-    }
-
-    /**
-     * Returns the test dataset.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet()
-    {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/../../_files/mysql_menu.yml');
     }
 
     /**
@@ -49,7 +49,7 @@ class GetMenuTest extends DatabaseTestCase
 
         $out = new GetMenu($layout);
 
-        $this->assertSame($expected, $out->getMenu(1, '<h2>%s</h2>%c', $options));
+        self::assertSame($expected, $out->getMenu(1, '<h2>%s</h2>%c', $options));
     }
 
     public function dpForTestGetMenu()

--- a/tests/libraries/ilch/RequestTest.php
+++ b/tests/libraries/ilch/RequestTest.php
@@ -46,7 +46,7 @@ class RequestTest extends TestCase
         $this->request->setParams($params);
         $actualParams = $this->request->getParams();
 
-        $this->assertEquals($params, $actualParams, 'Param array got manipulated unexpectedly.');
+        self::assertEquals($params, $actualParams, 'Param array got manipulated unexpectedly.');
     }
 
     /**
@@ -61,7 +61,7 @@ class RequestTest extends TestCase
         ];
         $this->request->setParams($params);
 
-        $this->assertEquals(123, $actualParam = $this->request->getParam('id'), 'Param got manipulated unexpectedly.');
+        self::assertEquals(123, $actualParam = $this->request->getParam('id'), 'Param got manipulated unexpectedly.');
     }
 
     /**
@@ -77,7 +77,7 @@ class RequestTest extends TestCase
         ];
         $this->request->setParams($params);
 
-        $this->assertEquals(
+        self::assertEquals(
             null,
             $actualParam = $this->request->getParam('nullParam'),
             'Param got manipulated unexpectedly.'
@@ -99,7 +99,7 @@ class RequestTest extends TestCase
         $this->request->setParams($params);
         $actualParams = $this->request->getParams();
 
-        $this->assertArrayHasKey('nullParam', $actualParams, 'The param with value null got deleted.');
+        self::assertArrayHasKey('nullParam', $actualParams, 'The param with value null got deleted.');
     }
 
     /**
@@ -110,7 +110,7 @@ class RequestTest extends TestCase
         $this->request->setParam('nullParam', null);
         $actualParams = $this->request->getParams();
 
-        $this->assertArrayHasKey('nullParam', $actualParams, 'The param with value null got deleted.');
+        self::assertArrayHasKey('nullParam', $actualParams, 'The param with value null got deleted.');
     }
 
     /**
@@ -121,7 +121,7 @@ class RequestTest extends TestCase
         $this->request->setParam('username', 'testuser');
         $actualParams = $this->request->getParams();
 
-        $this->assertArrayHasKey('username', $actualParams, 'The saved param got deleted.');
+        self::assertArrayHasKey('username', $actualParams, 'The saved param got deleted.');
     }
 
     /**
@@ -140,7 +140,7 @@ class RequestTest extends TestCase
         $params['testvar'] = false;
         $actualParams = $this->request->getParams();
 
-        $this->assertEquals($expectedParams, $actualParams, 'Param array got manipulated unexpectedly.');
+        self::assertEquals($expectedParams, $actualParams, 'Param array got manipulated unexpectedly.');
     }
 
     /**
@@ -149,7 +149,7 @@ class RequestTest extends TestCase
     public function testGetModuleName()
     {
         $this->request->setModuleName('moduleNameTest');
-        $this->assertEquals('moduleNameTest', $this->request->getModuleName(), 'Modulename changed.');
+        self::assertEquals('moduleNameTest', $this->request->getModuleName(), 'Modulename changed.');
     }
 
     /**
@@ -158,7 +158,7 @@ class RequestTest extends TestCase
     public function testGetControllerName()
     {
         $this->request->setControllerName('controllerNameTest');
-        $this->assertEquals('controllerNameTest', $this->request->getControllerName(), 'Controllername changed.');
+        self::assertEquals('controllerNameTest', $this->request->getControllerName(), 'Controllername changed.');
     }
 
     /**
@@ -167,7 +167,7 @@ class RequestTest extends TestCase
     public function testGetActionName()
     {
         $this->request->setActionName('actionNameTest');
-        $this->assertEquals('actionNameTest', $this->request->getActionName(), 'Actionname changed.');
+        self::assertEquals('actionNameTest', $this->request->getActionName(), 'Actionname changed.');
     }
 
     /**
@@ -183,7 +183,7 @@ class RequestTest extends TestCase
         $_POST = $params;
         $_REQUEST = $params;
 
-        $this->assertTrue($this->request->isPost());
+        self::assertTrue($this->request->isPost());
     }
 
     /**
@@ -193,7 +193,7 @@ class RequestTest extends TestCase
     {
         $_GET['username'] = 'testuser';
 
-        $this->assertEquals(
+        self::assertEquals(
             'testuser',
             $this->request->getQuery('username'),
             'The request object didnt returned the GET parameter.'
@@ -207,7 +207,7 @@ class RequestTest extends TestCase
     {
         $_POST['username'] = 'testuser';
 
-        $this->assertEquals(
+        self::assertEquals(
             'testuser',
             $this->request->getPost('username'),
             'The request object didnt returned the POST parameter.'

--- a/tests/libraries/ilch/RouterTest.php
+++ b/tests/libraries/ilch/RouterTest.php
@@ -37,15 +37,15 @@ class RouterTest extends TestCase
         $pattern = Router::DEFAULT_REGEX_PATTERN;
         $pattern = '#^' . $pattern . '$#i';
 
-        $this->assertRegExp($pattern, 'module/controller');
-        $this->assertRegExp($pattern, 'module/controller/action');
-        $this->assertRegExp($pattern, 'module/controller/action/param1/value1/param2/value2');
+        self::assertRegExp($pattern, 'module/controller');
+        self::assertRegExp($pattern, 'module/controller/action');
+        self::assertRegExp($pattern, 'module/controller/action/param1/value1/param2/value2');
     }
 
     public function testParamConvertingIntoArray()
     {
         $params = $this->router->convertParamStringIntoArray('param1/value1/param2/value2');
-        $this->assertEquals($params, ['param1' => 'value1', 'param2' => 'value2']);
+        self::assertEquals(['param1' => 'value1', 'param2' => 'value2'], $params);
     }
 
     public function testMatchModuleController()
@@ -59,7 +59,7 @@ class RouterTest extends TestCase
         ];
 
         $match = $this->router->matchByRegexp($expectedResult[0]);
-        $this->assertTrue(is_array($match), 'Expected match result need to be an array!');
+        self::assertTrue(\is_array($match), 'Expected match result need to be an array!');
     }
 
     public function testMatchModuleControllerAction()
@@ -76,7 +76,7 @@ class RouterTest extends TestCase
         ];
 
         $match = $this->router->matchByRegexp($expectedResult[0]);
-        $this->assertTrue(is_array($match), 'Expected route does not match!');
+        self::assertTrue(\is_array($match), 'Expected route does not match!');
     }
 
     public function testMatchModuleControllerActionParams()
@@ -96,16 +96,16 @@ class RouterTest extends TestCase
         ];
 
         $match = $this->router->matchByRegexp($expectedResult[0]);
-        $this->assertTrue(is_array($match), 'Expected route does not match!');
+        self::assertTrue(\is_array($match), 'Expected route does not match!');
         $params = $this->router->convertParamStringIntoArray($match['params']);
-        $this->assertEquals($params, ['param1' => 'value1', 'param2' => 'value2']);
+        self::assertEquals(['param1' => 'value1', 'param2' => 'value2'], $params);
     }
 
     public function testMatchByQuery()
     {
         $route = 'page/index/show/param1/value1/param2/value2';
         $match = $this->router->matchByQuery($route);
-        $this->assertTrue(is_array($match), 'Expected route does not match!');
+        self::assertTrue(\is_array($match), 'Expected route does not match!');
     }
 
     /**
@@ -129,11 +129,11 @@ class RouterTest extends TestCase
         $result = $this->router->matchByQuery($route);
         $this->router->updateRequest($result);
 
-        $this->assertSame($expectIsAdmin, $this->request->isAdmin());
-        $this->assertSame($expectedModule, $this->request->getModuleName());
-        $this->assertSame($expectedController, $this->request->getControllerName());
-        $this->assertSame($expectedAction, $this->request->getActionName());
-        $this->assertSame($expectedParams, $this->request->getParams());
+        self::assertSame($expectIsAdmin, $this->request->isAdmin());
+        self::assertSame($expectedModule, $this->request->getModuleName());
+        self::assertSame($expectedController, $this->request->getControllerName());
+        self::assertSame($expectedAction, $this->request->getActionName());
+        self::assertSame($expectedParams, $this->request->getParams());
     }
 
     /**
@@ -175,21 +175,21 @@ class RouterTest extends TestCase
         $result = $this->router->matchByRegexp($route);
         $this->router->updateRequest($result);
 
-        $this->assertSame(false, $this->request->isAdmin());
-        $this->assertSame('page', $this->request->getModuleName());
-        $this->assertSame('index', $this->request->getControllerName());
-        $this->assertSame('show', $this->request->getActionName());
-        $this->assertSame(['param1' => 'value1', 'param2' => 'value2'], $this->request->getParams());
+        self::assertFalse($this->request->isAdmin());
+        self::assertSame('page', $this->request->getModuleName());
+        self::assertSame('index', $this->request->getControllerName());
+        self::assertSame('show', $this->request->getActionName());
+        self::assertSame(['param1' => 'value1', 'param2' => 'value2'], $this->request->getParams());
 
 
         $route = 'admin/page/index/show/param1/value1/param2/value2';
         $result = $this->router->matchByRegexp($route);
         $this->router->updateRequest($result);
 
-        $this->assertSame(true, $this->request->isAdmin());
-        $this->assertSame('page', $this->request->getModuleName());
-        $this->assertSame('index', $this->request->getControllerName());
-        $this->assertSame('show', $this->request->getActionName());
-        $this->assertSame(['param1' => 'value1', 'param2' => 'value2'], $this->request->getParams());
+        self::assertTrue($this->request->isAdmin());
+        self::assertSame('page', $this->request->getModuleName());
+        self::assertSame('index', $this->request->getControllerName());
+        self::assertSame('show', $this->request->getActionName());
+        self::assertSame(['param1' => 'value1', 'param2' => 'value2'], $this->request->getParams());
     }
 }

--- a/tests/libraries/ilch/TranslatorTest.php
+++ b/tests/libraries/ilch/TranslatorTest.php
@@ -21,7 +21,7 @@ class TranslatorTest extends TestCase
     public function testLoadTranslationsFile()
     {
         $translator = new Translator('de_DE');
-        $this->assertTrue($translator->load(__DIR__ . '/_files'));
+        self::assertTrue($translator->load(__DIR__ . '/_files'));
     }
 
     /**
@@ -30,7 +30,7 @@ class TranslatorTest extends TestCase
     public function testLoadTranslationFileNotExists()
     {
         $translator = new Translator('xx_xx');
-        $this->assertFalse(
+        self::assertFalse(
             $translator->load(__DIR__ . '/_files'),
             'The translator didn\'t return false when the translation file doesn\'t exist.'
         );
@@ -42,7 +42,7 @@ class TranslatorTest extends TestCase
     public function testLoadTranslationDirNotExists()
     {
         $translator = new Translator('de_DE');
-        $this->assertFalse(
+        self::assertFalse(
             $translator->load('someImaginaryFolder'),
             'The translator didn\'t return false when the given translation directory doesn\'t exist.'
         );
@@ -57,7 +57,7 @@ class TranslatorTest extends TestCase
         $translator = new Translator('en_EN');
         $translator->load(__DIR__ . '/_files');
 
-        $this->assertEquals(
+        self::assertEquals(
             'The user gets what he wants!',
             $translator->trans('userGetsWhatHeWants'),
             'The text wasnt translated using the translation file.'
@@ -73,7 +73,7 @@ class TranslatorTest extends TestCase
         $translator = new Translator('en_EN');
         $translator->load(__DIR__ . '/_files');
 
-        $this->assertEquals(
+        self::assertEquals(
             'notTranslatedText',
             $translator->trans('notTranslatedText'),
             'The text wasnt simply returned.'
@@ -89,7 +89,7 @@ class TranslatorTest extends TestCase
         $translator = new Translator('en_EN');
         $translator->load(__DIR__ . '/_files');
 
-        $this->assertEquals(
+        self::assertEquals(
             'Welcome, Hans',
             $translator->trans('welcomeUser', 'Hans'),
             'The text wasnt returned with the placeholder.'
@@ -105,7 +105,7 @@ class TranslatorTest extends TestCase
         $translator = new Translator('en_EN');
         $translator->load(__DIR__ . '/_files');
 
-        $this->assertEquals(
+        self::assertEquals(
             'Welcome, Hans, ur last login was yesterday',
             $translator->trans('welcomeUserExtended', 'Hans', 'yesterday'),
             'The text wasnt returned with the placeholder.'
@@ -118,7 +118,7 @@ class TranslatorTest extends TestCase
     public function testRequestLocaleDefinition()
     {
         $translator = new Translator('en_EN');
-        $this->assertEquals('en_EN', $translator->getLocale());
+        self::assertEquals('en_EN', $translator->getLocale());
     }
 
     /**
@@ -128,7 +128,7 @@ class TranslatorTest extends TestCase
     public function testRequestLocaleDefinitionDefault()
     {
         $translator = new Translator();
-        $this->assertEquals('de_DE', $translator->getLocale());
+        self::assertEquals('de_DE', $translator->getLocale());
     }
 
     /**
@@ -140,7 +140,7 @@ class TranslatorTest extends TestCase
         $translator->load(__DIR__ . '/_files');
 
         $expectedTranslations = require __DIR__ . '/_files/en.php';
-        $this->assertEquals(
+        self::assertEquals(
             $expectedTranslations,
             $translator->getTranslations(),
             'The translations array was returned wrongly.'
@@ -153,6 +153,6 @@ class TranslatorTest extends TestCase
     public function testShortenLocale()
     {
         $translator = new Translator();
-        $this->assertEquals('en', $translator->shortenLocale('en_EN'), 'The locale wasn\'t trimmed correctly.');
+        self::assertEquals('en', $translator->shortenLocale('en_EN'), 'The locale wasn\'t trimmed correctly.');
     }
 }

--- a/tests/libraries/ilch/Validation/Validators/DateTest.php
+++ b/tests/libraries/ilch/Validation/Validators/DateTest.php
@@ -22,10 +22,10 @@ class DateTest extends TestCase
     {
         $validator = new Date($data);
         $validator->run();
-        $this->assertSame($expectedIsValid, $validator->isValid());
+        self::assertSame($expectedIsValid, $validator->isValid());
         if (!empty($expectedErrorKey)) {
-            $this->assertSame($expectedErrorKey, $validator->getErrorKey());
-            $this->assertSame($expectedErrorParameters, $validator->getErrorParameters());
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
         }
     }
 

--- a/tests/libraries/ilch/Validation/Validators/MaxTest.php
+++ b/tests/libraries/ilch/Validation/Validators/MaxTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -22,10 +22,10 @@ class MaxTest extends TestCase
     {
         $validator = new Max($data);
         $validator->run();
-        $this->assertSame($expectedIsValid, $validator->isValid());
+        self::assertSame($expectedIsValid, $validator->isValid());
         if (!empty($expectedErrorKey)) {
-            $this->assertSame($expectedErrorKey, $validator->getErrorKey());
-            $this->assertSame($expectedErrorParameters, $validator->getErrorParameters());
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
         }
     }
 

--- a/tests/libraries/ilch/Validation/Validators/MinTest.php
+++ b/tests/libraries/ilch/Validation/Validators/MinTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -22,10 +22,10 @@ class MinTest extends TestCase
     {
         $validator = new Min($data);
         $validator->run();
-        $this->assertSame($expectedIsValid, $validator->isValid());
+        self::assertSame($expectedIsValid, $validator->isValid());
         if (!empty($expectedErrorKey)) {
-            $this->assertSame($expectedErrorKey, $validator->getErrorKey());
-            $this->assertSame($expectedErrorParameters, $validator->getErrorParameters());
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
         }
     }
 

--- a/tests/libraries/ilch/ValidationTest.php
+++ b/tests/libraries/ilch/ValidationTest.php
@@ -33,9 +33,9 @@ class ValidationTest extends TestCase
     {
         $validation = Validation::create($params, ['testField' => ($inverted ? 'NOT' : '').'integer']);
 
-        $this->assertSame($expected, $validation->isValid());
+        self::assertSame($expected, $validation->isValid());
         if (!$expected) {
-            $this->assertTrue($validation->getErrorBag()->hasError('testField'));
+            self::assertTrue($validation->getErrorBag()->hasError('testField'));
         }
     }
 
@@ -71,9 +71,9 @@ class ValidationTest extends TestCase
     ) {
         $validation = Validation::create($params, ['testField' => $validatorRules]);
 
-        $this->assertSame($expected, $validation->isValid());
+        self::assertSame($expected, $validation->isValid());
         if (!$expected) {
-            $this->assertSame($expectedErrors, $validation->getErrorBag()->getErrors());
+            self::assertSame($expectedErrors, $validation->getErrorBag()->getErrors());
         }
     }
 
@@ -135,9 +135,9 @@ class ValidationTest extends TestCase
 
         $validation = Validation::create($params, ['testField' => $validatorRules]);
 
-        $this->assertSame($expected, $validation->isValid());
+        self::assertSame($expected, $validation->isValid());
         if (!$expected) {
-            $this->assertSame($expectedErrors, $validation->getErrorBag()->getErrors());
+            self::assertSame($expectedErrors, $validation->getErrorBag()->getErrors());
         }
     }
 
@@ -198,6 +198,6 @@ class ValidationTest extends TestCase
 
         $errorMessages = $validation->getErrorBag()->getErrorMessages();
 
-        $this->assertSame(['Das Feld muss mindestens 3 betragen.'], $errorMessages);
+        self::assertSame(['Das Feld muss mindestens 3 betragen.'], $errorMessages);
     }
 }

--- a/tests/modules/admin/_files/mysql_database.yml
+++ b/tests/modules/admin/_files/mysql_database.yml
@@ -4,14 +4,14 @@ admin_notifications:
     timestamp: "2014-01-01 12:12:12"
     module: "article"
     message: "Testmessage1"
-    url: "http://www.google.de"
+    url: "https://www.google.de"
     type: "articleNewArticle"
   -
     id: 2
     timestamp: "2014-01-01 12:12:12"
     module: "awards"
     message: "Testmessage2"
-    url: "http://www.ilch.de"
+    url: "https://www.ilch.de"
     type: "awardsNewAward"
 
 admin_notifications_permission:

--- a/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
+++ b/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Ilch\DatabaseTestCase;
 use Modules\Admin\Config\Config as ModuleConfig;
 use Modules\Admin\Mappers\LayoutAdvSettings;
 use Modules\Admin\Models\LayoutAdvSettings as LayoutAdvSettingsModel;
+use PHPUnit\Ilch\PhpunitDataset;
 
 /**
  * Tests the LayoutAdvSettings mapper class.
@@ -22,21 +23,14 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
      * @var LayoutAdvSettings
      */
     protected $out;
+    protected $phpunitDataset;
 
     public function setUp()
     {
         parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
         $this->out = new LayoutAdvSettings();
-    }
-
-    /**
-     * Creates and returns a dataset object.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_AbstractDataSet
-     */
-    protected function getDataSet()
-    {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/../_files/mysql_database.yml');
     }
 
     /**
@@ -57,10 +51,10 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
     {
         $layoutSetting = $this->out->getSetting('testLayoutKey1', 'testKey1');
 
-        $this->assertEquals($layoutSetting->getId(), 1);
-        $this->assertSame($layoutSetting->getLayoutKey(), 'testLayoutKey1');
-        $this->assertSame($layoutSetting->getKey(), 'testKey1');
-        $this->assertSame($layoutSetting->getValue(), 'testValue1');
+        self::assertEquals(1, $layoutSetting->getId());
+        self::assertSame($layoutSetting->getLayoutKey(), 'testLayoutKey1');
+        self::assertSame($layoutSetting->getKey(), 'testKey1');
+        self::assertSame($layoutSetting->getValue(), 'testValue1');
     }
 
     /**
@@ -70,15 +64,15 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
     {
         $layoutSetting = $this->out->getSettings('testLayoutKey1');
 
-        $this->assertEquals($layoutSetting['testKey1']->getId(), 1);
-        $this->assertSame($layoutSetting['testKey1']->getLayoutKey(), 'testLayoutKey1');
-        $this->assertSame($layoutSetting['testKey1']->getKey(), 'testKey1');
-        $this->assertSame($layoutSetting['testKey1']->getValue(), 'testValue1');
+        self::assertEquals(1, $layoutSetting['testKey1']->getId());
+        self::assertSame($layoutSetting['testKey1']->getLayoutKey(), 'testLayoutKey1');
+        self::assertSame($layoutSetting['testKey1']->getKey(), 'testKey1');
+        self::assertSame($layoutSetting['testKey1']->getValue(), 'testValue1');
 
-        $this->assertEquals($layoutSetting['testKey2']->getId(), 2);
-        $this->assertSame($layoutSetting['testKey2']->getLayoutKey(), 'testLayoutKey1');
-        $this->assertSame($layoutSetting['testKey2']->getKey(), 'testKey2');
-        $this->assertSame($layoutSetting['testKey2']->getValue(), 'testValue2');
+        self::assertEquals(2, $layoutSetting['testKey2']->getId());
+        self::assertSame($layoutSetting['testKey2']->getLayoutKey(), 'testLayoutKey1');
+        self::assertSame($layoutSetting['testKey2']->getKey(), 'testKey2');
+        self::assertSame($layoutSetting['testKey2']->getValue(), 'testValue2');
     }
 
     /**
@@ -88,9 +82,9 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
     {
         $layoutKeyList = $this->out->getListOfLayoutKeys();
 
-        $this->assertCount(2, $layoutKeyList);
-        $this->assertSame($layoutKeyList[0], 'testLayoutKey1');
-        $this->assertSame($layoutKeyList[1], 'testLayoutKey2');
+        self::assertCount(2, $layoutKeyList);
+        self::assertSame($layoutKeyList[0], 'testLayoutKey1');
+        self::assertSame($layoutKeyList[1], 'testLayoutKey2');
     }
 
     /**
@@ -98,7 +92,7 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
      */
     public function testHasSettings()
     {
-        $this->assertTrue($this->out->hasSettings('testLayoutKey1'));
+        self::assertTrue($this->out->hasSettings('testLayoutKey1'));
     }
 
     /**
@@ -106,7 +100,7 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
      */
     public function testHasSettingsNotExisting()
     {
-        $this->assertFalse($this->out->hasSettings('notExistingLayoutKey'));
+        self::assertFalse($this->out->hasSettings('notExistingLayoutKey'));
     }
 
     /**
@@ -122,10 +116,10 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
         $this->out->save($layoutSettingsArray);
 
         $layoutSetting = $this->out->getSetting('testLayoutKey3','testKey5');
-        $this->assertEquals($layoutSetting->getId(), 5);
-        $this->assertSame($layoutSetting->getLayoutKey(), 'testLayoutKey3');
-        $this->assertSame($layoutSetting->getKey(), 'testKey5');
-        $this->assertSame($layoutSetting->getValue(), 'testValue5');
+        self::assertEquals(5, $layoutSetting->getId());
+        self::assertSame($layoutSetting->getLayoutKey(), 'testLayoutKey3');
+        self::assertSame($layoutSetting->getKey(), 'testKey5');
+        self::assertSame($layoutSetting->getValue(), 'testValue5');
     }
 
     /**
@@ -148,15 +142,15 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
         $this->out->save($layoutSettingsArray);
 
         $layoutSetting = $this->out->getSettings('testLayoutKey3');
-        $this->assertEquals($layoutSetting['testKey5']->getId(), 5);
-        $this->assertSame($layoutSetting['testKey5']->getLayoutKey(), 'testLayoutKey3');
-        $this->assertSame($layoutSetting['testKey5']->getKey(), 'testKey5');
-        $this->assertSame($layoutSetting['testKey5']->getValue(), 'testValue5');
+        self::assertEquals(5, $layoutSetting['testKey5']->getId());
+        self::assertSame($layoutSetting['testKey5']->getLayoutKey(), 'testLayoutKey3');
+        self::assertSame($layoutSetting['testKey5']->getKey(), 'testKey5');
+        self::assertSame($layoutSetting['testKey5']->getValue(), 'testValue5');
 
-        $this->assertEquals($layoutSetting['testKey6']->getId(), 6);
-        $this->assertSame($layoutSetting['testKey6']->getLayoutKey(), 'testLayoutKey3');
-        $this->assertSame($layoutSetting['testKey6']->getKey(), 'testKey6');
-        $this->assertSame($layoutSetting['testKey6']->getValue(), 'testValue6');
+        self::assertEquals(6, $layoutSetting['testKey6']->getId());
+        self::assertSame($layoutSetting['testKey6']->getLayoutKey(), 'testLayoutKey3');
+        self::assertSame($layoutSetting['testKey6']->getKey(), 'testKey6');
+        self::assertSame($layoutSetting['testKey6']->getValue(), 'testValue6');
     }
 
     /**
@@ -165,7 +159,7 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
     public function testDeleteSetting()
     {
         $this->out->deleteSetting('testLayoutKey1','testKey1');
-        $this->assertEmpty($this->out->getSetting('testLayoutKey1','testKey1'));
+        self::assertEmpty($this->out->getSetting('testLayoutKey1','testKey1'));
     }
 
     /**
@@ -174,7 +168,7 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
     public function testDeleteSettingById()
     {
         $this->out->deleteSettingById(2);
-        $this->assertEmpty($this->out->getSetting('testLayoutKey1','testKey2'));
+        self::assertEmpty($this->out->getSetting('testLayoutKey1','testKey2'));
     }
 
     /**
@@ -183,6 +177,6 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
     public function testDeleteSettings()
     {
         $this->out->deleteSettings('testLayoutKey2');
-        $this->assertEmpty($this->out->getSettings('testLayoutKey2'));
+        self::assertEmpty($this->out->getSettings('testLayoutKey2'));
     }
 }

--- a/tests/modules/admin/mappers/NotificationPermissionTest.php
+++ b/tests/modules/admin/mappers/NotificationPermissionTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Ilch\DatabaseTestCase;
 use Modules\Admin\Config\Config as ModuleConfig;
 use Modules\Admin\Mappers\NotificationPermission as NotificationPermissionMapper;
 use Modules\Admin\Models\NotificationPermission as NotificationPermissionModel;
+use PHPUnit\Ilch\PhpunitDataset;
 
 /**
  * Tests the NotificationPermission mapper class.
@@ -22,10 +23,13 @@ class NotificationPermissionTest extends DatabaseTestCase
      * @var UserMapper
      */
     protected $out;
+    protected $phpunitDataset;
 
     public function setUp()
     {
         parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
         $this->out = new NotificationPermissionMapper();
     }
 
@@ -35,7 +39,7 @@ class NotificationPermissionTest extends DatabaseTestCase
      */
     public function testGetPermissions()
     {
-        $this->assertTrue(count($this->out->getPermissions()) == 2);
+        self::assertCount(2, $this->out->getPermissions());
     }
 
     /**
@@ -44,7 +48,7 @@ class NotificationPermissionTest extends DatabaseTestCase
      */
     public function testGetPermissionOfModuleNotExisting()
     {
-        $this->assertNull($this->out->getPermissionOfModule('xyzmodul'));
+        self::assertNull($this->out->getPermissionOfModule('xyzmodul'));
     }
 
     /**
@@ -59,7 +63,7 @@ class NotificationPermissionTest extends DatabaseTestCase
         $notificationPermissionModel->setLimit(3);
 
         $this->out->updatePermissionOfModule($notificationPermissionModel);
-        $this->assertEquals($notificationPermissionModel, $this->out->getPermissionOfModule('article'));
+        self::assertEquals($notificationPermissionModel, $this->out->getPermissionOfModule('article'));
     }
 
     /**
@@ -70,7 +74,7 @@ class NotificationPermissionTest extends DatabaseTestCase
     {
         $this->out->updatePermissionGrantedOfModule('article', false);
         $notificationPermissionModel = $this->out->getPermissionOfModule('article');
-        $this->assertTrue($notificationPermissionModel->getGranted() == 0);
+        self::assertEquals(0, $notificationPermissionModel->getGranted());
     }
 
     /**
@@ -81,7 +85,7 @@ class NotificationPermissionTest extends DatabaseTestCase
     {
         $this->out->updateLimitOfModule('article', 3);
         $notificationPermissionModel = $this->out->getPermissionOfModule('article');
-        $this->assertTrue($notificationPermissionModel->getLimit() == 3);
+        self::assertEquals(3, $notificationPermissionModel->getLimit());
     }
 
     /**
@@ -94,7 +98,7 @@ class NotificationPermissionTest extends DatabaseTestCase
         $this->out->updateLimitOfModule('article', 300);
         $notificationPermissionModel = $this->out->getPermissionOfModule('article');
         // If the limit is bigger than 255 (UNSIGNED TINYINT) then it gets set to the maximum of 255.
-        $this->assertTrue($notificationPermissionModel->getLimit() == 255);
+        self::assertEquals(255, $notificationPermissionModel->getLimit());
     }
 
     /**
@@ -107,7 +111,7 @@ class NotificationPermissionTest extends DatabaseTestCase
         $this->out->updateLimitOfModule('article', -1);
         $notificationPermissionModel = $this->out->getPermissionOfModule('article');
         // If the limit is negative (UNSIGNED) then it gets set to 0.
-        $this->assertTrue($notificationPermissionModel->getLimit() == 0);
+        self::assertEquals(0, $notificationPermissionModel->getLimit());
     }
 
     /**
@@ -122,7 +126,7 @@ class NotificationPermissionTest extends DatabaseTestCase
         $notificationPermissionModel->setLimit(5);
 
         $this->out->addPermissionForModule($notificationPermissionModel);
-        $this->assertEquals($notificationPermissionModel, $this->out->getPermissionOfModule('away'));
+        self::assertEquals($notificationPermissionModel, $this->out->getPermissionOfModule('away'));
     }
 
     /**
@@ -132,17 +136,7 @@ class NotificationPermissionTest extends DatabaseTestCase
     public function testDeletePermissionOfModule()
     {
         $this->out->deletePermissionOfModule('article');
-        $this->assertNull($this->out->getPermissionOfModule('article'));
-    }
-
-    /**
-     * Creates and returns a dataset object.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_AbstractDataSet
-     */
-    protected function getDataSet()
-    {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/../_files/mysql_database.yml');
+        self::assertNull($this->out->getPermissionOfModule('article'));
     }
 
     /**

--- a/tests/modules/admin/mappers/NotificationsTest.php
+++ b/tests/modules/admin/mappers/NotificationsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -10,6 +10,7 @@ use PHPUnit\Ilch\DatabaseTestCase;
 use Modules\Admin\Config\Config as ModuleConfig;
 use Modules\Admin\Mappers\Notifications as NotificationsMapper;
 use Modules\Admin\Models\Notification as NotificationModel;
+use PHPUnit\Ilch\PhpunitDataset;
 
 /**
  * Tests the Notifications mapper class.
@@ -23,9 +24,13 @@ class NotificationsTest extends DatabaseTestCase
      */
     protected $out;
 
+    protected $phpunitDataset;
+
     public function setUp()
     {
         parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
         $this->out = new NotificationsMapper();
     }
 
@@ -41,17 +46,17 @@ class NotificationsTest extends DatabaseTestCase
         $notificationModel->setTimestamp('2014-01-01 12:12:12');
         $notificationModel->setModule('article');
         $notificationModel->setMessage('Testmessage1');
-        $notificationModel->setURL('http://www.google.de');
+        $notificationModel->setURL('https://www.google.de');
         $notificationModel->setType('articleNewArticle');
 
         $notification = $this->out->getNotificationById(1);
-        $this->assertTrue($notification->getId() == 1);
+        self::assertEquals(1, $notification->getId());
         // The timestamp can vary by one hour. Therefore for example comparing
         // the notificationModel with the one from the database assertEquals() would not work always.
-        $this->assertTrue($notification->getModule() == 'article');
-        $this->assertTrue($notification->getMessage() == 'Testmessage1');
-        $this->assertTrue($notification->getURL() == 'http://www.google.de');
-        $this->assertTrue($notification->getType() == 'articleNewArticle');
+        self::assertSame($notification->getModule(), 'article');
+        self::assertSame($notification->getMessage(), 'Testmessage1');
+        self::assertSame($notification->getURL(), 'https://www.google.de');
+        self::assertSame($notification->getType(), 'articleNewArticle');
     }
 
     /**
@@ -61,7 +66,7 @@ class NotificationsTest extends DatabaseTestCase
      */
     public function testGetNotificationByIdNotExisting()
     {
-        $this->assertNull($this->out->getNotificationById(99));
+        self::assertNull($this->out->getNotificationById(99));
     }
 
     /**
@@ -70,7 +75,7 @@ class NotificationsTest extends DatabaseTestCase
      */
     public function testGetNotifications()
     {
-        $this->assertTrue(count($this->out->getNotifications()) == 2);
+        self::assertCount(2, $this->out->getNotifications());
     }
 
     /**
@@ -79,7 +84,7 @@ class NotificationsTest extends DatabaseTestCase
      */
     public function testGetNotificationsByModule()
     {
-        $this->assertTrue(count($this->out->getNotificationsByModule('article')) == 1);
+        self::assertCount(1, $this->out->getNotificationsByModule('article'));
     }
 
     /**
@@ -88,7 +93,7 @@ class NotificationsTest extends DatabaseTestCase
      */
     public function testGetNotificationsByModuleNotExisting()
     {
-        $this->assertEmpty($this->out->getNotificationsByModule('xyzmodule'));
+        self::assertEmpty($this->out->getNotificationsByModule('xyzmodule'));
     }
 
     /**
@@ -97,7 +102,7 @@ class NotificationsTest extends DatabaseTestCase
      */
     public function testGetNotificationsByType()
     {
-        $this->assertTrue(count($this->out->getNotificationsByType('articleNewArticle')) == 1);
+        self::assertCount(1, $this->out->getNotificationsByType('articleNewArticle'));
     }
 
     /**
@@ -106,7 +111,7 @@ class NotificationsTest extends DatabaseTestCase
      */
     public function testGetNotificationsByTypeNotExisting()
     {
-        $this->assertEmpty($this->out->getNotificationsByType('xyzmodule'));
+        self::assertEmpty($this->out->getNotificationsByType('xyzmodule'));
     }
 
     /**
@@ -120,10 +125,10 @@ class NotificationsTest extends DatabaseTestCase
         $notificationModel->setTimestamp('2014-01-01 12:12:12');
         $notificationModel->setModule('article');
         $notificationModel->setMessage('Testmessage1');
-        $notificationModel->setURL('http://www.google.de');
+        $notificationModel->setURL('https://www.google.de');
         $_SERVER['HTTP_HOST'] = '127.0.0.1';
 
-        $this->assertTrue($this->out->isValidNotification($notificationModel));
+        self::assertTrue($this->out->isValidNotification($notificationModel));
     }
 
     /**
@@ -136,16 +141,16 @@ class NotificationsTest extends DatabaseTestCase
         $notificationModel = new NotificationModel();
         $notificationModel->setModule('awards');
         $notificationModel->setMessage('Testmessage3');
-        $notificationModel->setURL('http://www.google.de');
+        $notificationModel->setURL('https://www.google.de');
         $notificationModel->setType('awardsNewAward');
         $_SERVER['HTTP_HOST'] = '127.0.0.1';
 
-        $this->assertTrue($this->out->addNotification($notificationModel) == 3);
+        self::assertEquals(3, $this->out->addNotification($notificationModel));
         $notification = $this->out->getNotificationById(3);
-        $this->assertTrue($notification->getModule() == 'awards');
-        $this->assertTrue($notification->getMessage() == 'Testmessage3');
-        $this->assertTrue($notification->getURL() == 'http://www.google.de');
-        $this->assertTrue($notification->getType() == 'awardsNewAward');
+        self::assertSame($notification->getModule(), 'awards');
+        self::assertSame($notification->getMessage(), 'Testmessage3');
+        self::assertSame($notification->getURL(), 'https://www.google.de');
+        self::assertSame($notification->getType(), 'awardsNewAward');
     }
 
     /**
@@ -159,16 +164,16 @@ class NotificationsTest extends DatabaseTestCase
         $notificationModel->setId(2);
         $notificationModel->setModule('awards');
         $notificationModel->setMessage('Testmessage3');
-        $notificationModel->setURL('http://www.google.de');
+        $notificationModel->setURL('https://www.google.de');
         $notificationModel->setType('awardsNewAward2');
         $_SERVER['HTTP_HOST'] = '127.0.0.1';
 
         $this->out->updateNotificationById($notificationModel);
         $notification = $this->out->getNotificationById(2);
-        $this->assertTrue($notification->getModule() == 'awards');
-        $this->assertTrue($notification->getMessage() == 'Testmessage3');
-        $this->assertTrue($notification->getURL() == 'http://www.google.de');
-        $this->assertTrue($notification->getType() == 'awardsNewAward2');
+        self::assertSame($notification->getModule(), 'awards');
+        self::assertSame($notification->getMessage(), 'Testmessage3');
+        self::assertSame($notification->getURL(), 'https://www.google.de');
+        self::assertSame($notification->getType(), 'awardsNewAward2');
     }
 
     /**
@@ -178,7 +183,7 @@ class NotificationsTest extends DatabaseTestCase
     public function testDeleteNotificationById()
     {
         $this->out->deleteNotificationById(1);
-        $this->assertNull($this->out->getNotificationById(1));
+        self::assertNull($this->out->getNotificationById(1));
     }
 
     /**
@@ -188,7 +193,7 @@ class NotificationsTest extends DatabaseTestCase
     public function testDeleteNotificationByIdNotExisting()
     {
         $this->out->deleteNotificationById(99);
-        $this->assertTrue(count($this->out->getNotifications()) == 2);
+        self::assertCount(2, $this->out->getNotifications());
     }
 
     /**
@@ -198,7 +203,7 @@ class NotificationsTest extends DatabaseTestCase
     public function testDeleteNotificationsByModule()
     {
         $this->out->deleteNotificationsByModule('article');
-        $this->assertTrue(count($this->out->getNotificationsByModule('article')) == 0);
+        self::assertCount(0, $this->out->getNotificationsByModule('article'));
     }
 
     /**
@@ -208,7 +213,7 @@ class NotificationsTest extends DatabaseTestCase
     public function testDeleteNotificationsByModuleNotExisting()
     {
         $this->out->deleteNotificationsByModule('xyzmodule');
-        $this->assertTrue(count($this->out->getNotifications()) == 2);
+        self::assertCount(2, $this->out->getNotifications());
     }
 
     /**
@@ -218,7 +223,7 @@ class NotificationsTest extends DatabaseTestCase
     public function testDeleteNotificationsByType()
     {
         $this->out->deleteNotificationsByType('awardsNewAward');
-        $this->assertTrue(count($this->out->getNotificationsByType('awardsNewAward')) == 0);
+        self::assertCount(0, $this->out->getNotificationsByType('awardsNewAward'));
     }
 
     /**
@@ -228,7 +233,7 @@ class NotificationsTest extends DatabaseTestCase
     public function testDeleteNotificationsByTypeNotExisting()
     {
         $this->out->deleteNotificationsByType('xyzmodule');
-        $this->assertTrue(count($this->out->getNotifications()) == 2);
+        self::assertCount(2, $this->out->getNotifications());
     }
 
     /**
@@ -237,17 +242,7 @@ class NotificationsTest extends DatabaseTestCase
      */
     public function testDeleteAllNotifications() {
         $this->out->deleteAllNotifications();
-        $this->assertTrue(count($this->out->getNotifications()) == 0);
-    }
-
-    /**
-     * Creates and returns a dataset object.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_AbstractDataSet
-     */
-    protected function getDataSet()
-    {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/../_files/mysql_database.yml');
+        self::assertCount(0, $this->out->getNotifications());
     }
 
     /**

--- a/tests/modules/forum/mappers/RankTest.php
+++ b/tests/modules/forum/mappers/RankTest.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
 namespace Modules\Forum\Mappers;
 
 use PHPUnit\Ilch\DatabaseTestCase;
-use \Modules\Forum\Mappers\Rank as RankMapper;
-use \Modules\Forum\Models\Rank as RankModel;
-use \Modules\Forum\Config\Config as ModuleConfig;
+use Modules\Forum\Mappers\Rank as RankMapper;
+use Modules\Forum\Models\Rank as RankModel;
+use Modules\Forum\Config\Config as ModuleConfig;
+use PHPUnit\Ilch\PhpunitDataset;
 
 /**
  * Tests the rank mapper class.
@@ -18,9 +19,13 @@ use \Modules\Forum\Config\Config as ModuleConfig;
  */
 class RankTest extends DatabaseTestCase
 {
+    protected $phpunitDataset;
+
     public function setUp()
     {
         parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
     }
 
     /**
@@ -31,7 +36,7 @@ class RankTest extends DatabaseTestCase
         $mapper = new RankMapper();
         $ranks = $mapper->getRanks();
 
-        $this->assertTrue(count($ranks) == 3);
+        self::assertCount(3, $ranks);
     }
 
     /**
@@ -42,9 +47,9 @@ class RankTest extends DatabaseTestCase
         $mapper = new RankMapper();
         $rank = $mapper->getRankById(1);
 
-        $this->assertTrue($rank->getId() == 1);
-        $this->assertTrue($rank->getTitle() == 'Gruenschnabel');
-        $this->assertTrue($rank->getPosts() == 0);
+        self::assertEquals(1, $rank->getId());
+        self::assertSame($rank->getTitle(), 'Gruenschnabel');
+        self::assertEquals(0, $rank->getPosts());
     }
 
     /**
@@ -55,9 +60,9 @@ class RankTest extends DatabaseTestCase
         $mapper = new RankMapper();
         $rank = $mapper->getRankByPosts(1);
 
-        $this->assertTrue($rank->getId() == 1);
-        $this->assertTrue($rank->getTitle() == 'Gruenschnabel');
-        $this->assertTrue($rank->getPosts() == 0);
+        self::assertEquals(1, $rank->getId());
+        self::assertSame($rank->getTitle(), 'Gruenschnabel');
+        self::assertEquals(0, $rank->getPosts());
     }
 
     /**
@@ -68,9 +73,9 @@ class RankTest extends DatabaseTestCase
         $mapper = new RankMapper();
         $rank = $mapper->getRankByPosts(25);
 
-        $this->assertTrue($rank->getId() == 2);
-        $this->assertTrue($rank->getTitle() == 'Jungspund');
-        $this->assertTrue($rank->getPosts() == 25);
+        self::assertEquals(2, $rank->getId());
+        self::assertSame($rank->getTitle(), 'Jungspund');
+        self::assertEquals(25, $rank->getPosts());
     }
 
     /**
@@ -82,9 +87,9 @@ class RankTest extends DatabaseTestCase
         $mapper = new RankMapper();
         $rank = $mapper->getRankByPosts(30);
 
-        $this->assertTrue($rank->getId() == 2);
-        $this->assertTrue($rank->getTitle() == 'Jungspund');
-        $this->assertTrue($rank->getPosts() == 25);
+        self::assertEquals(2, $rank->getId());
+        self::assertSame($rank->getTitle(), 'Jungspund');
+        self::assertEquals(25, $rank->getPosts());
     }
 
     /**
@@ -95,9 +100,9 @@ class RankTest extends DatabaseTestCase
         $mapper = new RankMapper();
         $rank = $mapper->getRankByPosts(50);
 
-        $this->assertTrue($rank->getId() == 3);
-        $this->assertTrue($rank->getTitle() == 'Mitglied');
-        $this->assertTrue($rank->getPosts() == 50);
+        self::assertEquals(3, $rank->getId());
+        self::assertSame($rank->getTitle(), 'Mitglied');
+        self::assertEquals(50, $rank->getPosts());
     }
 
     /**
@@ -115,9 +120,9 @@ class RankTest extends DatabaseTestCase
 
         $rank = $mapper->getRankById(4);
 
-        $this->assertTrue($rank->getId() == 4);
-        $this->assertTrue($rank->getTitle() == 'TestTitle');
-        $this->assertTrue($rank->getPosts() == 100);
+        self::assertEquals(4, $rank->getId());
+        self::assertSame($rank->getTitle(), 'TestTitle');
+        self::assertEquals(100, $rank->getPosts());
     }
 
     /**
@@ -136,9 +141,9 @@ class RankTest extends DatabaseTestCase
 
         $rank = $mapper->getRankById(3);
 
-        $this->assertTrue($rank->getId() == 3);
-        $this->assertTrue($rank->getTitle() == 'TestTitle');
-        $this->assertTrue($rank->getPosts() == 100);
+        self::assertEquals(3, $rank->getId());
+        self::assertSame($rank->getTitle(), 'TestTitle');
+        self::assertEquals(100, $rank->getPosts());
     }
 
     /**
@@ -151,17 +156,7 @@ class RankTest extends DatabaseTestCase
         $mapper->delete(3);
         $ranks = $mapper->getRanks();
 
-        $this->assertTrue(count($ranks) == 2);
-    }
-
-    /**
-     * Creates and returns a dataset object.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_AbstractDataSet
-     */
-    protected function getDataSet()
-    {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/../_files/mysql_database.yml');
+        self::assertCount(2, $ranks);
     }
 
     /**

--- a/tests/modules/forum/models/RankTest.php
+++ b/tests/modules/forum/models/RankTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -24,7 +24,7 @@ class RankTest extends TestCase
         $model = new RankModel();
         $model->setId(1);
 
-        $this->assertEquals(1, $model->getId(), 'The rank id was not saved correctly.');
+        self::assertEquals(1, $model->getId(), 'The rank id was not saved correctly.');
     }
 
     /**
@@ -35,7 +35,7 @@ class RankTest extends TestCase
         $model = new RankModel();
         $model->setTitle('TestTitle');
 
-        $this->assertEquals('TestTitle', $model->getTitle(), 'The rank title was not saved correctly.');
+        self::assertEquals('TestTitle', $model->getTitle(), 'The rank title was not saved correctly.');
     }
 
     /**
@@ -46,6 +46,6 @@ class RankTest extends TestCase
         $model = new RankModel();
         $model->setPosts(100);
 
-        $this->assertEquals(100, $model->getPosts(), 'The rank posts was not saved correctly.');
+        self::assertEquals(100, $model->getPosts(), 'The rank posts was not saved correctly.');
     }
 }

--- a/tests/modules/user/mappers/AuthTokenTest.php
+++ b/tests/modules/user/mappers/AuthTokenTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -9,8 +9,9 @@ namespace Modules\User\Mappers;
 use PHPUnit\Ilch\DatabaseTestCase;
 use Modules\User\Config\Config as ModuleConfig;
 use Modules\Admin\Config\Config as AdminConfig;
-use \Modules\User\Mappers\AuthToken as AuthTokenMapper;
-use \Modules\User\Models\AuthToken as AuthTokenModel;
+use Modules\User\Mappers\AuthToken as AuthTokenMapper;
+use Modules\User\Models\AuthToken as AuthTokenModel;
+use PHPUnit\Ilch\PhpunitDataset;
 
 /**
  * Tests the auth token mapper class.
@@ -19,6 +20,15 @@ use \Modules\User\Models\AuthToken as AuthTokenModel;
  */
 class AuthTokenTest extends DatabaseTestCase
 {
+    protected $phpunitDataset;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
+    }
+
     /**
      * Tests if an auth token model is returned with that selector and the expected content.
      */
@@ -27,10 +37,10 @@ class AuthTokenTest extends DatabaseTestCase
         $mapper = new AuthTokenMapper();
 
         $authToken = $mapper->getAuthToken('selector');
-        $this->assertInstanceOf(AuthTokenModel::class, $authToken);
-        $this->assertEquals('token', $authToken->getToken());
-        $this->assertEquals(1, $authToken->getUserid());
-        $this->assertEquals('2014-01-01 12:12:12', $authToken->getExpires());
+        self::assertInstanceOf(AuthTokenModel::class, $authToken);
+        self::assertEquals('token', $authToken->getToken());
+        self::assertEquals(1, $authToken->getUserid());
+        self::assertEquals('2014-01-01 12:12:12', $authToken->getExpires());
     }
 
     /**
@@ -41,7 +51,7 @@ class AuthTokenTest extends DatabaseTestCase
         $mapper = new AuthTokenMapper();
 
         $authToken = $mapper->getAuthToken('invalid');
-        $this->assertNull($authToken);
+        self::assertNull($authToken);
     }
 
     /**
@@ -57,12 +67,12 @@ class AuthTokenTest extends DatabaseTestCase
         $model->setUserid(3);
         $model->setExpires('2014-01-02 10:10:10');
 
-        $this->assertEquals(3, $mapper->AddAuthToken($model));
+        self::assertEquals(3, $mapper->AddAuthToken($model));
         $authToken = $mapper->getAuthToken('selector3');
-        $this->assertInstanceOf(AuthTokenModel::class, $authToken);
-        $this->assertEquals('token3', $authToken->getToken());
-        $this->assertEquals(3, $authToken->getUserid());
-        $this->assertEquals('2014-01-02 10:10:10', $authToken->getExpires());
+        self::assertInstanceOf(AuthTokenModel::class, $authToken);
+        self::assertEquals('token3', $authToken->getToken());
+        self::assertEquals(3, $authToken->getUserid());
+        self::assertEquals('2014-01-02 10:10:10', $authToken->getExpires());
     }
 
     /**
@@ -78,12 +88,12 @@ class AuthTokenTest extends DatabaseTestCase
         $model->setUserid(4);
         $model->setExpires('2014-01-02 10:10:10');
 
-        $this->assertEquals(1, $mapper->updateAuthToken($model));
+        self::assertEquals(1, $mapper->updateAuthToken($model));
         $authToken = $mapper->getAuthToken('selector2');
-        $this->assertInstanceOf(AuthTokenModel::class, $authToken);
-        $this->assertEquals('token2', $authToken->getToken());
-        $this->assertEquals(4, $authToken->getUserid());
-        $this->assertEquals('2014-01-02 10:10:10', $authToken->getExpires());
+        self::assertInstanceOf(AuthTokenModel::class, $authToken);
+        self::assertEquals('token2', $authToken->getToken());
+        self::assertEquals(4, $authToken->getUserid());
+        self::assertEquals('2014-01-02 10:10:10', $authToken->getExpires());
     }
 
     /**
@@ -99,7 +109,7 @@ class AuthTokenTest extends DatabaseTestCase
         $model->setUserid(4);
         $model->setExpires('2014-01-02 10:10:10');
 
-        $this->assertEquals(0, $mapper->updateAuthToken($model));
+        self::assertEquals(0, $mapper->updateAuthToken($model));
     }
 
     /**
@@ -109,7 +119,7 @@ class AuthTokenTest extends DatabaseTestCase
     {
         $mapper = new AuthTokenMapper();
 
-        $this->assertEquals(1, $mapper->deleteAuthToken('selector2'));
+        self::assertEquals(1, $mapper->deleteAuthToken('selector2'));
     }
 
     /**
@@ -119,7 +129,7 @@ class AuthTokenTest extends DatabaseTestCase
     {
         $mapper = new AuthTokenMapper();
 
-        $this->assertEquals(0, $mapper->deleteAuthToken('invalid'));
+        self::assertEquals(0, $mapper->deleteAuthToken('invalid'));
     }
 
     /**
@@ -129,7 +139,7 @@ class AuthTokenTest extends DatabaseTestCase
     {
         $mapper = new AuthTokenMapper();
 
-        $this->assertEquals(1, $mapper->deleteAllAuthTokenOfUser(1));
+        self::assertEquals(1, $mapper->deleteAllAuthTokenOfUser(1));
     }
 
     /**
@@ -139,7 +149,7 @@ class AuthTokenTest extends DatabaseTestCase
     {
         $mapper = new AuthTokenMapper();
 
-        $this->assertEquals(0, $mapper->deleteAllAuthTokenOfUser(-1));
+        self::assertEquals(0, $mapper->deleteAllAuthTokenOfUser(-1));
     }
 
     /**
@@ -149,17 +159,7 @@ class AuthTokenTest extends DatabaseTestCase
     {
         $mapper = new AuthTokenMapper();
 
-        $this->assertEquals(2, $mapper->deleteExpiredAuthTokens());
-    }
-
-    /**
-     * Creates and returns a dataset object.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_AbstractDataSet
-     */
-    protected function getDataSet()
-    {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/../_files/mysql_database.yml');
+        self::assertEquals(2, $mapper->deleteExpiredAuthTokens());
     }
 
     /**

--- a/tests/modules/user/mappers/CookieStolenTest.php
+++ b/tests/modules/user/mappers/CookieStolenTest.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
 namespace Modules\User\Mappers;
 
 use PHPUnit\Ilch\DatabaseTestCase;
-use \Modules\User\Mappers\CookieStolen as CookieStolenMapper;
+use Modules\User\Mappers\CookieStolen as CookieStolenMapper;
 use Modules\User\Config\Config as ModuleConfig;
 use Modules\Admin\Config\Config as AdminConfig;
+use PHPUnit\Ilch\PhpunitDataset;
 
 /**
  * Tests the cookie stolen mapper class.
@@ -18,6 +19,15 @@ use Modules\Admin\Config\Config as AdminConfig;
  */
 class CookieStolenTest extends DatabaseTestCase
 {
+    protected $phpunitDataset;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
+    }
+
     /**
      * Tests containsCookieStolen(). Should return 1.
      */
@@ -25,7 +35,7 @@ class CookieStolenTest extends DatabaseTestCase
     {
         $mapper = new CookieStolenMapper();
 
-        $this->assertEquals(1, $mapper->containsCookieStolen(1));
+        self::assertEquals(1, $mapper->containsCookieStolen(1));
     }
 
     /**
@@ -35,7 +45,7 @@ class CookieStolenTest extends DatabaseTestCase
     {
         $mapper = new CookieStolenMapper();
 
-        $this->assertEquals(0, $mapper->containsCookieStolen(0));
+        self::assertEquals(0, $mapper->containsCookieStolen(0));
     }
 
     /**
@@ -46,7 +56,7 @@ class CookieStolenTest extends DatabaseTestCase
         $mapper = new CookieStolenMapper();
 
         $mapper->addCookieStolen(2);
-        $this->assertEquals(1, $mapper->containsCookieStolen(2));
+        self::assertEquals(1, $mapper->containsCookieStolen(2));
     }
 
     /**
@@ -56,7 +66,7 @@ class CookieStolenTest extends DatabaseTestCase
     {
         $mapper = new CookieStolenMapper();
 
-        $this->assertEquals(1, $mapper->deleteCookieStolen(1));
+        self::assertEquals(1, $mapper->deleteCookieStolen(1));
     }
 
     /**
@@ -66,17 +76,7 @@ class CookieStolenTest extends DatabaseTestCase
     {
         $mapper = new CookieStolenMapper();
 
-        $this->assertEquals(0, $mapper->deleteCookieStolen(0));
-    }
-
-    /**
-     * Creates and returns a dataset object.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_AbstractDataSet
-     */
-    protected function getDataSet()
-    {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/../_files/mysql_database.yml');
+        self::assertEquals(0, $mapper->deleteCookieStolen(0));
     }
 
     /**

--- a/tests/modules/user/mappers/GroupTest.php
+++ b/tests/modules/user/mappers/GroupTest.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
 namespace Modules\User\Mappers;
 
 use PHPUnit\Ilch\TestCase;
-use \Modules\User\Mappers\Group as GroupMapper;
+use Modules\User\Mappers\Group as GroupMapper;
 
 /**
  * Tests the user group mapper class.
@@ -31,8 +31,8 @@ class GroupTest extends TestCase
         $mapper = new GroupMapper();
         $group = $mapper->loadFromArray($groupRow);
 
-        $this->assertTrue($group !== false);
-        $this->assertEquals(1, $group->getId());
-        $this->assertEquals('Administrator', $group->getName());
+        self::assertNotFalse($group);
+        self::assertEquals(1, $group->getId());
+        self::assertEquals('Administrator', $group->getName());
     }
 }

--- a/tests/modules/user/mappers/UserTest.php
+++ b/tests/modules/user/mappers/UserTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -13,6 +13,7 @@ use Modules\User\Config\Config as ModuleConfig;
 use Modules\Admin\Config\Config as AdminConfig;
 use Modules\User\Mappers\User as UserMapper;
 use Modules\User\Models\User as UserModel;
+use PHPUnit\Ilch\PhpunitDataset;
 
 /**
  * Tests the user mapper class.
@@ -26,26 +27,19 @@ class UserTest extends DatabaseTestCase
      */
     protected $out;
 
+    protected $phpunitDataset;
+
     public function setUp()
     {
         parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
         $this->out = new UserMapper();
     }
 
-
     public function testGetAdministratorCount()
     {
-        $this->assertEquals(1, $this->out->getAdministratorCount());
-    }
-
-    /**
-     * Creates and returns a dataset object.
-     *
-     * @return \PHPUnit_Extensions_Database_DataSet_AbstractDataSet
-     */
-    protected function getDataSet()
-    {
-        return new \PHPUnit\DbUnit\DataSet\YamlDataSet(__DIR__ . '/../_files/mysql_database.yml');
+        self::assertEquals(1, $this->out->getAdministratorCount());
     }
 
     /**

--- a/tests/modules/user/models/GroupTest.php
+++ b/tests/modules/user/models/GroupTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -23,7 +23,7 @@ class GroupTest extends TestCase
         $group = new Group();
         $group->setName('newGroup');
 
-        $this->assertEquals('newGroup', $group->getName(), 'The group name did not save correctly.');
+        self::assertEquals('newGroup', $group->getName(), 'The group name did not save correctly.');
     }
 
     /**
@@ -34,7 +34,7 @@ class GroupTest extends TestCase
         $group = new Group();
         $group->setId(3);
 
-        $this->assertEquals(3, $group->getId(), 'The group id did not save correctly.');
-        $this->assertTrue(is_int($group->getId()), 'The group id was not returned as an Integer.');
+        self::assertEquals(3, $group->getId(), 'The group id did not save correctly.');
+        self::assertTrue(\is_int($group->getId()), 'The group id was not returned as an Integer.');
     }
 }

--- a/tests/modules/user/models/UserTest.php
+++ b/tests/modules/user/models/UserTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -33,7 +33,7 @@ class UserTest extends TestCase
     {
         $user = new User();
         $user->setId(123);
-        $this->assertEquals(123, $user->getId(), 'The id wasnt saved or returned correctly.');
+        self::assertEquals(123, $user->getId(), 'The id wasnt saved or returned correctly.');
     }
 
     /**
@@ -43,7 +43,7 @@ class UserTest extends TestCase
     {
         $user = new User();
         $user->setName('username');
-        $this->assertEquals('username', $user->getName(), 'The username wasnt saved or returned correctly.');
+        self::assertEquals('username', $user->getName(), 'The username wasnt saved or returned correctly.');
     }
 
     /**
@@ -53,7 +53,7 @@ class UserTest extends TestCase
     {
         $user = new User();
         $user->setEmail('email');
-        $this->assertEquals('email', $user->getEmail(), 'The email wasnt saved or returned correctly.');
+        self::assertEquals('email', $user->getEmail(), 'The email wasnt saved or returned correctly.');
     }
 
     /**
@@ -72,7 +72,7 @@ class UserTest extends TestCase
         $group3->setName('Clanleader');
         $user = new User();
         $user->setGroups([$group1, $group2, $group3]);
-        $this->assertEquals(
+        self::assertEquals(
             [$group1, $group2, $group3],
             $user->getGroups(),
             'The user groups wasnt saved or returned correctly.'
@@ -96,7 +96,7 @@ class UserTest extends TestCase
         $user = new User();
         $user->setGroups([$group1, $group3]);
         $user->addGroup($group2);
-        $this->assertEquals(
+        self::assertEquals(
             [$group1, $group3, $group2],
             $user->getGroups(),
             'The user groups wasnt added or returned correctly.'
@@ -124,11 +124,11 @@ class UserTest extends TestCase
 
         $user->addGroup($group1)->addGroup($group2)->addGroup($group3);
 
-        $this->assertTrue($user->hasGroup(2), 'The user has not the group with id "2".');
-        $this->assertFalse($user->hasGroup(4), 'The user has the group with id "4".');
+        self::assertTrue($user->hasGroup(2), 'The user has not the group with id "2".');
+        self::assertFalse($user->hasGroup(4), 'The user has the group with id "4".');
 
         $user->setGroups([]);
-        $this->assertFalse($user->hasGroup(2), 'The user has the group with id "2".');
+        self::assertFalse($user->hasGroup(2), 'The user has the group with id "2".');
     }
 
     /**
@@ -144,22 +144,22 @@ class UserTest extends TestCase
         $user->addGroup($group);
 
         $dbMock = $this->createPartialMock(Mysql::class, ['queryCell', 'escape']);
-        $dbMock->expects($this->once())
+        $dbMock->expects(self::once())
             ->method('escape')
             ->willReturnArgument(0);
-        $dbMock->expects($this->once())
+        $dbMock->expects(self::once())
             ->method('queryCell')
             ->with(
-                $this->logicalAnd(
-                    $this->stringContains('FROM [prefix]_groups_access'),
-                    $this->stringContains('INNER JOIN `[prefix]_modules`'),
-                    $this->stringContains('user')
+                self::logicalAnd(
+                    self::stringContains('FROM [prefix]_groups_access'),
+                    self::stringContains('INNER JOIN `[prefix]_modules`'),
+                    self::stringContains('user')
                 )
             )
-            ->will($this->returnValue('0'));
+            ->willReturn('0');
         Registry::remove('db');
         Registry::set('db', $dbMock);
 
-        $this->assertEquals(0, $user->hasAccess('module_user'));
+        self::assertEquals(0, $user->hasAccess('module_user'));
     }
 }


### PR DESCRIPTION
# Description

The goal is to be able to run unit tests under PHP 8 and newer.
- DbUnit is abandoned and is currently used to do unit tests against the database.
- phpunit/phpunit-mock-objects as separate part is abandoned and got merged into PHPUnit (version 7?) in early 2018.
- Currently a really old version of PHPUnit is used. An upgrade to a newer version is hard as Ilch for example supports PHP 7.0 and 7.1. Maybe remove support of PHP 7.0, 7.1 and maybe even 7.2 earlier than ~June 2022 if necessary.

See:
https://github.com/IlchCMS/Ilch-2.0/issues/475
https://github.com/IlchCMS/Ilch-2.0/issues/475#issuecomment-650542426
https://phpunit.de/supported-versions.html
https://github.com/IlchCMS/Ilch-2.0/issues/482

- Removed dependency on the deprecated DbUnit by replacing it with an own solution (not as feature rich, but works for current tests).
- Adjusted existing unit tests to work with the new replacement.
- Fixed various issues found by the IDE.

There are a few more points that can be targeted, but I leave that for later pull requests. For example:
- Support loading of other file types if needed.
- Accept directly an array and therefore avoid having to access files (currently yml).
- Cache content of files to not read them too often?

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update