### PR TITLE
Fix/ticket483 readaccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### Ilch 2 [![Build Status](https://travis-ci.com/IlchCMS/Ilch-2.0.png?branch=master)](https://travis-ci.com/IlchCMS/Ilch-2.0)
-Ilch 2 ist der direkte Nachfolger der Ilch Versionen 1.1. 
+Ilch 2 ist der direkte Nachfolger der Ilch Versionen 1.1.
 
 ### Neueste Version (für Anwender)
 - [Zur neuesten Version](https://github.com/IlchCMS/Ilch-2.0/releases/latest)
@@ -22,9 +22,8 @@ Ilch 2 ist der direkte Nachfolger der Ilch Versionen 1.1.
 
 ### Voraussetzungen
 - PHP Version 7.0 oder neuer
-- MySQL (5.5.3), MariaDB (5.5) oder Equivalent
+- MySQL (5.5.3 oder neuer), MariaDB (5.5 oder neuer) oder Equivalent
 
 ### Support/Dokumentation
 - https://www.ilch.de
 - https://github.com/IlchCMS/Ilch-2.0/wiki
-

--- a/application/libraries/Ilch/Database/Mysql/Delete.php
+++ b/application/libraries/Ilch/Database/Mysql/Delete.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -55,7 +55,7 @@ class Delete extends QueryBuilder
      */
     public function generateSql()
     {
-        $sql = 'DELETE  FROM ' . $this->db->quote('[prefix]_' . $this->table);
+        $sql = 'DELETE FROM ' . $this->db->quote('[prefix]_' . $this->table);
 
         $sql .= $this->generateWhereSql();
 

--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -787,6 +787,11 @@ class Config extends \Ilch\Config\Install
                     ->execute()
                     ->fetchRows();
 
+                $existingGroups = $this->db()->select('id')
+                    ->from(['groups'])
+                    ->execute()
+                    ->fetchList();
+
                 $sql = 'INSERT INTO [prefix]_articles_access (article_id, group_id) VALUES';
                 $sqlWithValues = $sql;
                 $rowCount = 0;
@@ -804,9 +809,13 @@ class Config extends \Ilch\Config\Install
                             $sqlWithValues = $sql;
                         }
 
-                        $rowCount += \count($groupIds);
-
                         foreach ($groupIds as $groupId) {
+                            // Don't try to add a groupId that doesn't exist in the groups table as this would
+                            // lead to an error (foreign key constraint).
+                            if (in_array($groupId, $existingGroups)) {
+                                continue;
+                            }
+                            $rowCount++;
                             $sqlWithValues .= '(' . $articleId . ',' . $groupId . '),';
                         }
                     }

--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -676,7 +676,7 @@ class Config extends \Ilch\Config\Install
                 if (!empty($comments)) {
                     foreach($comments as $comment) {
                         $key = '';
-                        if (!(strlen($comment['key']) - (strrpos($comment['key'], '/')) === 0)) {
+                        if (!(\strlen($comment['key']) - (strrpos($comment['key'], '/')) === 0)) {
                             // Add missing slash at the end to usually terminate the id.
                             // This is needed for example so that id 11 doesn't get counted as id 1.
                             $key = $comment['key'] . '/';
@@ -809,13 +809,12 @@ class Config extends \Ilch\Config\Install
                             $sqlWithValues = $sql;
                         }
 
+                        // Don't try to add a groupId that doesn't exist in the groups table as this would
+                        // lead to an error (foreign key constraint).
+                        $groupIds = array_intersect($existingGroups, $groupIds);
+                        $rowCount += \count($groupIds);
+
                         foreach ($groupIds as $groupId) {
-                            // Don't try to add a groupId that doesn't exist in the groups table as this would
-                            // lead to an error (foreign key constraint).
-                            if (in_array($groupId, $existingGroups)) {
-                                continue;
-                            }
-                            $rowCount++;
                             $sqlWithValues .= '(' . $articleId . ',' . $groupId . '),';
                         }
                     }

--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -818,6 +818,9 @@ class Config extends \Ilch\Config\Install
 
                 // Delete old read_access column of table articles.
                 $this->db()->query('ALTER TABLE `[prefix]_articles` DROP COLUMN `read_access`;');
+
+                // Add constraint to articles_content.
+                $this->db()->query('ALTER TABLE `[prefix]_articles_content` ADD CONSTRAINT `FK_[prefix]_articles_content_[prefix]_articles` FOREIGN KEY (`article_id`) REFERENCES `[prefix]_articles` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
         }
 
         return 'Update function executed.';

--- a/application/modules/article/boxes/Archive.php
+++ b/application/modules/article/boxes/Archive.php
@@ -1,20 +1,35 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
 namespace Modules\Article\Boxes;
 
 use Modules\Article\Mappers\Article as ArticleMapper;
+use Modules\User\Mappers\User as UserMapper;
 
 class Archive extends \Ilch\Box
 {
     public function render()
     {
         $articleMapper = new ArticleMapper();
+        $userMapper = new UserMapper();
+
+        $user = null;
+        if ($this->getUser()) {
+            $user = $userMapper->getUserById($this->getUser()->getId());
+        }
+
+        $readAccess = [3];
+        if ($user) {
+            foreach ($user->getGroups() as $us) {
+                $readAccess[] = $us->getId();
+            }
+        }
 
         $this->getView()->set('articleMapper', $articleMapper)
-            ->set('archive', $articleMapper->getArticleDateList($this->getConfig()->get('article_box_archiveLimit')));
+            ->set('archive', $articleMapper->getArticleDateListAccess($readAccess, $this->getConfig()->get('article_box_archiveLimit')))
+            ->set('readAccess', $readAccess);
     }
 }

--- a/application/modules/article/boxes/Article.php
+++ b/application/modules/article/boxes/Article.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -33,7 +33,6 @@ class Article extends \Ilch\Box
             $locale = $this->getTranslator()->getLocale();
         }
 
-        $this->getView()->set('articles', $articleMapper->getArticleList($locale, $this->getConfig()->get('article_box_articleLimit')))
-                        ->set('readAccess', $readAccess);
+        $this->getView()->set('articles', $articleMapper->getArticleListAccess($readAccess, $locale, $this->getConfig()->get('article_box_articleLimit')));
     }
 }

--- a/application/modules/article/boxes/Categories.php
+++ b/application/modules/article/boxes/Categories.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -8,6 +8,7 @@ namespace Modules\Article\Boxes;
 
 use Modules\Article\Mappers\Category as CategoryMapper;
 use Modules\Article\Mappers\Article as ArticleMapper;
+use Modules\User\Mappers\User as UserMapper;
 
 class Categories extends \Ilch\Box
 {
@@ -15,8 +16,22 @@ class Categories extends \Ilch\Box
     {
         $categoryMapper = new CategoryMapper();
         $articleMapper = new ArticleMapper();
+        $userMapper = new UserMapper();
+
+        $user = null;
+        if ($this->getUser()) {
+            $user = $userMapper->getUserById($this->getUser()->getId());
+        }
+
+        $readAccess = [3];
+        if ($user) {
+            foreach ($user->getGroups() as $us) {
+                $readAccess[] = $us->getId();
+            }
+        }
 
         $this->getView()->set('articleMapper', $articleMapper)
-            ->set('cats', $categoryMapper->getCategories());
+            ->set('cats', $categoryMapper->getCategories())
+            ->set('readAccess', $readAccess);
     }
 }

--- a/application/modules/article/boxes/Keywords.php
+++ b/application/modules/article/boxes/Keywords.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
 namespace Modules\Article\Boxes;
 
+use Modules\User\Mappers\User as UserMapper;
 use Modules\Article\Mappers\Article as ArticleMapper;
 
 class Keywords extends \Ilch\Box
@@ -13,9 +14,22 @@ class Keywords extends \Ilch\Box
     public function render()
     {
         $articleMapper = new ArticleMapper();
+        $userMapper = new UserMapper();
+
+        $user = null;
+        if ($this->getUser()) {
+            $user = $userMapper->getUserById($this->getUser()->getId());
+        }
+
+        $readAccess = [3];
+        if ($user) {
+            foreach ($user->getGroups() as $us) {
+                $readAccess[] = $us->getId();
+            }
+        }
 
         $keywordsList = [];
-        foreach ($articleMapper->getKeywordsList() as $keywords) {
+        foreach ($articleMapper->getKeywordsListAccess($readAccess) as $keywords) {
             $keywordsList[] = $keywords->getKeywords();
         }
 

--- a/application/modules/article/boxes/views/archive.php
+++ b/application/modules/article/boxes/views/archive.php
@@ -17,7 +17,7 @@ $archive = $this->get('archive');
                         </a>
                     </span>
                     <span class="badge">
-                        <?=$articleMapper->getCountArticlesByMonthYear($archiv->getDateCreated()) ?>
+                        <?=$articleMapper->getCountArticlesByMonthYearAccess($archiv->getDateCreated(), $this->get('readAccess')) ?>
                     </span>
                 </li>
             <?php endforeach; ?>

--- a/application/modules/article/boxes/views/article.php
+++ b/application/modules/article/boxes/views/article.php
@@ -1,12 +1,5 @@
 <?php
 $articles = $this->get('articles');
-
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
-
-$displayedArticles = 0;
 ?>
 
 <link href="<?=$this->getBoxUrl('static/css/article.css') ?>" rel="stylesheet">
@@ -15,11 +8,6 @@ $displayedArticles = 0;
     <div class="article-box">
         <ul class="list-unstyled">
             <?php foreach ($articles as $article):
-                if (!is_in_array($this->get('readAccess'), explode(',', $article->getReadAccess())) && $adminAccess == false) {
-                    continue;
-                }
-
-                $displayedArticles++;
                 $date = new \Ilch\Date($article->getDateCreated());
             ?>
                 <li class="ellipsis" style="line-height: 25px;">
@@ -36,9 +24,6 @@ $displayedArticles = 0;
                     </span>
                 </li>
             <?php endforeach; ?>
-            <?php if ($displayedArticles == 0) : ?>
-                <?=$this->getTrans('noArticles') ?>
-            <?php endif; ?>
         </ul>
     </div>
 <?php else: ?>

--- a/application/modules/article/boxes/views/categories.php
+++ b/application/modules/article/boxes/views/categories.php
@@ -9,6 +9,13 @@ $cats = $this->get('cats');
     <div class="article-box">
         <ul class="list-unstyled">
             <?php foreach ($cats as $cat): ?>
+                <?php
+                    $count = $articleMapper->getCountArticlesByCatIdAccess($cat->getId(), $this->get('readAccess'));
+
+                    if ($count === 0) {
+                        continue;
+                    }
+                ?>
                 <li class="ellipsis">
                     <span class="ellipsis-item">
                         <a href="<?=$this->getUrl(['module' => 'article', 'controller' => 'cats', 'action' => 'show', 'id' => $cat->getId()]) ?>">
@@ -16,7 +23,7 @@ $cats = $this->get('cats');
                         </a>
                     </span>
                     <span class="badge">
-                        <?=$articleMapper->getCountArticlesByCatId($cat->getId()) ?>
+                        <?=$count ?>
                     </span>
                 </li>
             <?php endforeach; ?>

--- a/application/modules/article/config/config.php
+++ b/application/modules/article/config/config.php
@@ -110,7 +110,9 @@ class Config extends \Ilch\Config\Install
                   `perma` VARCHAR(255) NOT NULL,
                   `img` VARCHAR(255) NOT NULL,
                   `img_source` VARCHAR(255) NOT NULL,
-                  `votes` LONGTEXT NOT NULL
+                  `votes` LONGTEXT NOT NULL,
+                  INDEX `FK_[prefix]_articles_content_[prefix]_articles` (`article_id`) USING BTREE,
+                  CONSTRAINT `FK_[prefix]_articles_content_[prefix]_articles` FOREIGN KEY (`article_id`) REFERENCES `[prefix]_articles` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
                 CREATE TABLE IF NOT EXISTS `[prefix]_articles_templates` (

--- a/application/modules/article/config/config.php
+++ b/application/modules/article/config/config.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -78,9 +78,17 @@ class Config extends \Ilch\Config\Install
                   `date_created` DATETIME NOT NULL,
                   `top` TINYINT(1) NOT NULL DEFAULT 0,
                   `commentsDisabled` TINYINT(1) NOT NULL DEFAULT 0,
-                  `read_access` VARCHAR(255) NOT NULL DEFAULT \'1,2,3\',
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
+
+                CREATE TABLE `[prefix]_articles_access` (
+                    `article_id` INT(11) NOT NULL,
+                    `group_id` INT(11) NOT NULL,
+                    PRIMARY KEY (`article_id`, `group_id`) USING BTREE,
+                    INDEX `FK_[prefix]_articles_access_[prefix]_groups` (`group_id`) USING BTREE,
+                    CONSTRAINT `FK_[prefix]_articles_access_[prefix]_articles` FOREIGN KEY (`article_id`) REFERENCES `[prefix]_articles` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    CONSTRAINT `FK_[prefix]_articles_access_[prefix]_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
                 CREATE TABLE IF NOT EXISTS `[prefix]_articles_cats` (
                   `id` INT(11) NOT NULL AUTO_INCREMENT,
@@ -122,10 +130,12 @@ class Config extends \Ilch\Config\Install
 
                 INSERT INTO `[prefix]_articles` (`cat_id`, `date_created`, `top`) VALUES (1, now(), 0);
 
+                INSERT INTO `[prefix]_articles_access` (`article_id`, `group_id`) VALUES (1,1), (1,2), (1,3);
+
                 INSERT INTO `[prefix]_articles_cats` (`name`) VALUES ("Allgemein");
 
                 INSERT INTO `[prefix]_articles_content` (`article_id`, `author_id`, `title`, `teaser`, `content`, `keywords`, `perma`) VALUES
-                (1, 1, "Willkommen", "Willkommen beim Ilch CMS!", "<p>Dies ist dein erster Artikel mit dem Ilch - Content Management System</p><p>Bei Fragen oder Probleme im <a href=\"http://www.ilch.de/forum.html\">Ilch Forum</a>&nbsp;melden.</p><p>Viel Erfolg<br />Ilch</p>", "willkommen, ilch, cms, news", "willkommen.html");';
+                (1, 1, "Willkommen", "Willkommen beim Ilch CMS!", "<p>Dies ist dein erster Artikel mit dem Ilch - Content Management System</p><p>Bei Fragen oder Probleme im <a href=\"https://www.ilch.de/forum.html\">Ilch Forum</a>&nbsp;melden.</p><p>Viel Erfolg<br />Ilch</p>", "willkommen, ilch, cms, news", "willkommen.html");';
     }
 
     public function getUpdate($installedVersion)

--- a/application/modules/article/controllers/Archive.php
+++ b/application/modules/article/controllers/Archive.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -63,8 +63,7 @@ class Archive extends \Ilch\Controller\Frontend
             ->set('commentMapper', $commentMapper)
             ->set('userMapper', $userMapper)
             ->set('article_articleRating', \Ilch\Registry::get('config')->get('article_articleRating'))
-            ->set('articles', $articleMapper->getArticles($this->locale, $pagination))
-            ->set('readAccess', $readAccess)
+            ->set('articles', $articleMapper->getArticlesByAccess($readAccess, $this->locale, $pagination))
             ->set('pagination', $pagination);
     }
 
@@ -96,7 +95,7 @@ class Archive extends \Ilch\Controller\Frontend
             $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans($date->format('F', true)).$date->format(' Y', true), ['action' => 'show', 'year' => $this->getRequest()->getParam('year'), 'month' => $this->getRequest()->getParam('month')]);
 
-            $pagination->setRowsPerPage($this->getConfig()->get('defaultPaginationObjects'));
+            $pagination->setRowsPerPage(!$this->getConfig()->get('article_articlesPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('article_articlesPerPage'));
             $pagination->setPage($this->getRequest()->getParam('page'));
 
             $user = null;
@@ -111,10 +110,9 @@ class Archive extends \Ilch\Controller\Frontend
                 }
             }
 
-            $articles = $articleMapper->getArticlesByDate($date, $pagination, $this->locale);
+            $articles = $articleMapper->getArticlesByDateAccess($date, $readAccess, $pagination, $this->locale);
 
-            $this->getView()->set('readAccess', $readAccess)
-                ->set('pagination', $pagination);
+            $this->getView()->set('pagination', $pagination);
         }
 
         $this->getView()->set('categoryMapper', $categoryMapper)

--- a/application/modules/article/controllers/Cats.php
+++ b/application/modules/article/controllers/Cats.php
@@ -96,8 +96,7 @@ class Cats extends \Ilch\Controller\Frontend
         $this->getView()->set('categoryMapper', $categoryMapper)
             ->set('commentMapper', $commentMapper)
             ->set('article_articleRating', \Ilch\Registry::get('config')->get('article_articleRating'))
-            ->set('articles', $articleMapper->getArticlesByCats($this->getRequest()->getParam('id'), $this->locale, $pagination))
-            ->set('readAccess', $readAccess)
+            ->set('articles', $articleMapper->getArticlesByCatsAccess($this->getRequest()->getParam('id'), $readAccess, $this->locale, $pagination))
             ->set('pagination', $pagination);
     }
 

--- a/application/modules/article/controllers/Cats.php
+++ b/application/modules/article/controllers/Cats.php
@@ -33,6 +33,7 @@ class Cats extends \Ilch\Controller\Frontend
     {
         $articleMapper = new ArticleMapper();
         $categoryMapper = new CategoryMapper();
+        $userMapper = new UserMapper();
 
         $this->getLayout()->header()
             ->css('static/css/article.css');
@@ -43,8 +44,21 @@ class Cats extends \Ilch\Controller\Frontend
             ->add($this->getTranslator()->trans('menuArticle'), ['controller' => 'index', 'action' => 'index'])
             ->add($this->getTranslator()->trans('menuCats'), ['action' => 'index']);
 
+        $user = null;
+        if ($this->getUser()) {
+            $user = $userMapper->getUserById($this->getUser()->getId());
+        }
+
+        $readAccess = [3];
+        if ($user) {
+            foreach ($user->getGroups() as $us) {
+                $readAccess[] = $us->getId();
+            }
+        }
+
         $this->getView()->set('articleMapper', $articleMapper)
-            ->set('cats', $categoryMapper->getCategories());
+            ->set('cats', $categoryMapper->getCategories())
+            ->set('readAccess', $readAccess);
     }
 
     public function showAction()

--- a/application/modules/article/controllers/Index.php
+++ b/application/modules/article/controllers/Index.php
@@ -66,9 +66,8 @@ class Index extends \Ilch\Controller\Frontend
         $this->getView()->set('categoryMapper', $categoryMapper)
             ->set('commentMapper', $commentMapper)
             ->set('article_articleRating', \Ilch\Registry::get('config')->get('article_articleRating'))
-            ->set('articles', $articleMapper->getArticles($this->locale, $pagination))
-            ->set('pagination', $pagination)
-            ->set('readAccess', $readAccess);
+            ->set('articles', $articleMapper->getArticlesByAccess($readAccess, $this->locale, $pagination))
+            ->set('pagination', $pagination);
     }
 
     public function showAction()
@@ -276,7 +275,7 @@ class Index extends \Ilch\Controller\Frontend
         $user = null;
         // FIXME: Only create RSS-Feed with guest rights to avoid leaking articles not supposed to be for everyone.
         // This (unfinished) feature needs a complete rewrite to be ready.
-        // http://redmine.ilch2.de/issues/591
+        // https://github.com/IlchCMS/Ilch-2.0/issues/448
         // if ($this->getUser()) {
             // $user = $userMapper->getUserById($this->getUser()->getId());
         // }

--- a/application/modules/article/controllers/Keywords.php
+++ b/application/modules/article/controllers/Keywords.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -98,8 +98,7 @@ class Keywords extends \Ilch\Controller\Frontend
         $this->getView()->set('categoryMapper', $categoryMapper)
             ->set('commentMapper', $commentMapper)
             ->set('article_articleRating', \Ilch\Registry::get('config')->get('article_articleRating'))
-            ->set('articles', $articleMapper->getArticlesByKeyword($keyword, $this->locale, $pagination))
-            ->set('readAccess', $readAccess)
+            ->set('articles', $articleMapper->getArticlesByKeywordAccess($keyword, $readAccess, $this->locale, $pagination))
             ->set('pagination', $pagination);
     }
 

--- a/application/modules/article/controllers/Keywords.php
+++ b/application/modules/article/controllers/Keywords.php
@@ -32,6 +32,7 @@ class Keywords extends \Ilch\Controller\Frontend
     public function indexAction()
     {
         $articleMapper = new ArticleMapper();
+        $userMapper = new UserMapper();
 
         $this->getLayout()->getTitle()
             ->add($this->getTranslator()->trans('menuArticle'))
@@ -40,8 +41,20 @@ class Keywords extends \Ilch\Controller\Frontend
             ->add($this->getTranslator()->trans('menuArticle'), ['controller' => 'index', 'action' => 'index'])
             ->add($this->getTranslator()->trans('menuKeywords'), ['action' => 'index']);
 
+        $user = null;
+        if ($this->getUser()) {
+            $user = $userMapper->getUserById($this->getUser()->getId());
+        }
+
+        $readAccess = [3];
+        if ($user) {
+            foreach ($user->getGroups() as $us) {
+                $readAccess[] = $us->getId();
+            }
+        }
+
         $keywordsList = [];
-        foreach ($articleMapper->getKeywordsList() as $keywords) {
+        foreach ($articleMapper->getKeywordsListAccess($readAccess) as $keywords) {
             $keywordsList[] = $keywords->getKeywords();
         }
 

--- a/application/modules/article/controllers/admin/Cats.php
+++ b/application/modules/article/controllers/admin/Cats.php
@@ -48,7 +48,7 @@ class Cats extends \Ilch\Controller\Admin
             ]
         ];
 
-        if ($this->getRequest()->getControllerName() == 'cats' && $this->getRequest()->getActionName() == 'treat') {
+        if ($this->getRequest()->getControllerName() === 'cats' && $this->getRequest()->getActionName() === 'treat') {
             $items[1][0]['active'] = true;
         } else {
             $items[1]['active'] = true;

--- a/application/modules/article/controllers/admin/Index.php
+++ b/application/modules/article/controllers/admin/Index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -189,7 +189,7 @@ class Index extends \Ilch\Controller\Admin
         }
 
         if ($this->getRequest()->getParam('id')) {
-            $groups = explode(',', $articleMapper->getArticleByIdLocale($this->getRequest()->getParam('id'), '')->getReadAccess());
+            $groups = explode(',', $articleMapper->getArticleByIdLocale($this->getRequest()->getParam('id'))->getReadAccess());
         } else {
             $groups = [1,2,3];
         }

--- a/application/modules/article/controllers/admin/Templates.php
+++ b/application/modules/article/controllers/admin/Templates.php
@@ -57,7 +57,7 @@ class Templates extends \Ilch\Controller\Admin
                 ->add($this->getTranslator()->trans('menuArticle'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('manageTemplates'), ['action' => 'index']);
 
-        if ($this->getRequest()->getPost('action') == 'delete' && $this->getRequest()->getPost('check_articles')) {
+        if ($this->getRequest()->getPost('action') === 'delete' && $this->getRequest()->getPost('check_articles')) {
             foreach ($this->getRequest()->getPost('check_articles') as $articleId) {
                 $templateMapper->delete($articleId);
             }

--- a/application/modules/article/mappers/Article.php
+++ b/application/modules/article/mappers/Article.php
@@ -778,7 +778,7 @@ class Article extends \Ilch\Mapper
      */
     public function getArticlePermas()
     {
-        $permas = $this->db()->select(['perma'])
+        $permas = $this->db()->select(['article_id', 'locale', 'perma'])
             ->from('articles_content')
             ->execute()
             ->fetchRows();

--- a/application/modules/article/mappers/Article.php
+++ b/application/modules/article/mappers/Article.php
@@ -886,7 +886,7 @@ class Article extends \Ilch\Mapper
             if ($this->getArticleByIdLocale($article->getId(), $article->getLocale())) {
                 // Update existing article with specific id and locale
                 $this->db()->update('articles')
-                    ->values(['cat_id' => $article->getCatId(), 'date_created' => $article->getDateCreated(), 'commentsDisabled' => $article->getCommentsDisabled()])
+                    ->values(['cat_id' => $article->getCatId(), 'date_created' => $article->getDateCreated(), 'commentsDisabled' => (int)$article->getCommentsDisabled()])
                     ->where(['id' => $article->getId()])
                     ->execute();
 
@@ -924,7 +924,7 @@ class Article extends \Ilch\Mapper
         } else {
             // Insert new article
             $articleId = $this->db()->insert('articles')
-                ->values(['cat_id' => $article->getCatId(), 'date_created' => $article->getDateCreated(), 'commentsDisabled' => $article->getCommentsDisabled()])
+                ->values(['cat_id' => $article->getCatId(), 'date_created' => $article->getDateCreated(), 'commentsDisabled' => (int)$article->getCommentsDisabled()])
                 ->execute();
 
             $this->db()->insert('articles_content')
@@ -945,7 +945,7 @@ class Article extends \Ilch\Mapper
             $id = $articleId;
         }
 
-        $this->setTopArticle($id, $article->getTopArticle());
+        $this->setTopArticle($id, (int)$article->getTopArticle());
         $this->saveReadAccess($id, $article->getReadAccess());
 
         return $id;

--- a/application/modules/article/mappers/Article.php
+++ b/application/modules/article/mappers/Article.php
@@ -307,7 +307,9 @@ class Article extends \Ilch\Mapper
             ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
             ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
             ->where(['p.date_created >=' => $dateFrom, 'p.date_created <' => $dateTo, 'pc.locale' => $this->db()->escape($locale)])
-            ->group(['p.id' => 'DESC', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes']);
+            ->group(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->order(['p.id' => 'DESC']);
+
 
         if ($pagination !== null) {
             $select->limit($pagination->getLimit())
@@ -362,7 +364,8 @@ class Article extends \Ilch\Mapper
             ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
             ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
             ->where(['ra.group_id' => $groupIds, 'p.date_created >=' => $dateFrom, 'p.date_created <' => $dateTo, 'pc.locale' => $this->db()->escape($locale)])
-            ->group(['p.id' => 'DESC', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes']);
+            ->group(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->order(['p.id' => 'DESC']);
 
         if ($pagination !== null) {
             $select->limit($pagination->getLimit())

--- a/application/modules/article/mappers/Article.php
+++ b/application/modules/article/mappers/Article.php
@@ -63,7 +63,7 @@ class Article extends \Ilch\Mapper
      * @return array|null
      * @since 2.1.44
      */
-    public function getArticlesByAccess($groupIds = '3', $locale = '', $pagination = null)
+    public function getArticlesByAccess($groupIds = '3', string $locale = '', $pagination = null)
     {
         if (\is_string($groupIds)) {
             $groupIds = explode(',', $groupIds);
@@ -154,7 +154,7 @@ class Article extends \Ilch\Mapper
      * @return array|null
      * @since 2.1.44
      */
-    public function getArticlesByCatsAccess($catId, $groupIds = '3', $locale = '', $pagination = null)
+    public function getArticlesByCatsAccess(int $catId, $groupIds = '3', string $locale = '', $pagination = null)
     {
         if (\is_string($groupIds)) {
             $groupIds = explode(',', $groupIds);
@@ -244,7 +244,7 @@ class Article extends \Ilch\Mapper
      * @return array|null
      * @since 2.1.44
      */
-    public function getArticlesByKeywordAccess($keyword, $groupIds = '3', $locale = '', $pagination = null)
+    public function getArticlesByKeywordAccess(string $keyword, $groupIds = '3', string $locale = '', $pagination = null)
     {
         if (\is_string($groupIds)) {
             $groupIds = explode(',', $groupIds);
@@ -341,7 +341,7 @@ class Article extends \Ilch\Mapper
      * @return array|null
      * @since 2.1.44
      */
-    public function getArticlesByDateAccess(\DateTime $date, $groupIds = '3', $pagination = null, $locale = '')
+    public function getArticlesByDateAccess(\DateTime $date, $groupIds = '3', $pagination = null, string $locale = '')
     {
         $db = $this->db();
 
@@ -410,7 +410,7 @@ class Article extends \Ilch\Mapper
      * @return int
      * @since 2.1.44
      */
-    public function getCountArticlesByCatIdAccess($catId, $groupIds = '3')
+    public function getCountArticlesByCatIdAccess(int $catId, $groupIds = '3'): int
     {
         if (\is_string($groupIds)) {
             $groupIds = explode(',', $groupIds);
@@ -447,13 +447,13 @@ class Article extends \Ilch\Mapper
     /**
      * Get articles count by month and year and taking the group IDs into account.
      *
-     * @param null $date
+     * @param string|null $date
      * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
      * @return int
      * @throws \Ilch\Database\Exception
      * @since 2.1.44
      */
-    public function getCountArticlesByMonthYearAccess($date = null, $groupIds = '3')
+    public function getCountArticlesByMonthYearAccess(string $date = null, $groupIds = '3'): int
     {
         if (\is_string($groupIds)) {
             $groupIds = explode(',', $groupIds);
@@ -515,13 +515,13 @@ class Article extends \Ilch\Mapper
      * Get a list for the archive box and take the group IDs into account.
      *
      * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
-     * @param null $limit
+     * @param int|null $limit
      * @return array
      * @throws \Ilch\Database\Exception
      * @todo: Remove the group (aggregate) function MAX() workaround, which avoids duplicated entries in the archive-box if possible.
      * @since 2.1.44
      */
-    public function getArticleDateListAccess($groupIds = '3', $limit = null)
+    public function getArticleDateListAccess($groupIds = '3', int $limit = null): array
     {
         $sql = 'SELECT MAX(`date_created`) AS `date_created`
                 FROM `[prefix]_articles`
@@ -603,11 +603,11 @@ class Article extends \Ilch\Mapper
      *
      * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
      * @param string $locale
-     * @param null $limit
+     * @param int|null $limit
      * @return array|null
      * @since 2.1.44
      */
-    public function getArticleListAccess($groupIds = '3', $locale = '', $limit = null)
+    public function getArticleListAccess($groupIds = '3', string $locale = '', int $limit = null)
     {
         if (\is_string($groupIds)) {
             $groupIds = explode(',', $groupIds);
@@ -645,7 +645,7 @@ class Article extends \Ilch\Mapper
     /**
      * Returns article model found by the key.
      *
-     * @param string $id
+     * @param int $id
      * @param string $locale
      * @return ArticleModel|null
      */
@@ -693,6 +693,9 @@ class Article extends \Ilch\Mapper
 
         $keywordsList = [];
         foreach ($keywordsArray as $keywords) {
+            if ($keywords['keywords'] === '') {
+                continue;
+            }
             $articleModel = new ArticleModel();
             $articleModel->setKeywords($keywords['keywords']);
             $keywordsList[] = $articleModel;
@@ -705,11 +708,11 @@ class Article extends \Ilch\Mapper
      * Get a list of the keywords and take the group IDs into account.
      *
      * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
-     * @param null $limit
+     * @param int|null $limit
      * @return array
      * @since 2.1.44
      */
-    public function getKeywordsListAccess($groupIds = '3', $limit = null)
+    public function getKeywordsListAccess($groupIds = '3', int $limit = null): array
     {
         if (\is_string($groupIds)) {
             $groupIds = explode(',', $groupIds);
@@ -734,6 +737,9 @@ class Article extends \Ilch\Mapper
 
         $keywordsList = [];
         foreach ($keywordsArray as $keywords) {
+            if ($keywords['keywords'] === '') {
+                continue;
+            }
             $articleModel = new ArticleModel();
             $articleModel->setKeywords($keywords['keywords']);
             $keywordsList[] = $articleModel;
@@ -959,7 +965,7 @@ class Article extends \Ilch\Mapper
      * @throws \Ilch\Database\Exception
      * @since 2.1.44
      */
-    private function saveReadAccess($articleId, $readAccess)
+    private function saveReadAccess(int $articleId, string $readAccess)
     {
         // Delete possible old entries to later insert the new ones.
         $this->db()->delete('articles_access')
@@ -1045,7 +1051,7 @@ class Article extends \Ilch\Mapper
     /**
      * Delete an article with all associated comments
      *
-     * @param $id
+     * @param int $id
      * @param CommentMapper|null $commentsMapper
      */
     public function deleteWithComments($id, CommentMapper $commentsMapper = null)
@@ -1063,11 +1069,11 @@ class Article extends \Ilch\Mapper
     /**
      * Returns an article model created from an article row.
      *
-     * @param Array $articleRow
+     * @param array $articleRow
      * @return ArticleModel
      * @since 2.1.44
      */
-    private function loadFromArray($articleRow)
+    private function loadFromArray(array $articleRow)
     {
         $articleModel = new ArticleModel();
 

--- a/application/modules/article/mappers/Article.php
+++ b/application/modules/article/mappers/Article.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -22,13 +22,14 @@ class Article extends \Ilch\Mapper
     public function getArticles($locale = '', $pagination = null)
     {
         $select = $this->db()->select()
-                ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled', 'p.read_access'])
-                ->from(['p' => 'articles'])
-                ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
-                ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
-                ->where(['pc.locale' => $this->db()->escape($locale)])
-                ->group(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.read_access', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
-                ->order(['top' => 'DESC', 'date_created' => 'DESC']);
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
+            ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
+            ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
+            ->where(['pc.locale' => $this->db()->escape($locale)])
+            ->group(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->order(['top' => 'DESC', 'date_created' => 'DESC']);
 
         if ($pagination !== null) {
             $select->limit($pagination->getLimit())
@@ -47,26 +48,55 @@ class Article extends \Ilch\Mapper
 
         $articles = [];
         foreach ($articleArray as $articleRow) {
-            $articleModel = new ArticleModel();
-            $articleModel->setId($articleRow['id']);
-            $articleModel->setCatId($articleRow['cat_id']);
-            $articleModel->setVisits($articleRow['visits']);
-            $articleModel->setAuthorId($articleRow['author_id']);
-            $articleModel->setAuthorName($articleRow['name']);
-            $articleModel->setDescription($articleRow['description']);
-            $articleModel->setKeywords($articleRow['keywords']);
-            $articleModel->setTitle($articleRow['title']);
-            $articleModel->setTeaser($articleRow['teaser']);
-            $articleModel->setPerma($articleRow['perma']);
-            $articleModel->setContent($articleRow['content']);
-            $articleModel->setDateCreated($articleRow['date_created']);
-            $articleModel->setTopArticle($articleRow['top']);
-            $articleModel->setCommentsDisabled($articleRow['commentsDisabled']);
-            $articleModel->setReadAccess($articleRow['read_access']);
-            $articleModel->setImage($articleRow['img']);
-            $articleModel->setImageSource($articleRow['img_source']);
-            $articleModel->setVotes($articleRow['votes']);
-            $articles[] = $articleModel;
+            $articles[] = $this->loadFromArray($articleRow);
+        }
+
+        return $articles;
+    }
+
+    /**
+     * Get articles and taking the group IDs into account.
+     *
+     * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
+     * @param string $locale
+     * @param null $pagination
+     * @return array|null
+     * @since 2.1.44
+     */
+    public function getArticlesByAccess($groupIds = '3', $locale = '', $pagination = null)
+    {
+        if (\is_string($groupIds)) {
+            $groupIds = explode(',', $groupIds);
+        }
+
+        $select = $this->db()->select()
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
+            ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
+            ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
+            ->where(['ra.group_id' => $groupIds, 'pc.locale' => $this->db()->escape($locale)])
+            ->group(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->order(['top' => 'DESC', 'date_created' => 'DESC']);
+
+        if ($pagination !== null) {
+            $select->limit($pagination->getLimit())
+                ->useFoundRows();
+            $result = $select->execute();
+            $pagination->setRows($result->getFoundRows());
+        } else {
+            $result = $select->execute();
+        }
+
+        $articleArray = $result->fetchRows();
+
+        if (empty($articleArray)) {
+            return null;
+        }
+
+        $articles = [];
+        foreach ($articleArray as $articleRow) {
+            $articles[] = $this->loadFromArray($articleRow);
         }
 
         return $articles;
@@ -83,11 +113,13 @@ class Article extends \Ilch\Mapper
     public function getArticlesByCats($catId, $locale = '', $pagination = null)
     {
         $select = $this->db()->select()
-            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled', 'read_access'])
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
             ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
             ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
             ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
-            ->where(['p.cat_id LIKE' => '%'.$catId.'%', 'pc.locale' => $this->db()->escape($locale)])
+            ->where(['p.cat_id LIKE' => '%' . $catId . '%', 'pc.locale' => $this->db()->escape($locale)])
+            ->group(['p.id'])
             ->order(['id' => 'DESC']);
 
         if ($pagination !== null) {
@@ -106,26 +138,55 @@ class Article extends \Ilch\Mapper
 
         $articles = [];
         foreach ($articleArray as $articleRow) {
-            $articleModel = new ArticleModel();
-            $articleModel->setId($articleRow['id']);
-            $articleModel->setCatId($articleRow['cat_id']);
-            $articleModel->setVisits($articleRow['visits']);
-            $articleModel->setAuthorId($articleRow['author_id']);
-            $articleModel->setAuthorName($articleRow['name']);
-            $articleModel->setDescription($articleRow['description']);
-            $articleModel->setKeywords($articleRow['keywords']);
-            $articleModel->setTitle($articleRow['title']);
-            $articleModel->setTeaser($articleRow['teaser']);
-            $articleModel->setPerma($articleRow['perma']);
-            $articleModel->setContent($articleRow['content']);
-            $articleModel->setDateCreated($articleRow['date_created']);
-            $articleModel->setTopArticle($articleRow['top']);
-            $articleModel->setCommentsDisabled($articleRow['commentsDisabled']);
-            $articleModel->setReadAccess($articleRow['read_access']);
-            $articleModel->setImage($articleRow['img']);
-            $articleModel->setImageSource($articleRow['img_source']);
-            $articleModel->setVotes($articleRow['votes']);
-            $articles[] = $articleModel;
+            $articles[] = $this->loadFromArray($articleRow);
+        }
+
+        return $articles;
+    }
+
+    /**
+     * Get articles by category id and taking the group IDs into account.
+     *
+     * @param integer $catId
+     * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
+     * @param string $locale
+     * @param null $pagination
+     * @return array|null
+     * @since 2.1.44
+     */
+    public function getArticlesByCatsAccess($catId, $groupIds = '3', $locale = '', $pagination = null)
+    {
+        if (\is_string($groupIds)) {
+            $groupIds = explode(',', $groupIds);
+        }
+
+        $select = $this->db()->select()
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
+            ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
+            ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
+            ->where(['ra.group_id' => $groupIds, 'p.cat_id LIKE' => '%' . $catId . '%', 'pc.locale' => $this->db()->escape($locale)])
+            ->group(['p.id'])
+            ->order(['id' => 'DESC']);
+
+        if ($pagination !== null) {
+            $select->limit($pagination->getLimit())
+                ->useFoundRows();
+            $result = $select->execute();
+            $pagination->setRows($result->getFoundRows());
+        } else {
+            $result = $select->execute();
+        }
+        $articleArray = $result->fetchRows();
+
+        if (empty($articleArray)) {
+            return null;
+        }
+
+        $articles = [];
+        foreach ($articleArray as $articleRow) {
+            $articles[] = $this->loadFromArray($articleRow);
         }
 
         return $articles;
@@ -134,7 +195,7 @@ class Article extends \Ilch\Mapper
     /**
      * Get articles by keyword.
      *
-     * @param integer $keyword
+     * @param string $keyword
      * @param string $locale
      * @param \Ilch\Pagination|null $pagination
      * @return ArticleModel[]|array
@@ -142,11 +203,13 @@ class Article extends \Ilch\Mapper
     public function getArticlesByKeyword($keyword, $locale = '', $pagination = null)
     {
         $select = $this->db()->select()
-            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled', 'read_access'])
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
             ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
             ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
             ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
-            ->where(['pc.keywords LIKE' => '%'.$keyword.'%', 'pc.locale' => $this->db()->escape($locale)])
+            ->where(['pc.keywords LIKE' => '%' . $keyword . '%', 'pc.locale' => $this->db()->escape($locale)])
+            ->group(['p.id'])
             ->order(['id' => 'DESC']);
 
         if ($pagination !== null) {
@@ -165,26 +228,55 @@ class Article extends \Ilch\Mapper
 
         $articles = [];
         foreach ($articleArray as $articleRow) {
-            $articleModel = new ArticleModel();
-            $articleModel->setId($articleRow['id']);
-            $articleModel->setCatId($articleRow['cat_id']);
-            $articleModel->setVisits($articleRow['visits']);
-            $articleModel->setAuthorId($articleRow['author_id']);
-            $articleModel->setAuthorName($articleRow['name']);
-            $articleModel->setDescription($articleRow['description']);
-            $articleModel->setKeywords($articleRow['keywords']);
-            $articleModel->setTitle($articleRow['title']);
-            $articleModel->setTeaser($articleRow['teaser']);
-            $articleModel->setPerma($articleRow['perma']);
-            $articleModel->setContent($articleRow['content']);
-            $articleModel->setDateCreated($articleRow['date_created']);
-            $articleModel->setTopArticle($articleRow['top']);
-            $articleModel->setCommentsDisabled($articleRow['commentsDisabled']);
-            $articleModel->setReadAccess($articleRow['read_access']);
-            $articleModel->setImage($articleRow['img']);
-            $articleModel->setImageSource($articleRow['img_source']);
-            $articleModel->setVotes($articleRow['votes']);
-            $articles[] = $articleModel;
+            $articles[] = $this->loadFromArray($articleRow);
+        }
+
+        return $articles;
+    }
+
+    /**
+     * Get articles by keyword and taking the group IDs into account.
+     *
+     * @param string $keyword
+     * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
+     * @param string $locale
+     * @param null $pagination
+     * @return array|null
+     * @since 2.1.44
+     */
+    public function getArticlesByKeywordAccess($keyword, $groupIds = '3', $locale = '', $pagination = null)
+    {
+        if (\is_string($groupIds)) {
+            $groupIds = explode(',', $groupIds);
+        }
+
+        $select = $this->db()->select()
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
+            ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
+            ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
+            ->where(['ra.group_id' => $groupIds, 'pc.keywords LIKE' => '%' . $keyword . '%', 'pc.locale' => $this->db()->escape($locale)])
+            ->group(['p.id'])
+            ->order(['id' => 'DESC']);
+
+        if ($pagination !== null) {
+            $select->limit($pagination->getLimit())
+                ->useFoundRows();
+            $result = $select->execute();
+            $pagination->setRows($result->getFoundRows());
+        } else {
+            $result = $select->execute();
+        }
+        $articleArray = $result->fetchRows();
+
+        if (empty($articleArray)) {
+            return null;
+        }
+
+        $articles = [];
+        foreach ($articleArray as $articleRow) {
+            $articles[] = $this->loadFromArray($articleRow);
         }
 
         return $articles;
@@ -209,12 +301,13 @@ class Article extends \Ilch\Mapper
         $dateTo = $dateTo->format($db::FORMAT_DATETIME);
 
         $select = $this->db()->select()
-            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled', 'read_access'])
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
             ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
             ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
             ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
             ->where(['p.date_created >=' => $dateFrom, 'p.date_created <' => $dateTo, 'pc.locale' => $this->db()->escape($locale)])
-            ->group(['p.id' => 'DESC', 'p.cat_id', 'p.date_created', 'p.top', 'p.read_access', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes']);
+            ->group(['p.id' => 'DESC', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes']);
 
         if ($pagination !== null) {
             $select->limit($pagination->getLimit())
@@ -232,26 +325,62 @@ class Article extends \Ilch\Mapper
 
         $articles = [];
         foreach ($articleArray as $articleRow) {
-            $articleModel = new ArticleModel();
-            $articleModel->setId($articleRow['id']);
-            $articleModel->setCatId($articleRow['cat_id']);
-            $articleModel->setVisits($articleRow['visits']);
-            $articleModel->setAuthorId($articleRow['author_id']);
-            $articleModel->setAuthorName($articleRow['name']);
-            $articleModel->setDescription($articleRow['description']);
-            $articleModel->setKeywords($articleRow['keywords']);
-            $articleModel->setTitle($articleRow['title']);
-            $articleModel->setTeaser($articleRow['teaser']);
-            $articleModel->setPerma($articleRow['perma']);
-            $articleModel->setContent($articleRow['content']);
-            $articleModel->setDateCreated($articleRow['date_created']);
-            $articleModel->setTopArticle($articleRow['top']);
-            $articleModel->setCommentsDisabled($articleRow['commentsDisabled']);
-            $articleModel->setReadAccess($articleRow['read_access']);
-            $articleModel->setImage($articleRow['img']);
-            $articleModel->setImageSource($articleRow['img_source']);
-            $articleModel->setVotes($articleRow['votes']);
-            $articles[] = $articleModel;
+            $articles[] = $this->loadFromArray($articleRow);
+        }
+
+        return $articles;
+    }
+
+    /**
+     * Get articles of the month of the given date and taking the group IDs into account.
+     *
+     * @param \DateTime $date
+     * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
+     * @param null $pagination
+     * @param string $locale
+     * @return array|null
+     * @since 2.1.44
+     */
+    public function getArticlesByDateAccess(\DateTime $date, $groupIds = '3', $pagination = null, $locale = '')
+    {
+        $db = $this->db();
+
+        $dateTo = clone $date;
+        $dateTo->modify('first day of next month');
+
+        $dateFrom = $date->format($db::FORMAT_DATETIME);
+        $dateTo = $dateTo->format($db::FORMAT_DATETIME);
+
+        if (\is_string($groupIds)) {
+            $groupIds = explode(',', $groupIds);
+        }
+
+        $select = $this->db()->select()
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
+            ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
+            ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
+            ->where(['ra.group_id' => $groupIds, 'p.date_created >=' => $dateFrom, 'p.date_created <' => $dateTo, 'pc.locale' => $this->db()->escape($locale)])
+            ->group(['p.id' => 'DESC', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes']);
+
+        if ($pagination !== null) {
+            $select->limit($pagination->getLimit())
+                ->useFoundRows();
+            $result = $select->execute();
+            $pagination->setRows($result->getFoundRows());
+        } else {
+            $result = $select->execute();
+        }
+        $articleArray = $result->fetchRows();
+
+        if (empty($articleArray)) {
+            return null;
+        }
+
+        $articles = [];
+        foreach ($articleArray as $articleRow) {
+            $articles[] = $this->loadFromArray($articleRow);
         }
 
         return $articles;
@@ -261,12 +390,12 @@ class Article extends \Ilch\Mapper
      * Get articles count by cat id
      *
      * @param int $catId
-     * @return int|string $count
+     * @return int
      * @throws \Ilch\Database\Exception
      */
     public function getCountArticlesByCatId($catId)
     {
-        return $this->db()->select('COUNT(*)')
+        return (int)$this->db()->select('COUNT(*)')
             ->from('articles')
             ->where(['cat_id LIKE' => '%' . $catId . '%'])
             ->execute()
@@ -274,9 +403,31 @@ class Article extends \Ilch\Mapper
     }
 
     /**
+     * Get articles count by category id and taking the group IDs into account.
+     *
+     * @param int $catId
+     * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
+     * @return int
+     * @since 2.1.44
+     */
+    public function getCountArticlesByCatIdAccess($catId, $groupIds = '3')
+    {
+        if (\is_string($groupIds)) {
+            $groupIds = explode(',', $groupIds);
+        }
+
+        return (int)$this->db()->select('COUNT(DISTINCT(id))')
+            ->from('articles')
+            ->join(['articles_access'], 'id = article_id', 'LEFT')
+            ->where(['group_id' => $groupIds, 'cat_id LIKE' => '%' . $catId . '%'])
+            ->execute()
+            ->fetchCell();
+    }
+
+    /**
      * Get articles count by month and year
      *
-     * @param integer $date
+     * @param string $date
      * @return int
      * @throws \Ilch\Database\Exception
      */
@@ -286,11 +437,43 @@ class Article extends \Ilch\Mapper
                 FROM `[prefix]_articles`';
 
         if ($date != null) {
-            $sql .= ' WHERE YEAR(date_created) = YEAR("'.$this->db()->escape($date)
-                .'") AND MONTH(date_created) = MONTH("'.$this->db()->escape($date).'")';
+            $sql .= ' WHERE YEAR(date_created) = YEAR("' . $this->db()->escape($date)
+                . '") AND MONTH(date_created) = MONTH("' . $this->db()->escape($date) . '")';
         }
 
-        return $this->db()->queryCell($sql);
+        return (int)$this->db()->queryCell($sql);
+    }
+
+    /**
+     * Get articles count by month and year and taking the group IDs into account.
+     *
+     * @param null $date
+     * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
+     * @return int
+     * @throws \Ilch\Database\Exception
+     * @since 2.1.44
+     */
+    public function getCountArticlesByMonthYearAccess($date = null, $groupIds = '3')
+    {
+        if (\is_string($groupIds)) {
+            $groupIds = explode(',', $groupIds);
+        }
+
+        $sql = 'SELECT COUNT(DISTINCT(id))
+                FROM `[prefix]_articles`
+                LEFT JOIN `[prefix]_articles_access` ON `id` = `article_id`';
+
+        if ($date != null) {
+            $sql .= ' WHERE YEAR(date_created) = YEAR("' . $this->db()->escape($date)
+                . '") AND MONTH(date_created) = MONTH("' . $this->db()->escape($date) . '")';
+        }
+
+        $sql .= ' AND `group_id` IN (';
+        foreach ($groupIds as $groupId) {
+            $sql .= (int)$groupId . ',';
+        }
+        $sql = rtrim($sql, ',') . ') ';
+        return (int)$this->db()->queryCell($sql);
     }
 
     /**
@@ -309,7 +492,56 @@ class Article extends \Ilch\Mapper
                 ORDER BY `date_created` DESC';
 
         if ($limit !== null) {
-            $sql .= ' LIMIT '.(int)$limit;
+            $sql .= ' LIMIT ' . (int)$limit;
+        }
+
+        $articleArray = $this->db()->queryArray($sql);
+
+        if (empty($articleArray)) {
+            return [];
+        }
+
+        $articles = [];
+        foreach ($articleArray as $articleRow) {
+            $articleModel = new ArticleModel();
+            $articleModel->setDateCreated($articleRow['date_created']);
+            $articles[] = $articleModel;
+        }
+
+        return $articles;
+    }
+
+    /**
+     * Get a list for the archive box and take the group IDs into account.
+     *
+     * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
+     * @param null $limit
+     * @return array
+     * @throws \Ilch\Database\Exception
+     * @todo: Remove the group (aggregate) function MAX() workaround, which avoids duplicated entries in the archive-box if possible.
+     * @since 2.1.44
+     */
+    public function getArticleDateListAccess($groupIds = '3', $limit = null)
+    {
+        $sql = 'SELECT MAX(`date_created`) AS `date_created`
+                FROM `[prefix]_articles`
+                LEFT JOIN `[prefix]_articles_access` ON `article_id` = `id`';
+
+        if (\is_string($groupIds)) {
+            $groupIds = explode(',', $groupIds);
+        }
+
+        $sql .= ' WHERE `group_id` IN (';
+        foreach ($groupIds as $groupId) {
+            $sql .= (int)$groupId . ',';
+        }
+        $sql = rtrim($sql, ',') . ') ';
+
+        $sql .= 'GROUP BY YEAR(date_created), MONTH(date_created)
+                ORDER BY `date_created` DESC';
+
+        if ($limit !== null) {
+            $sql .= ' LIMIT ' . (int)$limit;
         }
 
         $articleArray = $this->db()->queryArray($sql);
@@ -338,14 +570,15 @@ class Article extends \Ilch\Mapper
     public function getArticleList($locale = '', $limit = null)
     {
         $select = $this->db()->select()
-                ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.read_access'])
-                ->from(['p' => 'articles'])
-                ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
-                ->join(['m' => 'media'], 'pc.img = m.url', 'LEFT', ['m.url_thumb', 'm.url'])
-                ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
-                ->where(['pc.locale' => $this->db()->escape($locale)])
-                ->group(['p.id', 'p.cat_id', 'p.date_created', 'p.read_access', 'pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes', 'm.url_thumb', 'm.url'])
-                ->order(['date_created' => 'DESC']);
+            ->fields(['p.id', 'p.cat_id', 'p.date_created'])
+            ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
+            ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->join(['m' => 'media'], 'pc.img = m.url', 'LEFT', ['m.url_thumb', 'm.url'])
+            ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
+            ->where(['pc.locale' => $this->db()->escape($locale)])
+            ->group(['p.id', 'p.cat_id', 'p.date_created', 'pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes', 'm.url_thumb', 'm.url'])
+            ->order(['date_created' => 'DESC']);
 
         if ($limit !== null) {
             $select->limit($limit);
@@ -359,23 +592,51 @@ class Article extends \Ilch\Mapper
 
         $articles = [];
         foreach ($articleArray as $articleRow) {
-            $articleModel = new ArticleModel();
-            $articleModel->setId($articleRow['id']);
-            $articleModel->setCatId($articleRow['cat_id']);
-            $articleModel->setDateCreated($articleRow['date_created']);
-            $articleModel->setAuthorId($articleRow['author_id']);
-            $articleModel->setAuthorName($articleRow['name']);
-            $articleModel->setVisits($articleRow['visits']);
-            $articleModel->setKeywords($articleRow['keywords']);
-            $articleModel->setTitle($articleRow['title']);
-            $articleModel->setTeaser($articleRow['teaser']);
-            $articleModel->setPerma($articleRow['perma']);
-            $articleModel->setReadAccess($articleRow['read_access']);
-            $articleModel->setImage($articleRow['img']);
-            $articleModel->setImageThumb($articleRow['url_thumb']);
-            $articleModel->setImageSource($articleRow['img_source']);
-            $articleModel->setVotes($articleRow['votes']);
-            $articles[] = $articleModel;
+            $articles[] = $this->loadFromArray($articleRow);
+        }
+
+        return $articles;
+    }
+
+    /**
+     * Get article list for overview and take the group IDs into account.
+     *
+     * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
+     * @param string $locale
+     * @param null $limit
+     * @return array|null
+     * @since 2.1.44
+     */
+    public function getArticleListAccess($groupIds = '3', $locale = '', $limit = null)
+    {
+        if (\is_string($groupIds)) {
+            $groupIds = explode(',', $groupIds);
+        }
+
+        $select = $this->db()->select()
+            ->fields(['p.id', 'p.cat_id', 'p.date_created'])
+            ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
+            ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->join(['m' => 'media'], 'pc.img = m.url', 'LEFT', ['m.url_thumb', 'm.url'])
+            ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
+            ->where(['ra.group_id' => $groupIds, 'pc.locale' => $this->db()->escape($locale)])
+            ->group(['p.id', 'p.cat_id', 'p.date_created', 'pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes', 'm.url_thumb', 'm.url'])
+            ->order(['date_created' => 'DESC']);
+
+        if ($limit !== null) {
+            $select->limit($limit);
+        }
+        $result = $select->execute();
+        $articleArray = $result->fetchRows();
+
+        if (empty($articleArray)) {
+            return null;
+        }
+
+        $articles = [];
+        foreach ($articleArray as $articleRow) {
+            $articles[] = $this->loadFromArray($articleRow);
         }
 
         return $articles;
@@ -390,44 +651,25 @@ class Article extends \Ilch\Mapper
      */
     public function getArticleByIdLocale($id, $locale = '')
     {
-        $select = $this->db()->select()
-                ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled', 'p.read_access'])
-                ->from(['p' => 'articles'])
-                ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.locale', 'pc.img', 'pc.img_source', 'pc.votes'])
-                ->where(['p.id' => $id, 'pc.locale' => $this->db()->escape($locale)]);
-
-        $result = $select->execute();
-        $articleRow = $result->fetchAssoc();
+        $articleRow = $this->db()->select()
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
+            ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
+            ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.locale', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->group(['p.id'])
+            ->where(['p.id' => $id, 'pc.locale' => $this->db()->escape($locale)])
+            ->execute()
+            ->fetchAssoc();
 
         if (empty($articleRow)) {
             return null;
         }
 
-        $articleModel = new ArticleModel();
-        $articleModel->setId($articleRow['id']);
-        $articleModel->setCatId($articleRow['cat_id']);
-        $articleModel->setAuthorId($articleRow['author_id']);
-        $articleModel->setVisits($articleRow['visits']);
-        $articleModel->setDescription($articleRow['description']);
-        $articleModel->setKeywords($articleRow['keywords']);
-        $articleModel->setTitle($articleRow['title']);
-        $articleModel->setTeaser($articleRow['teaser']);
-        $articleModel->setContent($articleRow['content']);
-        $articleModel->setLocale($articleRow['locale']);
-        $articleModel->setPerma($articleRow['perma']);
-        $articleModel->setDateCreated($articleRow['date_created']);
-        $articleModel->setTopArticle($articleRow['top']);
-        $articleModel->setCommentsDisabled($articleRow['commentsDisabled']);
-        $articleModel->setReadAccess($articleRow['read_access']);
-        $articleModel->setImage($articleRow['img']);
-        $articleModel->setImageSource($articleRow['img_source']);
-        $articleModel->setVotes($articleRow['votes']);
-
-        return $articleModel;
+        return $this->loadFromArray($articleRow);
     }
 
     /**
-     * Get articles.
+     * Get a list of the keywords.
      *
      * @param int $limit
      * @return ArticleModel[]|array
@@ -435,14 +677,56 @@ class Article extends \Ilch\Mapper
      */
     public function getKeywordsList($limit = null)
     {
-        $sql = 'SELECT `keywords`
-                FROM `[prefix]_articles_content`';
+        $sql = $this->db()->select('keywords')
+            ->from('articles_content');
 
         if ($limit !== null) {
-            $sql .= ' LIMIT '.(int)$limit;
+            $sql = $sql->limit((int)$limit);
         }
 
-        $keywordsArray = $this->db()->queryArray($sql);
+        $keywordsArray = $sql->execute()
+            ->fetchRows();
+
+        if (empty($keywordsArray)) {
+            return [];
+        }
+
+        $keywordsList = [];
+        foreach ($keywordsArray as $keywords) {
+            $articleModel = new ArticleModel();
+            $articleModel->setKeywords($keywords['keywords']);
+            $keywordsList[] = $articleModel;
+        }
+
+        return $keywordsList;
+    }
+
+    /**
+     * Get a list of the keywords and take the group IDs into account.
+     *
+     * @param string|array $groupIds A string like '1,2,3' or an array like [1,2,3]
+     * @param null $limit
+     * @return array
+     * @since 2.1.44
+     */
+    public function getKeywordsListAccess($groupIds = '3', $limit = null)
+    {
+        if (\is_string($groupIds)) {
+            $groupIds = explode(',', $groupIds);
+        }
+
+        $sql = $this->db()->select('keywords')
+            ->from('articles_content')
+            ->join(['p' => 'articles'], 'p.id = article_id', 'LEFT')
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT')
+            ->where(['ra.group_id' => $groupIds]);
+
+        if ($limit !== null) {
+            $sql = $sql->limit((int)$limit);
+        }
+
+        $keywordsArray = $sql->execute()
+            ->fetchRows();
 
         if (empty($keywordsArray)) {
             return [];
@@ -461,7 +745,7 @@ class Article extends \Ilch\Mapper
     /**
      * Check if keyword exists.
      *
-     * @param $keyword
+     * @param string $keyword
      * @return bool
      * @since 2.1.25
      */
@@ -475,7 +759,7 @@ class Article extends \Ilch\Mapper
         $keywordsListString = implode(', ', $keywordsList);
         $keywordsListArray = explode(', ', $keywordsListString);
 
-        return in_array($keyword, $keywordsListArray);
+        return \in_array($keyword, $keywordsListArray);
     }
 
     /**
@@ -486,7 +770,7 @@ class Article extends \Ilch\Mapper
      */
     public function getArticlePermas()
     {
-        $permas = $this->db()->select(['article_id', 'locale', 'perma'])
+        $permas = $this->db()->select(['perma'])
             ->from('articles_content')
             ->execute()
             ->fetchRows();
@@ -507,13 +791,16 @@ class Article extends \Ilch\Mapper
      * Get the top article.
      *
      * @return ArticleModel|null
+     * @deprecated Use getTopArticles() instead. There can be more than one top article.
      */
     public function getTopArticle()
     {
         $articleRow = $this->db()->select('*')
-            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled', 'p.read_access'])
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
             ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
             ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.locale', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->group(['p.id'])
             ->where(['top' => 1])
             ->execute()
             ->fetchAssoc();
@@ -522,27 +809,37 @@ class Article extends \Ilch\Mapper
             return null;
         }
 
-        $articleModel = new ArticleModel();
-        $articleModel->setId($articleRow['id']);
-        $articleModel->setCatId($articleRow['cat_id']);
-        $articleModel->setAuthorId($articleRow['author_id']);
-        $articleModel->setVisits($articleRow['visits']);
-        $articleModel->setDescription($articleRow['description']);
-        $articleModel->setKeywords($articleRow['keywords']);
-        $articleModel->setTitle($articleRow['title']);
-        $articleModel->setTeaser($articleRow['teaser']);
-        $articleModel->setContent($articleRow['content']);
-        $articleModel->setLocale($articleRow['locale']);
-        $articleModel->setPerma($articleRow['perma']);
-        $articleModel->setDateCreated($articleRow['date_created']);
-        $articleModel->setTopArticle($articleRow['top']);
-        $articleModel->setCommentsDisabled($articleRow['commentsDisabled']);
-        $articleModel->setReadAccess($articleRow['read_access']);
-        $articleModel->setImage($articleRow['img']);
-        $articleModel->setImageSource($articleRow['img_source']);
-        $articleModel->setVotes($articleRow['votes']);
+        return $this->loadFromArray($articleRow);
+    }
 
-        return $articleModel;
+    /**
+     * Get the top articles.
+     *
+     * @return array|ArticleModel[]
+     * @since 2.1.44
+     */
+    public function getTopArticles()
+    {
+        $articleRows = $this->db()->select('*')
+            ->fields(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'p.commentsDisabled'])
+            ->from(['p' => 'articles'])
+            ->join(['ra' => 'articles_access'], 'p.id = ra.article_id', 'LEFT', ['read_access' => 'GROUP_CONCAT(ra.group_id)'])
+            ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.locale', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->group(['p.id'])
+            ->where(['top' => 1])
+            ->execute()
+            ->fetchRows();
+
+        if (empty($articleRows)) {
+            return [];
+        }
+
+        $articleModels = [];
+        foreach ($articleRows as $articleRow) {
+            $articleModels[] = $this->loadFromArray($articleRow);
+        }
+
+        return $articleModels;
     }
 
     /**
@@ -568,9 +865,9 @@ class Article extends \Ilch\Mapper
     {
         if ($article->getVisits()) {
             $this->db()->update('articles_content')
-                    ->values(['visits' => $article->getVisits()])
-                    ->where(['article_id' => $article->getId()])
-                    ->execute();
+                ->values(['visits' => $article->getVisits()])
+                ->where(['article_id' => $article->getId()])
+                ->execute();
         }
     }
 
@@ -589,79 +886,26 @@ class Article extends \Ilch\Mapper
             if ($this->getArticleByIdLocale($article->getId(), $article->getLocale())) {
                 // Update existing article with specific id and locale
                 $this->db()->update('articles')
-                    ->values(['cat_id' => $article->getCatId(),
-                              'date_created' => $article->getDateCreated(),
-                              'commentsDisabled' => (bool)$article->getCommentsDisabled(),
-                              'read_access' => $article->getReadAccess()])
+                    ->values(['cat_id' => $article->getCatId(), 'date_created' => $article->getDateCreated(), 'commentsDisabled' => $article->getCommentsDisabled()])
                     ->where(['id' => $article->getId()])
                     ->execute();
 
                 $this->db()->update('articles_content')
-                    ->values
-                    (
-                        [
-                            'title' => $article->getTitle(),
-                            'teaser' => $article->getTeaser(),
-                            'description' => $article->getDescription(),
-                            'keywords' => $article->getKeywords(),
-                            'content' => $article->getContent(),
-                            'perma' => $article->getPerma(),
-                            'img' => $article->getImage(),
-                            'img_source' => $article->getImageSource(),
-                            'votes' => $article->getVotes()
-                        ]
-                    )
-                    ->where
-                    (
-                        [
-                            'article_id' => $article->getId(), 
-                            'locale' => $article->getLocale()
-                        ]
-                    )
+                    ->values(['title' => $article->getTitle(),
+                        'teaser' => $article->getTeaser(),
+                        'description' => $article->getDescription(),
+                        'keywords' => $article->getKeywords(),
+                        'content' => $article->getContent(),
+                        'perma' => $article->getPerma(),
+                        'img' => $article->getImage(),
+                        'img_source' => $article->getImageSource(),
+                        'votes' => $article->getVotes()])
+                    ->where(['article_id' => $article->getId(), 'locale' => $article->getLocale()])
                     ->execute();
             } else {
                 // Insert content with a new locale for an existing article
                 $this->db()->insert('articles_content')
-                    ->values
-                    (
-                        [
-                            'article_id' => $article->getId(),
-                            'author_id' => $article->getAuthorId(),
-                            'description' => $article->getDescription(),
-                            'keywords' => $article->getKeywords(),
-                            'title' => $article->getTitle(),
-                            'teaser' => $article->getTeaser(),
-                            'content' => $article->getContent(),
-                            'perma' => $article->getPerma(),
-                            'locale' => $article->getLocale(),
-                            'img' => $article->getImage(),
-                            'img_source' => $article->getImageSource(),
-                            'votes' => $article->getVotes()
-                        ]
-                    )
-                    ->execute();
-            }
-
-            $id = $article->getId();
-        } else {
-            // Insert new article
-            $articleId = $this->db()->insert('articles')
-                ->values
-                (
-                    [
-                        'cat_id' => $article->getCatId(),
-                        'date_created' => $article->getDateCreated(),
-                        'commentsDisabled' => (bool)$article->getCommentsDisabled(),
-                        'read_access' => $article->getReadAccess()
-                    ]
-                )
-                ->execute();
-
-            $this->db()->insert('articles_content')
-                ->values
-                (
-                    [
-                        'article_id' => $articleId,
+                    ->values(['article_id' => $article->getId(),
                         'author_id' => $article->getAuthorId(),
                         'description' => $article->getDescription(),
                         'keywords' => $article->getKeywords(),
@@ -672,17 +916,78 @@ class Article extends \Ilch\Mapper
                         'locale' => $article->getLocale(),
                         'img' => $article->getImage(),
                         'img_source' => $article->getImageSource(),
-                        'votes' => $article->getVotes()
-                    ]
-                )
+                        'votes' => $article->getVotes()])
+                    ->execute();
+            }
+
+            $id = $article->getId();
+        } else {
+            // Insert new article
+            $articleId = $this->db()->insert('articles')
+                ->values(['cat_id' => $article->getCatId(), 'date_created' => $article->getDateCreated(), 'commentsDisabled' => $article->getCommentsDisabled()])
+                ->execute();
+
+            $this->db()->insert('articles_content')
+                ->values(['article_id' => $articleId,
+                    'author_id' => $article->getAuthorId(),
+                    'description' => $article->getDescription(),
+                    'keywords' => $article->getKeywords(),
+                    'title' => $article->getTitle(),
+                    'teaser' => $article->getTeaser(),
+                    'content' => $article->getContent(),
+                    'perma' => $article->getPerma(),
+                    'locale' => $article->getLocale(),
+                    'img' => $article->getImage(),
+                    'img_source' => $article->getImageSource(),
+                    'votes' => $article->getVotes()])
                 ->execute();
 
             $id = $articleId;
         }
 
-        $this->setTopArticle($id, (bool)$article->getTopArticle());
+        $this->setTopArticle($id, $article->getTopArticle());
+        $this->saveReadAccess($id, $article->getReadAccess());
 
         return $id;
+    }
+
+    /**
+     * Update the entries for which user groups are allowed to read an article.
+     *
+     * @param int $articleId
+     * @param string $readAccess example: "1,2,3"
+     * @throws \Ilch\Database\Exception
+     * @since 2.1.44
+     */
+    private function saveReadAccess($articleId, $readAccess)
+    {
+        // Delete possible old entries to later insert the new ones.
+        $this->db()->delete('articles_access')
+            ->where(['article_id' => $articleId])
+            ->execute();
+
+        $sql = 'INSERT INTO [prefix]_articles_access (article_id, group_id) VALUES';
+        $sqlWithValues = $sql;
+        $rowCount = 0;
+        $groupIds = explode(',', $readAccess);
+
+        foreach ($groupIds as $groupId) {
+            // There is a limit of 1000 rows per insert, but according to some benchmarks found online
+            // the sweet spot seams to be around 25 rows per insert. So aim for that.
+            if ($rowCount >= 25) {
+                $sqlWithValues = rtrim($sqlWithValues, ',') . ';';
+                $this->db()->queryMulti($sqlWithValues);
+                $rowCount = 0;
+                $sqlWithValues = $sql;
+            }
+
+            $rowCount++;
+            $sqlWithValues .= '(' . (int)$articleId . ',' . (int)$groupId . '),';
+        }
+
+        // Insert remaining rows.
+        $sqlWithValues = rtrim($sqlWithValues, ',') . ';';
+        $this->db()->queryMulti($sqlWithValues);
     }
 
     /**
@@ -696,7 +1001,7 @@ class Article extends \Ilch\Mapper
         $votes = $this->getVotes($id);
 
         $this->db()->update('articles_content')
-            ->values(['votes' => $votes.$userId.','])
+            ->values(['votes' => $votes . $userId . ','])
             ->where(['article_id' => $id])
             ->execute();
     }
@@ -718,7 +1023,7 @@ class Article extends \Ilch\Mapper
 
     /**
      * Delete an article (with all language contents)
-     * 
+     *
      * @param int $id
      * @return int
      */
@@ -731,6 +1036,8 @@ class Article extends \Ilch\Mapper
         $this->db()->delete('articles_content')
             ->where(['article_id' => $id])
             ->execute();
+
+        // Rows in articles_access get automatically deleted due to foreign key constraints.
 
         return $deleted;
     }
@@ -751,5 +1058,95 @@ class Article extends \Ilch\Mapper
             $commentsMapper = new CommentMapper();
         }
         $commentsMapper->deleteByKey(sprintf(ArticleConfig::COMMENT_KEY_TPL, $id));
+    }
+
+    /**
+     * Returns an article model created from an article row.
+     *
+     * @param Array $articleRow
+     * @return ArticleModel
+     * @since 2.1.44
+     */
+    private function loadFromArray($articleRow)
+    {
+        $articleModel = new ArticleModel();
+
+        if (isset($articleRow['id'])) {
+            $articleModel->setId($articleRow['id']);
+        }
+
+        if (isset($articleRow['cat_id'])) {
+            $articleModel->setCatId($articleRow['cat_id']);
+        }
+
+        if (isset($articleRow['visits'])) {
+            $articleModel->setVisits($articleRow['visits']);
+        }
+
+        if (isset($articleRow['author_id'])) {
+            $articleModel->setAuthorId($articleRow['author_id']);
+        }
+
+        if (isset($articleRow['name'])) {
+            $articleModel->setAuthorName($articleRow['name']);
+        }
+
+        if (isset($articleRow['description'])) {
+            $articleModel->setDescription($articleRow['description']);
+        }
+
+        if (isset($articleRow['keywords'])) {
+            $articleModel->setKeywords($articleRow['keywords']);
+        }
+
+        if (isset($articleRow['title'])) {
+            $articleModel->setTitle($articleRow['title']);
+        }
+
+        if (isset($articleRow['teaser'])) {
+            $articleModel->setTeaser($articleRow['teaser']);
+        }
+
+        if (isset($articleRow['perma'])) {
+            $articleModel->setPerma($articleRow['perma']);
+        }
+
+        if (isset($articleRow['content'])) {
+            $articleModel->setContent($articleRow['content']);
+        }
+
+        if (isset($articleRow['locale'])) {
+            $articleModel->setLocale($articleRow['locale']);
+        }
+
+        if (isset($articleRow['date_created'])) {
+            $articleModel->setDateCreated($articleRow['date_created']);
+        }
+
+        if (isset($articleRow['top'])) {
+            $articleModel->setTopArticle($articleRow['top']);
+        }
+
+        if (isset($articleRow['commentsDisabled'])) {
+            $articleModel->setCommentsDisabled($articleRow['commentsDisabled']);
+        }
+
+        if (isset($articleRow['read_access'])) {
+            $articleModel->setReadAccess($articleRow['read_access']);
+        }
+
+        if (isset($articleRow['img'])) {
+            $articleModel->setImage($articleRow['img']);
+        }
+
+        if (isset($articleRow['img_source'])) {
+            $articleModel->setImageSource($articleRow['img_source']);
+        }
+
+        if (isset($articleRow['votes'])) {
+            $articleModel->setVotes($articleRow['votes']);
+        }
+
+        return $articleModel;
     }
 }

--- a/application/modules/article/mappers/Article.php
+++ b/application/modules/article/mappers/Article.php
@@ -310,7 +310,6 @@ class Article extends \Ilch\Mapper
             ->group(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
             ->order(['p.id' => 'DESC']);
 
-
         if ($pagination !== null) {
             $select->limit($pagination->getLimit())
                 ->useFoundRows();
@@ -364,7 +363,7 @@ class Article extends \Ilch\Mapper
             ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
             ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
             ->where(['ra.group_id' => $groupIds, 'p.date_created >=' => $dateFrom, 'p.date_created <' => $dateTo, 'pc.locale' => $this->db()->escape($locale)])
-            ->group(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->group(['p.id'])
             ->order(['p.id' => 'DESC']);
 
         if ($pagination !== null) {
@@ -1038,17 +1037,10 @@ class Article extends \Ilch\Mapper
      */
     public function delete($id)
     {
-        $deleted = $this->db()->delete('articles')
+        // Rows in articles_access and articles_content get automatically deleted due to foreign key constraints.
+        return $this->db()->delete('articles')
             ->where(['id' => $id])
             ->execute();
-
-        $this->db()->delete('articles_content')
-            ->where(['article_id' => $id])
-            ->execute();
-
-        // Rows in articles_access get automatically deleted due to foreign key constraints.
-
-        return $deleted;
     }
 
     /**

--- a/application/modules/article/mappers/Article.php
+++ b/application/modules/article/mappers/Article.php
@@ -307,7 +307,7 @@ class Article extends \Ilch\Mapper
             ->join(['pc' => 'articles_content'], 'p.id = pc.article_id', 'LEFT', ['pc.visits', 'pc.author_id', 'pc.description', 'pc.keywords', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.content', 'pc.img', 'pc.img_source', 'pc.votes'])
             ->join(['u' => 'users'], 'pc.author_id = u.id', 'LEFT', ['u.name'])
             ->where(['p.date_created >=' => $dateFrom, 'p.date_created <' => $dateTo, 'pc.locale' => $this->db()->escape($locale)])
-            ->group(['p.id', 'p.cat_id', 'p.date_created', 'p.top', 'pc.article_id', 'pc.author_id', 'pc.visits', 'pc.content', 'pc.description', 'pc.keywords', 'pc.locale', 'pc.title', 'pc.teaser', 'pc.perma', 'pc.img', 'pc.img_source', 'pc.votes'])
+            ->group(['p.id'])
             ->order(['p.id' => 'DESC']);
 
         if ($pagination !== null) {

--- a/application/modules/article/models/Article.php
+++ b/application/modules/article/models/Article.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -18,7 +18,7 @@ class Article extends \Ilch\Model
     /**
      * The catId of the article.
      *
-     * @var int
+     * @var string
      */
     protected $catId;
 
@@ -506,7 +506,7 @@ class Article extends \Ilch\Model
     /**
      * Sets the read access.
      *
-     * @param integer $readAccess
+     * @param string $readAccess
      * @return $this
      */
     public function setReadAccess($readAccess)

--- a/application/modules/article/views/admin/index/treat.php
+++ b/application/modules/article/views/admin/index/treat.php
@@ -8,7 +8,7 @@ if ($this->get('article') != '') {
 <h1><?=($this->get('article') != '') ? $this->getTrans('edit') : $this->getTrans('add') ?></h1>
 <form id="article_form" class="form-horizontal" method="POST">
     <?=$this->getTokenField() ?>
-    <div class="form-group <?=$this->validation()->hasError('cats') ? 'has-error' : '' ?>">
+    <div class="form-group <?=$this->validation()->hasError('template') ? 'has-error' : '' ?>">
         <label for="template" class="col-lg-2 control-label">
             <?=$this->getTrans('template') ?>:
         </label>
@@ -60,7 +60,7 @@ if ($this->get('article') != '') {
                    class="form-control"
                    id="date_created"
                    name="date_created"
-                   value="<?php if ($this->get('article') != '' && $this->get('article')->getDateCreated()) { echo date('d.m.Y H:i', strtotime($this->get('article')->getDateCreated())); } ?>"
+                   value="<?=($this->get('article') != '' && $this->get('article')->getDateCreated()) ? date('d.m.Y H:i', strtotime($this->get('article')->getDateCreated())) : '' ?>"
                    readonly>
             <span class="input-group-addon">
                 <span class="fa fa-calendar"></span>
@@ -201,7 +201,7 @@ if ($this->get('article') != '') {
                    class="form-control"
                    name="imageSource"
                    id="imageSource"
-                   value="<?php if ($this->get('article') != '') { echo $this->escape($this->get('article')->getImageSource()); } ?>" />
+                   value="<?=($this->get('article') != '') ? $this->escape($this->get('article')->getImageSource()) : $this->originalInput('imageSource') ?>" />
         </div>
     </div>
     <div class="form-group">
@@ -219,8 +219,8 @@ if ($this->get('article') != '') {
         </label>
         <div class="col-lg-4">
             <textarea class="form-control" 
-                      id="description" 
-                      name="description"><?php if ($this->get('article') != '') { echo $this->escape($this->get('article')->getDescription()); } ?></textarea>
+                      id="description"
+                      name="description"><?=($this->get('article') != '') ? $this->escape($this->get('article')->getDescription()) : $this->originalInput('description') ?></textarea>
         </div>
     </div>
     <div class="form-group">
@@ -230,7 +230,7 @@ if ($this->get('article') != '') {
         <div class="col-lg-4">
             <textarea class="form-control" 
                       id="keywords" 
-                      name="keywords"><?php if ($this->get('article') != '') { echo $this->escape($this->get('article')->getKeywords()); } ?></textarea>
+                      name="keywords"><?=($this->get('article') != '') ? $this->escape($this->get('article')->getKeywords()) : $this->originalInput('keywords')?></textarea>
         </div>
     </div>
     <div class="form-group <?=$this->validation()->hasError('permaLink') ? 'has-error' : '' ?>">
@@ -244,7 +244,7 @@ if ($this->get('article') != '') {
                        type="text"
                        id="permaLink"
                        name="permaLink"
-                       value="<?php if ($this->get('article') != '') { echo $this->escape($this->get('article')->getPerma()); } else { echo $this->get('post')['permaLink']; } ?>" />
+                       value="<?=($this->get('article') != '') ? $this->escape($this->get('article')->getPerma()) : $this->originalInput('permaLink') ?>" />
             </div>
         </div>
     </div>

--- a/application/modules/article/views/archive/index.php
+++ b/application/modules/article/views/archive/index.php
@@ -3,26 +3,13 @@ $articles = $this->get('articles');
 $categoryMapper = $this->get('categoryMapper');
 $commentMapper = $this->get('commentMapper');
 $userMapper = $this->get('userMapper');
-
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
 ?>
 
 <h1><?=$this->getTrans('menuArchives') ?></h1>
 <?php if ($articles != ''): ?>
     <ul class="list-group">
         <?php
-        $displayedArticles = 0;
-
         foreach ($articles as $article):
-            if (!is_in_array($this->get('readAccess'), explode(',', $article->getReadAccess())) && $adminAccess == false) {
-                continue;
-            }
-
-            $displayedArticles++;
-
             $date = new \Ilch\Date($article->getDateCreated());
             $commentsCount = $commentMapper->getCountComments(sprintf(Modules\Article\Config\Config::COMMENT_KEY_TPL, $article->getId()));
 
@@ -74,13 +61,9 @@ if ($this->getUser()) {
             </li>
         <?php endforeach; ?>
     </ul>
-    <?php if ($displayedArticles > 0) : ?>
-        <div class="pull-right">
-            <?=$this->get('pagination')->getHtml($this, ['action' => 'index', 'id' => $this->getRequest()->getParam('id')]) ?>
-        </div>
-    <?php else: ?>
-        <?=$this->getTrans('noArticles') ?>
-    <?php endif; ?>
+    <div class="pull-right">
+        <?=$this->get('pagination')->getHtml($this, ['action' => 'index', 'id' => $this->getRequest()->getParam('id')]) ?>
+    </div>
 <?php else: ?>
     <?=$this->getTrans('noArticles') ?>
 <?php endif; ?>

--- a/application/modules/article/views/archive/show.php
+++ b/application/modules/article/views/archive/show.php
@@ -3,11 +3,6 @@ $articles = $this->get('articles');
 $categoryMapper = $this->get('categoryMapper');
 $commentMapper = $this->get('commentMapper');
 
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
-
 $date = null;
 if ($this->get('date')) {
     $date = $this->get('date');
@@ -17,15 +12,7 @@ if ($this->get('date')) {
 <h1><?=$this->getTrans('monthArchives') ?><?=($date) ? ': <i>'.$this->getTrans($date->format('F', true)).$date->format(' Y', true).'</i>' : '' ?></h1>
 <?php if ($articles != ''): ?>
     <?php
-    $displayedArticles = 0;
-
     foreach ($articles as $article):
-        if (!is_in_array($this->get('readAccess'), explode(',', $article->getReadAccess())) && $adminAccess == false) {
-            continue;
-        }
-
-        $displayedArticles++;
-
         $date = new \Ilch\Date($article->getDateCreated());
         $commentsCount = $commentMapper->getCountComments(sprintf(Modules\Article\Config\Config::COMMENT_KEY_TPL, $article->getId()));
         $image = $article->getImage();
@@ -103,11 +90,9 @@ if ($this->get('date')) {
         </div>
         <br /><br /><br />
     <?php endforeach; ?>
-    <?php if ($displayedArticles > 0) : ?>
-        <?=$this->get('pagination')->getHtml($this, ['action' => 'show', 'year' => $this->getRequest()->getParam('year'), 'month' => $this->getRequest()->getParam('month')]) ?>
-    <?php else: ?>
-        <?=$this->getTrans('noArticles') ?>
-    <?php endif; ?>
+        <div class="pull-right">
+            <?=$this->get('pagination')->getHtml($this, ['action' => 'show', 'year' => $this->getRequest()->getParam('year'), 'month' => $this->getRequest()->getParam('month')]) ?>
+        </div>
 <?php else: ?>
     <?=$this->getTrans('noArticles') ?>
 <?php endif; ?>

--- a/application/modules/article/views/cats/index.php
+++ b/application/modules/article/views/cats/index.php
@@ -7,8 +7,15 @@ $cats = $this->get('cats');
 <?php if ($cats != ''): ?>
     <ul class="list-group">
         <?php foreach ($cats as $cat): ?>
+            <?php
+            $count = $articleMapper->getCountArticlesByCatIdAccess($cat->getId(), $this->get('readAccess'));
+
+            if ($count === 0) {
+                continue;
+            }
+            ?>
             <li class="list-group-item">
-                <span class="badge"><?=$articleMapper->getCountArticlesByCatId($cat->getId()) ?></span>
+                <span class="badge"><?=$count ?></span>
                 <a href="<?=$this->getUrl(['controller' => 'cats', 'action' => 'show', 'id' => $cat->getId()]) ?>"><?=$this->escape($cat->getName()) ?></a>
             </li>
         <?php endforeach; ?>

--- a/application/modules/article/views/cats/show.php
+++ b/application/modules/article/views/cats/show.php
@@ -3,24 +3,11 @@ $articles = $this->get('articles');
 $categoryMapper = $this->get('categoryMapper');
 $commentMapper = $this->get('commentMapper');
 $articlesCats = $categoryMapper->getCategoryById($this->getRequest()->getParam('id'));
-
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
 ?>
 
 <h1><?=$this->getTrans('catArchives') ?>: <i><?=$this->escape($articlesCats->getName()) ?></i></h1>
 <?php if ($articles != ''):
-    $displayedArticles = 0;
-
     foreach ($articles as $article):
-        if (!is_in_array($this->get('readAccess'), explode(',', $article->getReadAccess())) && $adminAccess == false) {
-            continue;
-        }
-
-        $displayedArticles++;
-
         $date = new \Ilch\Date($article->getDateCreated());
         $commentsCount = $commentMapper->getCountComments(sprintf(Modules\Article\Config\Config::COMMENT_KEY_TPL, $article->getId()));
         $image = $article->getImage();
@@ -98,13 +85,9 @@ if ($this->getUser()) {
         </div>
         <br /><br /><br />
     <?php endforeach; ?>
-    <?php if ($displayedArticles > 0) : ?>
-        <div class="pull-right">
-            <?=$this->get('pagination')->getHtml($this, ['action' => 'show', 'id' => $this->getRequest()->getParam('id')]) ?>
-        </div>
-    <?php else: ?>
-        <?=$this->getTrans('noArticles') ?>
-    <?php endif; ?>
+    <div class="pull-right">
+        <?=$this->get('pagination')->getHtml($this, ['action' => 'show', 'id' => $this->getRequest()->getParam('id')]) ?>
+    </div>
 
 <?php else: ?>
     <?=$this->getTrans('noArticles') ?>

--- a/application/modules/article/views/index/index.php
+++ b/application/modules/article/views/index/index.php
@@ -2,24 +2,11 @@
 $articles = $this->get('articles');
 $categoryMapper = $this->get('categoryMapper');
 $commentMapper = $this->get('commentMapper');
-
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
 ?>
 
 <h1><?=$this->getTrans('menuArticle') ?></h1>
 <?php if ($articles != ''):
-    $displayedArticles = 0;
-
     foreach ($articles as $article):
-        if (!is_in_array($this->get('readAccess'), explode(',', $article->getReadAccess())) && $adminAccess == false) {
-            continue;
-        }
-
-        $displayedArticles++;
-
         $date = new \Ilch\Date($article->getDateCreated());
         $commentsCount = $commentMapper->getCountComments(sprintf(Modules\Article\Config\Config::COMMENT_KEY_TPL, $article->getId()));
         $image = $article->getImage();
@@ -98,13 +85,9 @@ if ($this->getUser()) {
         </div>
         <br /><br /><br />
     <?php endforeach; ?>
-    <?php if ($displayedArticles > 0) : ?>
         <div class="pull-right">
             <?=$this->get('pagination')->getHtml($this, ['action' => 'index']) ?>
         </div>
-    <?php else: ?>
-        <?=$this->getTrans('noArticles') ?>
-    <?php endif; ?>
 <?php else: ?>
     <?=$this->getTrans('noArticles') ?>
 <?php endif; ?>

--- a/application/modules/article/views/index/rss.php
+++ b/application/modules/article/views/index/rss.php
@@ -53,11 +53,10 @@ if ($articles) {
         if (strpos($strippedContent, '[PREVIEWSTOP]') !== false) {
             $contentParts = explode('[PREVIEWSTOP]', $strippedContent);
             $data = $xml->createElement('description', reset($contentParts));
-            $item->appendChild($data);
         } else {
             $data = $xml->createElement('description', $strippedContent);
-            $item->appendChild($data);
         }
+        $item->appendChild($data);
 
         if ($user) {
             $data = $xml->createElement('author', $this->escape($user->getName()));

--- a/application/modules/article/views/keywords/show.php
+++ b/application/modules/article/views/keywords/show.php
@@ -3,24 +3,11 @@ $articles = $this->get('articles');
 $categoryMapper = $this->get('categoryMapper');
 $commentMapper = $this->get('commentMapper');
 $keyword = $this->getRequest()->getParam('keyword');
-
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
 ?>
 
 <h1><?=$this->getTrans('keyword') ?>: <i><?=$this->escape($keyword) ?></i></h1>
 <?php if ($articles != ''):
-    $displayedArticles = 0;
-
     foreach ($articles as $article):
-        if (!is_in_array($this->get('readAccess'), explode(',', $article->getReadAccess())) && $adminAccess == false) {
-            continue;
-        }
-
-        $displayedArticles++;
-
         $date = new \Ilch\Date($article->getDateCreated());
         $commentsCount = $commentMapper->getCountComments(sprintf(Modules\Article\Config\Config::COMMENT_KEY_TPL, $article->getId()));
         $image = $article->getImage();
@@ -96,14 +83,9 @@ if ($this->getUser()) {
         </div>
         <br /><br /><br />
     <?php endforeach; ?>
-    <?php if ($displayedArticles > 0) : ?>
-        <div class="pull-right">
-            <?=$this->get('pagination')->getHtml($this, ['action' => 'show', 'keyword' => urlencode($keyword)]) ?>
-        </div>
-    <?php else: ?>
-        <?=$this->getTrans('noArticles') ?>
-    <?php endif; ?>
-
+    <div class="pull-right">
+        <?=$this->get('pagination')->getHtml($this, ['action' => 'show', 'keyword' => urlencode($keyword)]) ?>
+    </div>
 <?php else: ?>
     <?=$this->getTrans('noArticles') ?>
 <?php endif; ?>

--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -401,9 +401,8 @@ class Index extends \Ilch\Controller\Frontend
                 $moduleMapper = new \Modules\Admin\Mappers\Module();
                 $boxMapper = new \Modules\Admin\Mappers\Box();
 
-                /*
-                 * Clear old tables.
-                 */
+                // Clear old tables
+                $db->query('SET FOREIGN_KEY_CHECKS = 0;');
                 $db->dropTablesByPrefix($db->getPrefix());
 
                 foreach ($modulesToInstall as $module) {
@@ -500,7 +499,9 @@ class Index extends \Ilch\Controller\Frontend
                     (2, 20, 0, 0, 0, 'article_article', 4, 'Letzte Artikel', '', ''),
                     (2, 30, 0, 0, 0, 'article_archive', 4, 'Archiv', '', ''),
                     (2, 40, 0, 0, 0, 'article_categories', 4, 'Kategorien', '', ''),
-                    (2, 50, 0, 0, 0, 'article_keywords', 4, 'Keywords', '', '')";
+                    (2, 50, 0, 0, 0, 'article_keywords', 4, 'Keywords', '', '');
+
+                    SET FOREIGN_KEY_CHECKS = 1;";
                 $db->queryMulti($boxes);
 
                 unset($_SESSION['install']);

--- a/tests/PHPUnit/Ilch/DatabaseTestCase.php
+++ b/tests/PHPUnit/Ilch/DatabaseTestCase.php
@@ -127,9 +127,11 @@ abstract class DatabaseTestCase extends \PHPUnit\Framework\TestCase
         $sql = 'SHOW TABLES';
         $tableList = $db->queryList($sql);
 
+        $db->query('SET FOREIGN_KEY_CHECKS = 0;');
         foreach ($tableList as $table) {
             $sql = 'DROP TABLE ' . $table;
             $db->query($sql);
         }
+        $db->query('SET FOREIGN_KEY_CHECKS = 1;');
     }
 }

--- a/tests/PHPUnit/Ilch/PhpunitDataset.php
+++ b/tests/PHPUnit/Ilch/PhpunitDataset.php
@@ -82,7 +82,9 @@ class PhpunitDataset extends DatabaseTestCase
                 ->fetchCell();
 
             if ($tableNotEmpty) {
+                $this->db->query('SET FOREIGN_KEY_CHECKS = 0;');
                 $this->db->truncate($table);
+                $this->db->query('SET FOREIGN_KEY_CHECKS = 1;');
             }
 
             foreach($rows as $row => $columns) {

--- a/tests/modules/article/_files/mysql_database.yml
+++ b/tests/modules/article/_files/mysql_database.yml
@@ -1,0 +1,88 @@
+articles:
+  -
+    id: 1
+    cat_id: "2"
+    date_created: "2021-05-08 08:10:38"
+    top: 0
+    commentsDisabled: 0
+  -
+    id: 2
+    cat_id: "1"
+    date_created: "2021-05-09 08:10:38"
+    top: 0
+    commentsDisabled: 0
+  -
+    id: 3
+    cat_id: "1"
+    date_created: "2021-05-10 08:10:38"
+    top: 0
+    commentsDisabled: 1
+
+articles_access:
+  -
+    article_id: 1
+    group_id: 1
+  -
+    article_id: 1
+    group_id: 2
+  -
+    article_id: 1
+    group_id: 3
+  -
+    article_id: 2
+    group_id: 1
+  -
+    article_id: 2
+    group_id: 2
+  -
+    article_id: 3
+    group_id: 1
+
+articles_content:
+  -
+    article_id: 1
+    author_id: 1
+    visits: 1
+    content: "TestContent"
+    description: "TestDescription"
+    keywords: "keyword1, keyword2"
+    locale: ""
+    title: "TestTitle"
+    teaser: "TestTeaser"
+    perma: "testtitle.html"
+    img: ""
+    img_source: ""
+    votes: ""
+  -
+    article_id: 2
+    author_id: 1
+    visits: 2
+    content: "TestContent2"
+    description: "TestDescription2"
+    keywords: "keyword1, keyword2"
+    locale: ""
+    title: "TestTitle2"
+    teaser: "TestTeaser2"
+    perma: "testtitle2.html"
+    img: ""
+    img_source: ""
+    votes: ""
+  -
+    article_id: 3
+    author_id: 1
+    visits: 3
+    content: "TestContent3"
+    description: "TestDescription3"
+    keywords: "keyword1, keyword2"
+    locale: ""
+    title: "TestTitle3"
+    teaser: "TestTeaser3"
+    perma: "testtitle3.html"
+    img: ""
+    img_source: ""
+    votes: ""
+
+users:
+  -
+    id: 1
+    name: admin

--- a/tests/modules/article/mappers/ArticleTest.php
+++ b/tests/modules/article/mappers/ArticleTest.php
@@ -1,0 +1,1066 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Modules\Article\Mappers;
+
+use Ilch\Pagination;
+use PHPUnit\Ilch\DatabaseTestCase;
+use Modules\Article\Mappers\Article as ArticleMapper;
+use Modules\Article\Models\Article as ArticleModel;
+use Modules\Article\Config\Config as ModuleConfig;
+use Modules\User\Config\Config as UserConfig;
+use Modules\Admin\Config\Config as AdminConfig;
+use PHPUnit\Ilch\PhpunitDataset;
+
+/**
+ * Tests the article mapper class.
+ *
+ * @package ilch_phpunit
+ */
+class ArticleTest extends DatabaseTestCase
+{
+    protected $phpunitDataset;
+    private $articleMapper;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
+
+        $this->articleMapper = new ArticleMapper();
+    }
+
+    /**
+     * Tests if getArticles() returns all articles from the database.
+     */
+    public function testgetArticlesAllRows()
+    {
+        $articles = $this->articleMapper->getArticles();
+
+        self::assertCount(3, $articles);
+    }
+
+    public function testgetArticles()
+    {
+        $articles = $this->articleMapper->getArticles();
+
+        self::assertCount(3, $articles);
+
+        self::assertEquals(3, $articles[0]->getId());
+        self::assertSame('1', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(3, $articles[0]->getVisits());
+        self::assertSame('testtitle3.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle3', $articles[0]->getTitle());
+        self::assertSame('TestTeaser3', $articles[0]->getTeaser());
+        self::assertSame('TestContent3', $articles[0]->getContent());
+        self::assertSame('TestDescription3', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getTopArticle());
+        self::assertEquals(1, $articles[0]->getCommentsDisabled());
+        self::assertSame('1', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getTopArticle());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+
+        self::assertEquals(1, $articles[2]->getId());
+        self::assertSame('2', $articles[2]->getCatId());
+        self::assertSame(1, $articles[2]->getAuthorId());
+        self::assertSame('admin', $articles[2]->getAuthorName());
+        self::assertSame(1, $articles[2]->getVisits());
+        self::assertSame('testtitle.html', $articles[2]->getPerma());
+        self::assertSame('TestTitle', $articles[2]->getTitle());
+        self::assertSame('TestTeaser', $articles[2]->getTeaser());
+        self::assertSame('TestContent', $articles[2]->getContent());
+        self::assertSame('TestDescription', $articles[2]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[2]->getKeywords());
+        self::assertSame('', $articles[2]->getLocale());
+        self::assertSame('2021-05-08 08:10:38', $articles[2]->getDateCreated());
+        self::assertEquals(0, $articles[2]->getTopArticle());
+        self::assertEquals(0, $articles[2]->getCommentsDisabled());
+        self::assertSame('1,2,3', $articles[2]->getReadAccess());
+        self::assertSame('', $articles[2]->getImage());
+        self::assertSame('', $articles[2]->getImageSource());
+        self::assertSame('', $articles[2]->getVotes());
+    }
+
+    public function testgetArticlesByAccess()
+    {
+        $articles = $this->articleMapper->getArticlesByAccess('1,2,3');
+
+        self::assertCount(3, $articles);
+
+        self::assertEquals(3, $articles[0]->getId());
+        self::assertSame('1', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(3, $articles[0]->getVisits());
+        self::assertSame('testtitle3.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle3', $articles[0]->getTitle());
+        self::assertSame('TestTeaser3', $articles[0]->getTeaser());
+        self::assertSame('TestContent3', $articles[0]->getContent());
+        self::assertSame('TestDescription3', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getTopArticle());
+        self::assertEquals(1, $articles[0]->getCommentsDisabled());
+        self::assertSame('1', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getTopArticle());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+
+        self::assertEquals(1, $articles[2]->getId());
+        self::assertSame('2', $articles[2]->getCatId());
+        self::assertSame(1, $articles[2]->getAuthorId());
+        self::assertSame('admin', $articles[2]->getAuthorName());
+        self::assertSame(1, $articles[2]->getVisits());
+        self::assertSame('testtitle.html', $articles[2]->getPerma());
+        self::assertSame('TestTitle', $articles[2]->getTitle());
+        self::assertSame('TestTeaser', $articles[2]->getTeaser());
+        self::assertSame('TestContent', $articles[2]->getContent());
+        self::assertSame('TestDescription', $articles[2]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[2]->getKeywords());
+        self::assertSame('', $articles[2]->getLocale());
+        self::assertSame('2021-05-08 08:10:38', $articles[2]->getDateCreated());
+        self::assertEquals(0, $articles[2]->getTopArticle());
+        self::assertEquals(0, $articles[2]->getCommentsDisabled());
+        self::assertSame('1,2,3', $articles[2]->getReadAccess());
+        self::assertSame('', $articles[2]->getImage());
+        self::assertSame('', $articles[2]->getImageSource());
+        self::assertSame('', $articles[2]->getVotes());
+    }
+
+    public function testgetArticlesByAccessArray()
+    {
+        $articles = $this->articleMapper->getArticlesByAccess([1, 2, 3]);
+
+        self::assertCount(3, $articles);
+    }
+
+    public function testgetArticlesByAccessGuest()
+    {
+        $articles = $this->articleMapper->getArticlesByAccess([3]);
+
+        self::assertCount(1, $articles);
+    }
+
+    public function testgetArticlesByAccessGuestDefault()
+    {
+        $articles = $this->articleMapper->getArticlesByAccess();
+
+        self::assertCount(1, $articles);
+    }
+
+    public function testgetArticlesByCats()
+    {
+        $articles = $this->articleMapper->getArticlesByCats('1');
+
+        self::assertCount(2, $articles);
+
+        self::assertEquals(3, $articles[0]->getId());
+        self::assertSame('1', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(3, $articles[0]->getVisits());
+        self::assertSame('testtitle3.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle3', $articles[0]->getTitle());
+        self::assertSame('TestTeaser3', $articles[0]->getTeaser());
+        self::assertSame('TestContent3', $articles[0]->getContent());
+        self::assertSame('TestDescription3', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+//        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getTopArticle());
+        self::assertEquals(1, $articles[0]->getCommentsDisabled());
+        self::assertSame('1', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+//        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getTopArticle());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+    }
+
+    public function testgetArticlesByCatsNoResult()
+    {
+        $articles = $this->articleMapper->getArticlesByCats('0');
+
+        self::assertNull($articles);
+    }
+
+    public function testgetArticlesByCatsAccess()
+    {
+        $articles = $this->articleMapper->getArticlesByCatsAccess('1', '1,2,3');
+
+        self::assertCount(2, $articles);
+
+        self::assertEquals(3, $articles[0]->getId());
+        self::assertSame('1', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(3, $articles[0]->getVisits());
+        self::assertSame('testtitle3.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle3', $articles[0]->getTitle());
+        self::assertSame('TestTeaser3', $articles[0]->getTeaser());
+        self::assertSame('TestContent3', $articles[0]->getContent());
+        self::assertSame('TestDescription3', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+//        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getTopArticle());
+        self::assertEquals(1, $articles[0]->getCommentsDisabled());
+        self::assertSame('1', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+//        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getTopArticle());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+    }
+
+    public function testgetArticlesByCatsAccessArray()
+    {
+        $articles = $this->articleMapper->getArticlesByCatsAccess('1', [1, 2, 3]);
+
+        self::assertCount(2, $articles);
+    }
+
+    public function testgetArticlesByCatsAccessGuest()
+    {
+        $articles = $this->articleMapper->getArticlesByCatsAccess('2', [3]);
+
+        self::assertCount(1, $articles);
+    }
+
+    public function testgetArticlesByCatsAccessGuestDefault()
+    {
+        $articles = $this->articleMapper->getArticlesByCatsAccess('2');
+
+        self::assertCount(1, $articles);
+    }
+
+    public function testgetArticlesByKeyword()
+    {
+        $articles = $this->articleMapper->getArticlesByKeyword('keyword1');
+
+        self::assertCount(3, $articles);
+
+        self::assertEquals(3, $articles[0]->getId());
+        self::assertSame('1', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(3, $articles[0]->getVisits());
+        self::assertSame('testtitle3.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle3', $articles[0]->getTitle());
+        self::assertSame('TestTeaser3', $articles[0]->getTeaser());
+        self::assertSame('TestContent3', $articles[0]->getContent());
+        self::assertSame('TestDescription3', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+//        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getTopArticle());
+        self::assertEquals(1, $articles[0]->getCommentsDisabled());
+        self::assertSame('1', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+//        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getTopArticle());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+
+        self::assertEquals(1, $articles[2]->getId());
+        self::assertSame('2', $articles[2]->getCatId());
+        self::assertSame(1, $articles[2]->getAuthorId());
+        self::assertSame('admin', $articles[2]->getAuthorName());
+        self::assertSame(1, $articles[2]->getVisits());
+        self::assertSame('testtitle.html', $articles[2]->getPerma());
+        self::assertSame('TestTitle', $articles[2]->getTitle());
+        self::assertSame('TestTeaser', $articles[2]->getTeaser());
+        self::assertSame('TestContent', $articles[2]->getContent());
+        self::assertSame('TestDescription', $articles[2]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[2]->getKeywords());
+//        self::assertSame('', $articles[2]->getLocale());
+        self::assertSame('2021-05-08 08:10:38', $articles[2]->getDateCreated());
+        self::assertEquals(0, $articles[2]->getTopArticle());
+        self::assertEquals(0, $articles[2]->getCommentsDisabled());
+        self::assertSame('1,2,3', $articles[2]->getReadAccess());
+        self::assertSame('', $articles[2]->getImage());
+        self::assertSame('', $articles[2]->getImageSource());
+        self::assertSame('', $articles[2]->getVotes());
+    }
+
+    public function testgetArticlesByKeywordNoResult()
+    {
+        $articles = $this->articleMapper->getArticlesByKeyword('NotExisting');
+
+        self::assertNull($articles);
+    }
+
+    public function testgetArticlesByKeywordAccess()
+    {
+        $articles = $this->articleMapper->getArticlesByKeywordAccess('keyword1', '1,2,3');
+
+        self::assertCount(3, $articles);
+
+        self::assertEquals(3, $articles[0]->getId());
+        self::assertSame('1', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(3, $articles[0]->getVisits());
+        self::assertSame('testtitle3.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle3', $articles[0]->getTitle());
+        self::assertSame('TestTeaser3', $articles[0]->getTeaser());
+        self::assertSame('TestContent3', $articles[0]->getContent());
+        self::assertSame('TestDescription3', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+//        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getTopArticle());
+        self::assertEquals(1, $articles[0]->getCommentsDisabled());
+        self::assertSame('1', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+//        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getTopArticle());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+
+        self::assertEquals(1, $articles[2]->getId());
+        self::assertSame('2', $articles[2]->getCatId());
+        self::assertSame(1, $articles[2]->getAuthorId());
+        self::assertSame('admin', $articles[2]->getAuthorName());
+        self::assertSame(1, $articles[2]->getVisits());
+        self::assertSame('testtitle.html', $articles[2]->getPerma());
+        self::assertSame('TestTitle', $articles[2]->getTitle());
+        self::assertSame('TestTeaser', $articles[2]->getTeaser());
+        self::assertSame('TestContent', $articles[2]->getContent());
+        self::assertSame('TestDescription', $articles[2]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[2]->getKeywords());
+//        self::assertSame('', $articles[2]->getLocale());
+        self::assertSame('2021-05-08 08:10:38', $articles[2]->getDateCreated());
+        self::assertEquals(0, $articles[2]->getTopArticle());
+        self::assertEquals(0, $articles[2]->getCommentsDisabled());
+        self::assertSame('1,2,3', $articles[2]->getReadAccess());
+        self::assertSame('', $articles[2]->getImage());
+        self::assertSame('', $articles[2]->getImageSource());
+        self::assertSame('', $articles[2]->getVotes());
+    }
+
+    public function testgetArticlesByKeywordAccessGuest()
+    {
+        $articles = $this->articleMapper->getArticlesByKeywordAccess('keyword1', '3');
+
+        self::assertCount(1, $articles);
+    }
+
+    public function testgetArticlesByDate()
+    {
+        $articles = $this->articleMapper->getArticlesByDate(new \Ilch\Date('2021-05-09'));
+
+        self::assertCount(2, $articles);
+
+        self::assertEquals(3, $articles[0]->getId());
+        self::assertSame('1', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(3, $articles[0]->getVisits());
+        self::assertSame('testtitle3.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle3', $articles[0]->getTitle());
+        self::assertSame('TestTeaser3', $articles[0]->getTeaser());
+        self::assertSame('TestContent3', $articles[0]->getContent());
+        self::assertSame('TestDescription3', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+//        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getTopArticle());
+        self::assertEquals(1, $articles[0]->getCommentsDisabled());
+        self::assertSame('1', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+//        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getTopArticle());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+    }
+
+    public function testgetArticlesByDatePagination()
+    {
+        $pagination = new Pagination();
+
+        // Without the pagination this would return 3 articles.
+        $pagination->setRowsPerPage(2);
+        $articles = $this->articleMapper->getArticlesByDate(new \Ilch\Date('2021-05-08'), $pagination);
+
+        self::assertCount(2, $articles);
+        self::assertCount(2, $pagination->getLimit());
+
+        self::assertEquals(3, $articles[0]->getId());
+        self::assertSame('1', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(3, $articles[0]->getVisits());
+        self::assertSame('testtitle3.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle3', $articles[0]->getTitle());
+        self::assertSame('TestTeaser3', $articles[0]->getTeaser());
+        self::assertSame('TestContent3', $articles[0]->getContent());
+        self::assertSame('TestDescription3', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+//        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getTopArticle());
+        self::assertEquals(1, $articles[0]->getCommentsDisabled());
+        self::assertSame('1', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+//        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getTopArticle());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+    }
+
+    public function testgetArticlesByDateAccess()
+    {
+        $articles = $this->articleMapper->getArticlesByDateAccess(new \Ilch\Date('2021-05-09'), '1,2,3');
+
+        self::assertCount(2, $articles);
+
+        self::assertEquals(3, $articles[0]->getId());
+        self::assertSame('1', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(3, $articles[0]->getVisits());
+        self::assertSame('testtitle3.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle3', $articles[0]->getTitle());
+        self::assertSame('TestTeaser3', $articles[0]->getTeaser());
+        self::assertSame('TestContent3', $articles[0]->getContent());
+        self::assertSame('TestDescription3', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+//        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getTopArticle());
+        self::assertEquals(1, $articles[0]->getCommentsDisabled());
+        self::assertSame('1', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+//        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getTopArticle());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+    }
+
+    public function testgetArticlesByDateAccessNoResult()
+    {
+        $articles = $this->articleMapper->getArticlesByDateAccess(new \Ilch\Date('2021-05-09'), '3');
+
+        self::assertNull($articles);
+    }
+
+    public function testgetArticlesByDateAccessGuest()
+    {
+        $articles = $this->articleMapper->getArticlesByDateAccess(new \Ilch\Date('2021-05-09'), '2');
+
+        self::assertCount(1, $articles);
+    }
+
+    public function testgetCountArticlesByCatId()
+    {
+        self::assertSame(2, $this->articleMapper->getCountArticlesByCatId("1"));
+    }
+
+    public function testgetCountArticlesByCatIdNotExisting()
+    {
+        self::assertSame(0, $this->articleMapper->getCountArticlesByCatId("3"));
+    }
+
+    public function testgetCountArticlesByCatIdAccess()
+    {
+        self::assertSame(2, $this->articleMapper->getCountArticlesByCatIdAccess("1", '1,2,3'));
+    }
+
+    public function testgetCountArticlesByCatIdNotExistingAccess()
+    {
+        self::assertSame(0, $this->articleMapper->getCountArticlesByCatIdAccess("3"));
+    }
+
+    public function testgetCountArticlesByMonthYear()
+    {
+        self::assertSame(3, $this->articleMapper->getCountArticlesByMonthYear("2021-05-10 08:10:38"));
+    }
+
+    public function testgetCountArticlesByMonthYearNotExisting()
+    {
+        self::assertSame(0, $this->articleMapper->getCountArticlesByMonthYear("2000-01-01 08:10:38"));
+    }
+
+    public function testgetCountArticlesByMonthYearAccess()
+    {
+        self::assertSame(3, $this->articleMapper->getCountArticlesByMonthYearAccess("2021-05-10 08:10:38", '1,2,3'));
+    }
+
+    public function testgetCountArticlesByMonthYearAccessGuest()
+    {
+        self::assertSame(1, $this->articleMapper->getCountArticlesByMonthYearAccess("2021-05-10 08:10:38"));
+    }
+
+    public function testgetCountArticlesByMonthYearAccessNotExisting()
+    {
+        self::assertSame(0, $this->articleMapper->getCountArticlesByMonthYearAccess("2000-01-01 08:10:38"));
+    }
+
+    public function testgetArticleDateList()
+    {
+        $articles = $this->articleMapper->getArticleDateList(3);
+
+        self::assertCount(1, $articles);
+
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+    }
+
+    public function testgetArticleDateListAccess()
+    {
+        $articles = $this->articleMapper->getArticleDateListAccess('1,2,3', 3);
+
+        self::assertCount(1, $articles);
+
+        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+    }
+
+//    // Needs the media table
+//    public function testgetArticleList()
+//    {
+//        $articles = $this->articleMapper->getArticleList('', 3);
+//
+//        self::assertCount(1, $articles);
+//
+//        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
+//    }
+
+    public function testgetArticleByIdLocale()
+    {
+        $article = $this->articleMapper->getArticleByIdLocale(3);
+
+        self::assertNotNull($article);
+
+        self::assertEquals(3, $article->getId());
+        self::assertSame('1', $article->getCatId());
+        self::assertSame(1, $article->getAuthorId());
+        self::assertSame('TestDescription3', $article->getDescription());
+        self::assertSame('keyword1, keyword2', $article->getKeywords());
+        self::assertSame('TestTitle3', $article->getTitle());
+        self::assertSame('TestTeaser3', $article->getTeaser());
+        self::assertSame('TestContent3', $article->getContent());
+        self::assertSame('testtitle3.html', $article->getPerma());
+        self::assertSame('', $article->getLocale());
+        self::assertSame('2021-05-10 08:10:38', $article->getDateCreated());
+        self::assertSame('0', $article->getTopArticle());
+        self::assertSame('1', $article->getCommentsDisabled());
+        self::assertSame('1', $article->getReadAccess());
+        self::assertSame('', $article->getImage());
+        self::assertSame('', $article->getImageSource());
+        self::assertSame('', $article->getVotes());
+    }
+
+    public function testgetArticleByIdLocaleNotExisting()
+    {
+        $articles = $this->articleMapper->getArticleByIdLocale(0);
+
+        self::assertNull($articles);
+    }
+
+    public function testgetKeywordsList()
+    {
+        $articles = $this->articleMapper->getKeywordsList(2);
+
+        self::assertCount(2, $articles);
+
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+    }
+
+    public function testgetKeywordsListAccess()
+    {
+        $articles = $this->articleMapper->getKeywordsListAccess('1,2,3', 2);
+
+        self::assertCount(2, $articles);
+
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+    }
+
+    public function testgetKeywordsListAccessGuest()
+    {
+        $articles = $this->articleMapper->getKeywordsListAccess('3', 2);
+
+        self::assertCount(1, $articles);
+
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+    }
+
+    public function testkeywordExists()
+    {
+        self::assertTrue($this->articleMapper->keywordExists('keyword1'));
+        self::assertTrue($this->articleMapper->keywordExists('keyword2'));
+
+    }
+
+    public function testkeywordExistsNotExisting()
+    {
+        self::assertFalse($this->articleMapper->keywordExists('notexisting'));
+    }
+
+    public function testgetArticlePermas()
+    {
+        $permas = $this->articleMapper->getArticlePermas();
+
+        self::assertCount(3, $permas);
+
+        self::assertSame('testtitle.html', $permas['testtitle.html']['perma']);
+        self::assertSame('testtitle2.html', $permas['testtitle2.html']['perma']);
+        self::assertSame('testtitle3.html', $permas['testtitle3.html']['perma']);
+    }
+
+    public function testgetTopArticleNoTopArticle()
+    {
+        $articles = $this->articleMapper->getTopArticle();
+
+        self::assertNull($articles);
+    }
+
+    public function testgetTopArticle()
+    {
+        $this->articleMapper->setTopArticle(1, 1);
+        $article = $this->articleMapper->getTopArticle();
+
+        self::assertNotNull($article);
+
+        self::assertEquals(1, $article->getId());
+        self::assertSame('2', $article->getCatId());
+        self::assertSame(1, $article->getAuthorId());
+        self::assertSame('TestDescription', $article->getDescription());
+        self::assertSame('keyword1, keyword2', $article->getKeywords());
+        self::assertSame('TestTitle', $article->getTitle());
+        self::assertSame('TestTeaser', $article->getTeaser());
+        self::assertSame('TestContent', $article->getContent());
+        self::assertSame('testtitle.html', $article->getPerma());
+        self::assertSame('', $article->getLocale());
+        self::assertSame('2021-05-08 08:10:38', $article->getDateCreated());
+        self::assertEquals(0, $article->getCommentsDisabled());
+        self::assertSame('1,2,3', $article->getReadAccess());
+        self::assertSame('', $article->getImage());
+        self::assertSame('', $article->getImageSource());
+        self::assertSame('', $article->getVotes());
+    }
+
+    public function testgetTopArticles()
+    {
+        $this->articleMapper->setTopArticle(1, 1);
+        $this->articleMapper->setTopArticle(2, 1);
+        $articles = $this->articleMapper->getTopArticles();
+
+        self::assertCount(2, $articles);
+
+        self::assertEquals(1, $articles[0]->getId());
+        self::assertSame('2', $articles[0]->getCatId());
+        self::assertSame(1, $articles[0]->getAuthorId());
+//        self::assertSame('admin', $articles[0]->getAuthorName());
+        self::assertSame(1, $articles[0]->getVisits());
+        self::assertSame('testtitle.html', $articles[0]->getPerma());
+        self::assertSame('TestTitle', $articles[0]->getTitle());
+        self::assertSame('TestTeaser', $articles[0]->getTeaser());
+        self::assertSame('TestContent', $articles[0]->getContent());
+        self::assertSame('TestDescription', $articles[0]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
+        self::assertSame('', $articles[0]->getLocale());
+        self::assertSame('2021-05-08 08:10:38', $articles[0]->getDateCreated());
+        self::assertEquals(0, $articles[0]->getCommentsDisabled());
+        self::assertSame('1,2,3', $articles[0]->getReadAccess());
+        self::assertSame('', $articles[0]->getImage());
+        self::assertSame('', $articles[0]->getImageSource());
+        self::assertSame('', $articles[0]->getVotes());
+
+        self::assertEquals(2, $articles[1]->getId());
+        self::assertSame('1', $articles[1]->getCatId());
+        self::assertSame(1, $articles[1]->getAuthorId());
+//        self::assertSame('admin', $articles[1]->getAuthorName());
+        self::assertSame(2, $articles[1]->getVisits());
+        self::assertSame('testtitle2.html', $articles[1]->getPerma());
+        self::assertSame('TestTitle2', $articles[1]->getTitle());
+        self::assertSame('TestTeaser2', $articles[1]->getTeaser());
+        self::assertSame('TestContent2', $articles[1]->getContent());
+        self::assertSame('TestDescription2', $articles[1]->getDescription());
+        self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
+        self::assertSame('', $articles[1]->getLocale());
+        self::assertSame('2021-05-09 08:10:38', $articles[1]->getDateCreated());
+        self::assertEquals(0, $articles[1]->getCommentsDisabled());
+        self::assertSame('1,2', $articles[1]->getReadAccess());
+        self::assertSame('', $articles[1]->getImage());
+        self::assertSame('', $articles[1]->getImageSource());
+        self::assertSame('', $articles[1]->getVotes());
+    }
+
+    public function testsaveVisits()
+    {
+        $model = new ArticleModel();
+
+        $model->setId(1);
+        $model->setVisits(20);
+        $this->articleMapper->saveVisits($model);
+
+        $article = $this->articleMapper->getArticleByIdLocale(1);
+
+        self::assertNotNull($article);
+        self::assertEquals(1, $article->getId());
+        self::assertSame(20, $article->getVisits());
+    }
+
+    public function testsaveVisitsEmptyVisits()
+    {
+        $model = new ArticleModel();
+
+        $model->setId(1);
+        $this->articleMapper->saveVisits($model);
+
+        $article = $this->articleMapper->getArticleByIdLocale(1);
+
+        self::assertNotNull($article);
+        self::assertEquals(1, $article->getId());
+        self::assertSame(1, $article->getVisits());
+    }
+
+    public function testsaveNewArticle()
+    {
+        $model = new ArticleModel();
+        $model->setCatId(1);
+        $model->setAuthorId(1);
+        $model->setDescription('TestDescription4');
+        $model->setKeywords('keywords1, keywords2');
+        $model->setTitle('TestTitle4');
+        $model->setTeaser('TestTeaser4');
+        $model->setContent('TestContent4');
+        $model->setPerma('testtitle4.html');
+        $model->setLocale('');
+        $model->setTopArticle(1);
+        $model->setCommentsDisabled(1);
+        $model->setReadAccess('1,2,3');
+        $model->setImage('');
+        $model->setImageSource('');
+        $model->setVotes('1,2,3');
+        $id = $this->articleMapper->save($model);
+
+        $article = $this->articleMapper->getArticleByIdLocale($id);
+
+        self::assertNotNull($article);
+        self::assertEquals($id, $article->getId());
+        self::assertSame('1', $article->getCatId());
+        self::assertSame(1, $article->getAuthorId());
+        self::assertSame('TestDescription4', $article->getDescription());
+        self::assertSame('keywords1, keywords2', $article->getKeywords());
+        self::assertSame('TestTitle4', $article->getTitle());
+        self::assertSame('TestTeaser4', $article->getTeaser());
+        self::assertSame('TestContent4', $article->getContent());
+        self::assertSame('testtitle4.html', $article->getPerma());
+        self::assertSame('', $article->getLocale());
+        self::assertSame('1', $article->getTopArticle());
+        self::assertSame('1', $article->getCommentsDisabled());
+        self::assertSame('1,2,3', $article->getReadAccess());
+        self::assertSame('', $article->getImage());
+        self::assertSame('', $article->getImageSource());
+        self::assertSame('1,2,3', $article->getVotes());
+    }
+
+    public function testsaveUpdateExistingArticle()
+    {
+        $model = new ArticleModel();
+        $model->setId(1);
+        $model->setCatId(1);
+        $model->setAuthorId(1);
+        $model->setDescription('TestDescription4');
+        $model->setKeywords('keywords1, keywords2');
+        $model->setTitle('TestTitle4');
+        $model->setTeaser('TestTeaser4');
+        $model->setContent('TestContent4');
+        $model->setPerma('testtitle4.html');
+        $model->setLocale('');
+        $model->setTopArticle(1);
+        $model->setCommentsDisabled(1);
+        $model->setReadAccess('1,2,3');
+        $model->setImage('');
+        $model->setImageSource('');
+        $model->setVotes('1,2,3');
+        $id = $this->articleMapper->save($model);
+
+        $article = $this->articleMapper->getArticleByIdLocale($id);
+
+        self::assertNotNull($article);
+        self::assertEquals(1, $id);
+        self::assertEquals(1, $article->getId());
+        self::assertSame('1', $article->getCatId());
+        self::assertSame(1, $article->getAuthorId());
+        self::assertSame('TestDescription4', $article->getDescription());
+        self::assertSame('keywords1, keywords2', $article->getKeywords());
+        self::assertSame('TestTitle4', $article->getTitle());
+        self::assertSame('TestTeaser4', $article->getTeaser());
+        self::assertSame('TestContent4', $article->getContent());
+        self::assertSame('testtitle4.html', $article->getPerma());
+        self::assertSame('', $article->getLocale());
+        self::assertSame('1', $article->getTopArticle());
+        self::assertSame('1', $article->getCommentsDisabled());
+        self::assertSame('1,2,3', $article->getReadAccess());
+        self::assertSame('', $article->getImage());
+        self::assertSame('', $article->getImageSource());
+        self::assertSame('1,2,3', $article->getVotes());
+    }
+
+    public function testsaveExistingArticleNewLocale()
+    {
+        $model = new ArticleModel();
+        $model->setId(1);
+        $model->setAuthorId(1);
+        $model->setDescription('TestDescription4');
+        $model->setKeywords('keywords1, keywords2');
+        $model->setTitle('TestTitle4');
+        $model->setTeaser('TestTeaser4');
+        $model->setContent('TestContent4');
+        $model->setPerma('testtitle4.html');
+        $model->setLocale('en');
+        $model->setTopArticle(1);
+        $model->setReadAccess('1,2,3');
+        $model->setImage('');
+        $model->setImageSource('');
+        $model->setVotes('1,2,3');
+        $id = $this->articleMapper->save($model);
+
+        $article = $this->articleMapper->getArticleByIdLocale($id, 'en');
+
+        self::assertNotNull($article);
+        self::assertEquals(1, $id);
+        self::assertEquals(1, $article->getId());
+        self::assertSame('2', $article->getCatId());
+        self::assertSame(1, $article->getAuthorId());
+        self::assertSame('TestDescription4', $article->getDescription());
+        self::assertSame('keywords1, keywords2', $article->getKeywords());
+        self::assertSame('TestTitle4', $article->getTitle());
+        self::assertSame('TestTeaser4', $article->getTeaser());
+        self::assertSame('TestContent4', $article->getContent());
+        self::assertSame('testtitle4.html', $article->getPerma());
+        self::assertSame('en', $article->getLocale());
+        self::assertSame('1', $article->getTopArticle());
+        self::assertSame('0', $article->getCommentsDisabled());
+        self::assertSame('1,2,3', $article->getReadAccess());
+        self::assertSame('', $article->getImage());
+        self::assertSame('', $article->getImageSource());
+        self::assertSame('1,2,3', $article->getVotes());
+    }
+
+    public function testsaveVotes()
+    {
+        $this->articleMapper->saveVotes(1, 1);
+        $this->articleMapper->saveVotes(1, 2);
+        $article = $this->articleMapper->getArticleByIdLocale(1);
+
+        self::assertNotNull($article);
+        self::assertSame('1,2,', $article->getVotes());
+    }
+
+    public function testgetVotes()
+    {
+        $this->articleMapper->saveVotes(1, 1);
+        $this->articleMapper->saveVotes(1, 2);
+
+        self::assertSame('1,2,', $this->articleMapper->getVotes(1));
+    }
+
+    public function testgetVotesNoVotes()
+    {
+        self::assertSame('', $this->articleMapper->getVotes(1));
+    }
+
+    public function testdelete()
+    {
+        self::assertSame(1, $this->articleMapper->delete(1));
+
+        $article = $this->articleMapper->getArticleByIdLocale(1);
+        self::assertNull($article);
+    }
+
+    /**
+     * Returns database schema sql statements to initialize database
+     *
+     * @return string
+     */
+    protected static function getSchemaSQLQueries()
+    {
+        $config = new ModuleConfig();
+        $configUser = new UserConfig();
+        $configAdmin = new AdminConfig();
+
+        return $configAdmin->getInstallSql() . $configUser->getInstallSql() . $config->getInstallSql();
+    }
+}


### PR DESCRIPTION
# Description
Intended to be part of Ilch 2.1.44. Therefore leaving it as a draft until 2.1.43 is released. Feel free to review.

- Fixes "A guest/user might not see the intended count of articles"
- Added unit tests for the article mapper.
- Moved values of the read_access column to an own table with the columns article_id and group_id and make use of foreign keys constraints.
- Make use of a constraint for the articles_content table and adjusted delete() in the article mapper.
- Adjusted the DatabaseTestCase and PHPunitDataset to work with tables with foreign keys.
- Deprecated getTopArticle() and added an replacement called getTopArticles().
- Boxes now always show the configured number of entries if there are enough in the database.
- Entries not visible to the visitor are no longer counted in the boxes.
- Fixed wrong input field highlighted when creating or editing an article and not entering required fields.
- Restore more previously entered fields if a required one was missing.
- Fix double space in "DELETE" SQL command (query builder).
- No longer show an empty string as a keyword.
- Remove deprecated GROUP BY DESC (see #534)
- A few other smaller fixes.

Fixes #483 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [X] Opera
- [ ] Edge
- [ ] IE
