### PR TITLE
Fix a few errors in the gallery module

### DIFF
--- a/application/modules/gallery/boxes/Pictureofx.php
+++ b/application/modules/gallery/boxes/Pictureofx.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -13,7 +13,7 @@ class Pictureofx extends \Ilch\Box
     public function render()
     {
         $imageMapper = new ImageMapper();
-        $galleries = $this->getConfig()->get('gallery_pictureOfXSource');
+        $galleries = explode(',', $this->getConfig()->get('gallery_pictureOfXSource'));
         $imageIds = $imageMapper->getListOfValidIds(['cat' => $galleries]);
 
         if (!empty($imageIds)) {

--- a/application/modules/gallery/config/config.php
+++ b/application/modules/gallery/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'gallery',
-        'version' => '1.17.0',
+        'version' => '1.18.0',
         'icon_small' => 'fa-picture-o',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/gallery/config/config.php
+++ b/application/modules/gallery/config/config.php
@@ -36,7 +36,7 @@ class Config extends \Ilch\Config\Install
             ]
         ],
         'ilchCore' => '2.1.37',
-        'phpVersion' => '5.6'
+        'phpVersion' => '7.0'
     ];
 
     public function install()

--- a/application/modules/gallery/mappers/Gallery.php
+++ b/application/modules/gallery/mappers/Gallery.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 

--- a/application/modules/gallery/mappers/Gallery.php
+++ b/application/modules/gallery/mappers/Gallery.php
@@ -48,12 +48,11 @@ class Gallery extends \Ilch\Mapper
     /**
      * Gets all gallery items by type.
      *
-     * @param $type
-     * @return array|null
+     * @param int $type
+     * @return array|GalleryItem[]
      */
-    public function getGalleryCatItem($type)
+    public function getGalleryCatItem(int $type): array
     {
-        $items = [];
         $itemRows = $this->db()->select('*')
                 ->from('gallery_items')
                 ->where(['type' => $type])
@@ -62,9 +61,10 @@ class Gallery extends \Ilch\Mapper
                 ->fetchRows();
 
         if (empty($itemRows)) {
-            return null;
+            return [];
         }
 
+        $items = [];
         foreach ($itemRows as $itemRow) {
             $itemModel = new GalleryItem();
             $itemModel->setId($itemRow['id']);

--- a/application/modules/gallery/mappers/Image.php
+++ b/application/modules/gallery/mappers/Image.php
@@ -23,7 +23,7 @@ class Image extends \Ilch\Mapper
             ->join(['m' => 'media'], 'g.image_id = m.id', 'LEFT')
             ->where(['g.id' => (int)$id])
             ->execute()
-            ->fetchRow();
+            ->fetchAssoc();
 
         if (empty($imageRow)) {
             return null;
@@ -58,7 +58,7 @@ class Image extends \Ilch\Mapper
             ->order(['g.id' => 'DESC'])
             ->limit(1)
             ->execute()
-            ->fetchRow();
+            ->fetchAssoc();
 
         if (empty($imageRow)) {
             return null;


### PR DESCRIPTION
# Description

Fix recently introduced errors in the gallery module and some older ones found while testing.

- Fixed 'Undefined array key "imgid"'
- Fixed 'foreach() argument must be of type array|object, null given' in settings
- PictureOfX previously didn't use pictures of all selected galleries.

Fixes #541 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
