### PR TITLE
Add a unit test for two joins

### DIFF
--- a/application/modules/checkoutbasic/config/config.php
+++ b/application/modules/checkoutbasic/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'checkoutbasic',
-        'version' => '1.4.1',
+        'version' => '1.4.2',
         'icon_small' => 'fa-credit-card',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/checkoutbasic/views/admin/index/settings.php
+++ b/application/modules/checkoutbasic/views/admin/index/settings.php
@@ -26,9 +26,11 @@
     <?=$this->getSaveBar('updateButton') ?>
 </form>
 
+<script>
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>') ?>
 
 <?=$this->getMedia()
     ->addMediaButton($this->getUrl('admin/media/iframe/index/type/single/'))
     ->addUploadController($this->getUrl('admin/media/index/upload'))
 ?>
+</script>

--- a/tests/libraries/ilch/Database/Mysql/SelectTest.php
+++ b/tests/libraries/ilch/Database/Mysql/SelectTest.php
@@ -539,4 +539,21 @@ class SelectTest extends \PHPUnit\Framework\TestCase
             ]
         ];
     }
+
+    /**
+     * Test if sql query is correct with two joins.
+     * There was an issue where the second (or more) join started with two spaces.
+     */
+    public function testGenerateSqlForMoreThanOneJoin()
+    {
+        $this->out->from(['a' => 'Test']);
+        $this->out->join(['b' => 'Table2'], 'a.field1 = b.field2');
+        $this->out->join(['c' => 'Table3'], 'a.field1 = c.field2');
+
+        $expectedSql = 'SELECT * FROM `[prefix]_Test` AS `a`'
+            . ' INNER JOIN `[prefix]_Table2` AS `b` ON `a`.`field1` = `b`.`field2`'
+            . ' INNER JOIN `[prefix]_Table3` AS `c` ON `a`.`field1` = `c`.`field2`';
+
+        self::assertEquals($expectedSql, $this->out->generateSql());
+    }
 }


### PR DESCRIPTION
# Description

Just adding a small unit test for two or more joins. Before the commit below a second (or more) join started with two spaces.
https://github.com/IlchCMS/Ilch-2.0/commit/c781cc0c0e0f23bab639b176bf80b5bb79f1a2ea

Before and after the fix:
```
Before:
SELECT * FROM `[prefix]_Test` AS `a` INNER JOIN `[prefix]_Table2` AS `b` ON `a`.`field1` = `b`.`field2`  INNER JOIN `[prefix]_Table3` AS `c` ON `a`.`field1` = `c`.`field2`;

After:
SELECT * FROM `[prefix]_Test` AS `a` INNER JOIN `[prefix]_Table2` AS `b` ON `a`.`field1` = `b`.`field2` INNER JOIN `[prefix]_Table3` AS `c` ON `a`.`field1` = `c`.`field2`;
```