### PR TITLE
Fix a few issues in the chat

### DIFF
--- a/application/libraries/Ilch/Database/Mysql/Select.php
+++ b/application/libraries/Ilch/Database/Mysql/Select.php
@@ -362,7 +362,7 @@ class Select extends QueryBuilder
         $sql .= $this->getFieldsSql($fields)
             . ' FROM ' . $this->getTableSql($this->table);
 
-        $sql .= implode(' ', $joinsSql);
+        $sql .= implode('', $joinsSql);
 
         $sql .= $this->generateWhereSql();
         $sql .= $this->generateGroupBySql();

--- a/application/modules/contact/translations/de.php
+++ b/application/modules/contact/translations/de.php
@@ -18,7 +18,7 @@ return [
     'addButton' => 'Senden',
     'writes' => 'schreibt',
     'privacy' => 'Datenschutzerklärung',
-    'acceptPrivacy' => 'Ich hab die <a href="/index.php/privacy/index/index" title="Datenschutzerklärung" target="_blank">Datenschutzerklärung</a>  zur Kenntnis genommen.',
+    'acceptPrivacy' => 'Ich hab die <a href="'.BASE_URL.'/index.php/privacy/index/index" title="Datenschutzerklärung" target="_blank">Datenschutzerklärung</a>  zur Kenntnis genommen.',
     'directOrReplyLink' => 'Sie können direkt auf diese E-Mail antworten oder folgenden Link nutzen',
     'welcomeMessage' => 'Willkommensnachricht',
 ];

--- a/application/modules/contact/translations/en.php
+++ b/application/modules/contact/translations/en.php
@@ -18,7 +18,7 @@ return [
     'addButton' => 'Send',
     'writes' => 'writes',
     'privacy' => 'Privacy',
-    'acceptPrivacy' => 'I have read the <a href="/index.php/privacy/index/index" title="data protection information" target="_blank">data protection information</a>.',
+    'acceptPrivacy' => 'I have read the <a href="'.BASE_URL.'/index.php/privacy/index/index" title="data protection information" target="_blank">data protection information</a>.',
     'directOrReplyLink' => 'You can reply directly to this email or use the following link',
     'welcomeMessage' => 'Welcome message',
 ];

--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -508,7 +508,7 @@ class Config extends \Ilch\Config\Install
                 $this->db()->query('ALTER TABLE `[prefix]_users_dialog_hidden` ADD COLUMN `permanent` TINYINT(1) UNSIGNED NOT NULL;');
                 break;
             case "2.1.43":
-                // convert old icons to new format
+                // Convert old icons to new format
                 $this->db()->query("UPDATE `[prefix]_profile_fields` SET `icon` = 'fas fa-globe' WHERE `icon` = 'fa-globe';");
                 $this->db()->query("UPDATE `[prefix]_profile_fields` SET `icon` = 'fab fa-facebook' WHERE `icon` = 'fa-facebook';");
                 $this->db()->query("UPDATE `[prefix]_profile_fields` SET `icon` = 'fab fa-twitter' WHERE `icon` = 'fa-twitter';");
@@ -517,6 +517,18 @@ class Config extends \Ilch\Config\Install
                 $this->db()->query("UPDATE `[prefix]_profile_fields` SET `icon` = 'fab fa-twitch' WHERE `icon` = 'fa-twitch';");
                 $this->db()->query("UPDATE `[prefix]_profile_fields` SET `icon` = 'fas fa-headphones' WHERE `icon` = 'fa-headphones';");
                 $this->db()->query("UPDATE `[prefix]_profile_fields` SET `icon` = 'fas fa-microphone' WHERE `icon` = 'fa-microphone';");
+
+                // Restore deleted dialogs with unread messages
+                $deletedDialogs = $this->db()->select('DISTINCT h.c_id')
+                    ->from(['h' => 'users_dialog_hidden'])
+                    ->join(['r' => 'users_dialog_reply'], 'h.c_id = r.c_id_fk', 'INNER')
+                    ->where(['h.permanent' => 1, 'r.read' => 0])
+                    ->execute()
+                    ->fetchList();
+
+                $this->db()->delete('users_dialog_hidden')
+                    ->where(['c_id' => $deletedDialogs], 'or')
+                    ->execute();
                 break;
         }
     }

--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -529,6 +529,9 @@ class Config extends \Ilch\Config\Install
                 $this->db()->delete('users_dialog_hidden')
                     ->where(['c_id' => $deletedDialogs], 'or')
                     ->execute();
+
+                // Add a composite primary key to the users_dialog_hidden table
+                $this->db()->query("ALTER TABLE `[prefix]_users_dialog_hidden` ADD PRIMARY KEY (`c_id`, `user_id`);");
                 break;
         }
     }

--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -430,18 +430,14 @@ class Panel extends BaseController
                         ->setText($text);
                     $dialogMapper->save($model);
 
+                    $dialogMapper->unhideDialog($c_id, $user_one);
+
                     $this->redirect(['action' => 'dialog','id'=> $c_id]);
+                } else {
+                    $dialogMapper->markAllAsRead($c_id, $this->getUser()->getId());
                 }
 
                 $this->getView()->set('inbox', $dialogMapper->getDialogMessage($c_id));
-
-                $dialog = $dialogMapper->getReadLastOneDialog($c_id);
-                if ($dialog && $dialog->getUserOne() != $this->getUser()->getId()) {
-                    $model = new DialogModel();
-                    $model->setCrId($dialog->getCrId())
-                        ->setRead(1);
-                    $dialogMapper->updateRead($model);
-                }
             } else {
                 $this->redirect(['action' => 'dialog']);
             }
@@ -499,13 +495,7 @@ class Panel extends BaseController
             $dialogMapper = new DialogMapper();
             $c_id = $this->getRequest()->getParam('id');
 
-            $dialog = $dialogMapper->getReadLastOneDialog($c_id);
-            if ($dialog && $dialog->getUserOne() != $this->getUser()->getId()) {
-                $model = new DialogModel();
-                $model->setCrId($dialog->getCrId())
-                    ->setRead(1);
-                $dialogMapper->updateRead($model);
-            }
+            $dialogMapper->markAllAsRead($c_id, $this->getUser()->getId());
 
             $this->getView()->set('inbox', $dialogMapper->getDialogMessage($c_id));
         }

--- a/application/modules/user/mappers/Dialog.php
+++ b/application/modules/user/mappers/Dialog.php
@@ -388,12 +388,15 @@ class Dialog extends \Ilch\Mapper
 
         // Dialog couldn't be really deleted as other user still uses it.
         // Hide the dialog and set it as permanently hidden (to make it later look like deleted).
+        // Additionally, mark all messages of the other user as read.
         $this->hideDialog($c_id, $userId);
 
         $this->db()->update('users_dialog_hidden')
             ->values(['permanent' => 1])
             ->where(['c_id' => $c_id, 'user_id' => $userId])
             ->execute();
+
+        $this->markAllAsRead($c_id, $userId);
     }
 
     /**
@@ -600,20 +603,16 @@ class Dialog extends \Ilch\Mapper
     }
 
     /**
-     * Updates dialog read.
+     * Mark all messages of the other user in a dialog as read.
      *
-     * @param DialogModel $model
+     * @param int $c_id dialog id
+     * @param int $userId id of the user (messages of the other user are getting marked as read)
      */
-    public function updateRead(DialogModel $model)
+    public function markAllAsRead(int $c_id, int $userId)
     {
-        $fields = [
-            'cr_id' => $model->getCrId(),
-            'read' => $model->getRead(),
-        ];
-
         $this->db()->update('users_dialog_reply')
-                ->values($fields)
-                ->where(['cr_id' => $model->getCrId()])
-                ->execute();
+            ->values(['read' => 1])
+            ->where(['c_id_fk' => $c_id, 'user_id_fk <>' => $userId])
+            ->execute();
     }
 }

--- a/application/modules/user/mappers/Dialog.php
+++ b/application/modules/user/mappers/Dialog.php
@@ -421,11 +421,11 @@ class Dialog extends \Ilch\Mapper
      */
     public function hideDialog($c_id, $userId)
     {
-        $dialogHiddenRow = $this->db()->select('*')
+        $dialogHiddenRow = $this->db()->select('c_id')
             ->from('users_dialog_hidden')
             ->where(['c_id' => $c_id, 'user_id' => $userId])
             ->execute()
-            ->fetchRow();
+            ->fetchCell();
 
         if (empty($dialogHiddenRow)) {
             $this->db()->insert('users_dialog_hidden')


### PR DESCRIPTION
# Description

- When user A got a message from user B, but just deletes the chat or reads it in the preview before deleting it, then that message was still shown as unread. Mark all messages as read when deleting the chat.
- When user A deleted a chat and user B writes him again after it, then a new message was shown, but user A was unable to read it.
- When user A received multiple messages from user B while offline or in another tab before returning then updateRead() got called too often - basically marking every single messages as read one by one. This caused unnecessary calls to the database.
- Restore dialogs/chats with unread messages with the ilch update

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [X] Opera
- [ ] Edge
- [ ] IE