### PR TITLE
Simplify the article template feature

### DIFF
--- a/application/modules/article/controllers/admin/Index.php
+++ b/application/modules/article/controllers/admin/Index.php
@@ -98,16 +98,11 @@ class Index extends \Ilch\Controller\Admin
         $groupMapper = new GroupMapper();
 
         $groupsList = $groupMapper->getGroupList();
-
-        if ($this->getRequest()->getParam('locale') == '') {
-            $locale = '';
-        } else {
-            $locale = $this->getRequest()->getParam('locale');
-        }
+        $locale = $this->getRequest()->getParam('locale');
 
         if ($this->getRequest()->getParam('template')) {
             $this->getView()->set('template', $this->getRequest()->getParam('template'));
-            $this->getView()->set('article', $templateMapper->getTemplateByIdLocale($this->getRequest()->getParam('template'), $locale));
+            $this->getView()->set('article', $templateMapper->getTemplateById($this->getRequest()->getParam('template')));
         } elseif ($this->getRequest()->getParam('id')) {
             $this->getLayout()->getAdminHmenu()
                     ->add($this->getTranslator()->trans('menuArticle'), ['action' => 'index'])
@@ -194,7 +189,7 @@ class Index extends \Ilch\Controller\Admin
             $groups = [1,2,3];
         }
 
-        $this->getView()->set('templates', $templateMapper->getTemplates());
+        $this->getView()->set('templates', $templateMapper->getTemplates($locale));
         $this->getView()->set('cats', $categoryMapper->getCategories());
         $this->getView()->set('contentLanguage', $this->getConfig()->get('content_language'));
         $this->getView()->set('languages', $this->getTranslator()->getLocaleList());

--- a/application/modules/article/controllers/admin/Templates.php
+++ b/application/modules/article/controllers/admin/Templates.php
@@ -67,7 +67,7 @@ class Templates extends \Ilch\Controller\Admin
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('templateMapper', $templateMapper);
-        $this->getView()->set('articles', $templateMapper->getTemplates('', $pagination));
+        $this->getView()->set('articles', $templateMapper->getTemplates(null, $pagination));
         $this->getView()->set('multilingual', (bool)$this->getConfig()->get('multilingual_acp'));
         $this->getView()->set('contentLanguage', $this->getConfig()->get('content_language'));
         $this->getView()->set('pagination', $pagination);
@@ -81,13 +81,7 @@ class Templates extends \Ilch\Controller\Admin
                 ->add($this->getTranslator()->trans('menuArticle'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('edit'), ['action' => 'treat']);
 
-        if ($this->getRequest()->getParam('locale') == '') {
-            $locale = '';
-        } else {
-            $locale = $this->getRequest()->getParam('locale');
-        }
-
-        $this->getView()->set('article', $templateMapper->getTemplateByIdLocale($this->getRequest()->getParam('id'), $locale));
+        $this->getView()->set('article', $templateMapper->getTemplateById($this->getRequest()->getParam('id')));
 
         if ($this->getRequest()->isPost()) {
             $validation = Validation::create($this->getRequest()->getPost(), [
@@ -109,6 +103,7 @@ class Templates extends \Ilch\Controller\Admin
                 $model->setAuthorId($this->getUser()->getId())
                     ->setDescription($this->getRequest()->getPost('description'))
                     ->setKeywords($this->getRequest()->getPost('keywords'))
+                    ->setLocale($this->getRequest()->getPost('language'))
                     ->setTitle($this->getRequest()->getPost('title'))
                     ->setTeaser($this->getRequest()->getPost('teaser'))
                     ->setContent($this->getRequest()->getPost('content'))

--- a/application/modules/article/views/admin/index/treat.php
+++ b/application/modules/article/views/admin/index/treat.php
@@ -21,7 +21,7 @@ if ($this->get('article') != '') {
                     <option value="0"><?=$this->getTrans('selectTemplate') ?></option>
                 <?php foreach ($this->get('templates') as $template): ?>
                     <option value="<?=$template->getId() ?>" <?=($this->get('template') == $template->getId()) ? 'selected="selected"' : '' ?>>
-                        <?=$this->escape($template->getTitle()) ?>
+                        <?=$this->escape($template->getTitle() . ($template->getLocale() ? ' (' . $template->getLocale() . ')' : '')) ?>
                     </option>
                 <?php endforeach; ?>
             </select>
@@ -294,7 +294,7 @@ $('#language').change(
 ?>
 
 $('#preview').click(
-    function(e) 
+    function(e)
     {
         e.preventDefault();
         $('#article_form').attr('action', '<?=$this->getUrl('index.php/article/index/show/preview/true') ?>');
@@ -323,11 +323,11 @@ $('#tags').on('tokenfield:createtoken', function (event) {
             event.preventDefault();
     });
 });
-$( "#template" ).change(function() {
+$('#template').change(function() {
     if (<?=($articleID) ? json_encode($articleID) : '""' ?>) {
-        window.location = '<?=$this->getUrl(['id' => $articleID]) ?>/template/'+$(this).val();
+        window.location = '<?=$this->getCurrentUrl(['id' => $articleID], false) ?>/template/'+$(this).val();
     } else {
-        window.location = '<?=$this->getUrl(['action' => 'treat']) ?>/template/'+$(this).val();
+        window.location = '<?=$this->getCurrentUrl(['action' => 'treat'], false) ?>/template/'+$(this).val();
     }
 });
 </script>

--- a/application/modules/article/views/admin/templates/index.php
+++ b/application/modules/article/views/admin/templates/index.php
@@ -9,9 +9,7 @@
                     <col class="icon_width" />
                     <col class="icon_width" />
                     <col />
-                    <?php if ($this->get('multilingual')): ?>
-                        <col class="col-lg-1">
-                    <?php endif; ?>
+                    <col />
                 </colgroup>
                 <thead>
                 <tr>
@@ -19,17 +17,7 @@
                     <th></th>
                     <th></th>
                     <th><?=$this->getTrans('title') ?></th>
-                    <?php if ($this->get('multilingual')): ?>
-                        <th class="text-right">
-                            <?php foreach ($this->getTranslator()->getLocaleList() as $key => $value): ?>
-                                <?php if ($key == $this->get('contentLanguage')): ?>
-                                    <?php continue; ?>
-                                <?php endif; ?>
-
-                                <img src="<?=$this->getStaticUrl('img/lang/'.$key.'.png') ?>" alt="<?=$this->getTrans('language').' '.$key ?>">
-                            <?php endforeach; ?>
-                        </th>
-                    <?php endif; ?>
+                    <th><?=$this->getTrans('language') ?></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -39,21 +27,7 @@
                         <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $article->getId()]) ?></td>
                         <td><?=$this->getDeleteIcon(['action' => 'delete', 'id' => $article->getId()]) ?></td>
                         <td><?=$this->escape($article->getTitle()) ?></td>
-                        <?php if ($this->get('multilingual')): ?>
-                            <td class="text-right">
-                                <?php foreach ($this->getTranslator()->getLocaleList() as $key => $value): ?>
-                                    <?php if ($key == $this->get('contentLanguage')): ?>
-                                        <?php continue; ?>
-                                    <?php endif; ?>
-
-                                    <?php if ($this->get('templateMapper')->getTemplateByIdLocale($article->getId(), $key)): ?>
-                                        <a href="<?=$this->getUrl(['action' => 'treat', 'id' => $article->getId(), 'locale' => $key]) ?>"><i class="fa fa-edit"></i></a>
-                                    <?php else: ?>
-                                        <a href="<?=$this->getUrl(['action' => 'treat', 'id' => $article->getId(), 'locale' => $key]) ?>"><i class="fa fa-plus-circle"></i></a>
-                                    <?php endif; ?>
-                                <?php endforeach; ?>
-                            </td>
-                        <?php endif; ?>
+                        <td><?=$this->escape($article->getLocale()) ?></td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>

--- a/application/modules/article/views/admin/templates/treat.php
+++ b/application/modules/article/views/admin/templates/treat.php
@@ -40,7 +40,7 @@ if ($this->get('article') != '') {
                       toolbar="ilch_html"><?=($this->get('article') != '') ? $this->get('article')->getContent(): $this->originalInput('content') ?></textarea>
         </div>
     </div>
-    <?php if ($this->get('multilingual') && $this->getRequest()->getParam('locale') != ''): ?>
+    <?php if ($this->get('multilingual')): ?>
         <div class="form-group">
             <label for="language" class="col-lg-2 control-label">
                 <?=$this->getTrans('language') ?>:
@@ -51,7 +51,7 @@ if ($this->get('article') != '') {
                     foreach ($this->get('languages') as $key => $value) {
                         $selected = '';
                         if ($key == $this->get('contentLanguage')) {
-                            continue;
+                            $key = '';
                         }
 
                         if ($this->getRequest()->getParam('locale') == $key) {


### PR DESCRIPTION
# Description

The article template feature doesn't need to take multi language into account. This was broken to begin with. Simplify the template feature.

These changes where laying around from earlier work. I pulled this out of a previous pull request to send it in separately.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [X] Opera
