### PR TITLE
Deprecate GROUP BY ASC or DESC

### DIFF
--- a/application/libraries/Ilch/Database/Mysql/Select.php
+++ b/application/libraries/Ilch/Database/Mysql/Select.php
@@ -232,6 +232,7 @@ class Select extends QueryBuilder
      *
      * @param array $fields ['field' => 'DESC|ASC', 'field2']
      * @param boolean $replace
+     * @deprecated providing a sort order like 'field' => 'DESC|ASC' is deprecated.
      *
      * @return \Ilch\Database\Mysql\Select
      */
@@ -492,9 +493,10 @@ class Select extends QueryBuilder
                     $fields[] = $this->db->quote($value);
                 } else {
                     if (!\in_array($value, ['ASC', 'DESC'])) {
-                        throw new \InvalidArgumentException('Invalid GROUP BY option: ' . $value);
+                        throw new \InvalidArgumentException('Invalid GROUP BY option: ' . $value . ' Note: a sort order within GROUP BY is deprecated.');
                     }
-                    $fields[] = $this->db->quote($key) . ' ' . $value;
+                    $this->order[$key] = $value; // TODO: Remove this line when support for 'field' => 'DESC|ASC' in group() gets removed.
+                    $fields[] = $this->db->quote($key);
                 }
             }
             $sql .= implode(',', $fields);

--- a/tests/libraries/ilch/Database/Mysql/SelectTest.php
+++ b/tests/libraries/ilch/Database/Mysql/SelectTest.php
@@ -464,8 +464,40 @@ class SelectTest extends \PHPUnit\Framework\TestCase
                 'expectedSqlPart' => '`field1`,`table`.`field2`'
             ],
             'one field with direction (conversion to separate ORDER BY)' => [
-                'groupByFields' => ['table.field' => 'DESC'],
-                'expectedSqlPart' => '`table`.`field` ORDER BY `table`.`field` DESC'
+                'groupByFields' => ['table.field1' => 'DESC'],
+                'expectedSqlPart' => '`table`.`field1` ORDER BY `table`.`field1` DESC'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dpForTestGenerateSqlWithGroupDirectionAndOrder
+     *
+     * @param array $groupByFields
+     * @param string $expectedSqlPart
+     */
+    public function testGenerateSqlWithGroupDirectionAndOrder($groupByFields, $orderByFields, $expectedSqlPart)
+    {
+        $this->out->from('Test')
+            ->group($groupByFields)
+            ->order($orderByFields);
+
+        $expected = 'SELECT * FROM `[prefix]_Test`'
+            . ' GROUP BY ' . $expectedSqlPart;
+
+        self::assertEquals($expected, $this->out->generateSql());
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestGenerateSqlWithGroupDirectionAndOrder()
+    {
+        return [
+            'one field with direction (conversion to separate ORDER BY)' => [
+                'groupByFields' => ['table.field1' => 'DESC'],
+                'orderByFields' => ['table.field2' => 'DESC'],
+                'expectedSqlPart' => '`table`.`field1` ORDER BY `table`.`field2` DESC,`table`.`field1` DESC'
             ]
         ];
     }

--- a/tests/libraries/ilch/Database/Mysql/SelectTest.php
+++ b/tests/libraries/ilch/Database/Mysql/SelectTest.php
@@ -463,9 +463,9 @@ class SelectTest extends \PHPUnit\Framework\TestCase
                 'groupByFields' => ['field1', 'table.field2'],
                 'expectedSqlPart' => '`field1`,`table`.`field2`'
             ],
-            'one field with direction' => [
+            'one field with direction (conversion to separate ORDER BY)' => [
                 'groupByFields' => ['table.field' => 'DESC'],
-                'expectedSqlPart' => '`table`.`field` DESC'
+                'expectedSqlPart' => '`table`.`field` ORDER BY `table`.`field` DESC'
             ]
         ];
     }


### PR DESCRIPTION
# Description

Add deprecation warnings and adjust the QueryBuilder so that it converts those to a separate ORDER BY.
Further adjusted the existing unit test and added a unit test for the case group() is used with direction and order() too (order() should not "overwrite" the ORDER BY of the GROUP BY).

> "GROUP BY" with ASC or DESC is deprecated since MySQL 5.7 and support got removed with MySQL 8.0.13 released on October 22nd of 2018.

[QueryBuilder: GROUP BY ASC or DESC is no longer supported](https://github.com/IlchCMS/Ilch-2.0/issues/534)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

The documentation for the QueryBuilder needs to be updated to show that providing a sortorder to group() is no longer supported.