### PR TITLE
Issue 535: add support for inserting multiple rows

### DIFF
--- a/application/modules/guestbook/config/config.php
+++ b/application/modules/guestbook/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'guestbook',
-        'version' => '1.10.0',
+        'version' => '1.11.0',
         'icon_small' => 'fa-book',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -74,9 +74,10 @@ class Config extends \Ilch\Config\Install
             case "1.7.0":
             case "1.8.0":
             case "1.9.0":
+            case "1.10.0":
                 // Update description
                 foreach($this->config['languages'] as $key => $value) {
-                    $this->db()->query(sprintf("UPDATE `[prefix]_modules_content` SET `description` = '%s' WHERE `key` = 'vote' AND `locale` = '%s';", $value['description'], $key));
+                    $this->db()->query(sprintf("UPDATE `[prefix]_modules_content` SET `description` = '%s' WHERE `key` = 'guestbook' AND `locale` = '%s';", $value['description'], $key));
                 }
         }
     }

--- a/application/modules/user/mappers/GalleryImage.php
+++ b/application/modules/user/mappers/GalleryImage.php
@@ -22,7 +22,7 @@ class GalleryImage extends \Ilch\Mapper
         $imageRow = $this->db()->select(['g.image_id', 'g.cat', 'imgid' => 'g.id', 'g.image_title', 'g.image_description', 'g.visits', 'm.url', 'm.id', 'm.url_thumb'])
             ->from(['g' => 'users_gallery_imgs'])
             ->join(['m' => 'users_media'], 'g.image_id = m.id', 'LEFT')
-            ->where(['g.cat' => $id])
+            ->where(['g.id' => $id])
             ->execute()
             ->fetchAssoc();
 

--- a/application/modules/vote/config/config.php
+++ b/application/modules/vote/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'vote',
-        'version' => '1.10.0',
+        'version' => '1.11.0',
         'icon_small' => 'fa-tasks',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -94,6 +94,8 @@ class Config extends \Ilch\Config\Install
                 $this->db()->query('ALTER TABLE `[prefix]_poll_ip` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
             case '1.7.0':
             case '1.8.0':
+            case '1.9.0':
+            case '1.10.0':
                 // Update description
                 foreach($this->config['languages'] as $key => $value) {
                     $this->db()->query(sprintf("UPDATE `[prefix]_modules_content` SET `description` = '%s' WHERE `key` = 'vote' AND `locale` = '%s';", $value['description'], $key));

--- a/tests/libraries/ilch/Database/Mysql/InsertTest.php
+++ b/tests/libraries/ilch/Database/Mysql/InsertTest.php
@@ -66,4 +66,40 @@ class InsertTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals($expected, $this->out->generateSql());
     }
+
+    public function testGenerateSqlForValuesMultipleRows()
+    {
+        $this->out->into('Test')
+            ->columns(['super', 'next'])
+            ->values([['data', 'fieldData'], ['data2', 'fieldData2'], ['data3', 'fieldData3']]);
+
+        $expected = 'INSERT INTO `[prefix]_Test` '
+            . '(`super`,`next`) VALUES ("data","fieldData"),("data2","fieldData2"),("data3","fieldData3")';
+
+        self::assertEquals($expected, $this->out->generateSql());
+    }
+
+    public function testGenerateSqlForValuesMultipleRowsInvalidCount()
+    {
+        $this->out->into('Test')
+            ->columns(['super', 'next'])
+            ->values([['data'], ['data2', 'fieldData2']]);
+
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('count of values does not fit the count of columns');
+
+        $this->out->generateSql();
+    }
+
+    public function testGenerateSqlForValuesMultipleRowsNotAnArray()
+    {
+        $this->out->into('Test')
+            ->columns(['super', 'next'])
+            ->values(['data', 'data2', 'fieldData2']);
+
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('no valid values for insert');
+
+        $this->out->generateSql();
+    }
 }


### PR DESCRIPTION
# Description
- Added support for inserting multiple rows
- Added a few unit tests
- Fixed guestbook updating description of wrong module

Fixes #535 

What do you think of this change and the syntax for the QueryBuilder? Please review.

The syntax should be:
> $this->db()->insert('Test')
>     ->columns(['super', 'next'])
>     ->values([['data', 'fieldData'], ['data2', 'fieldData2'], ['data3', 'fieldData3']]);
>     ->execute();

As of now not tested outside the unit tests for the query builder.

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update
