### PR TITLE
Issue 459: Add notifications to away module

### DIFF
--- a/application/modules/away/config/config.php
+++ b/application/modules/away/config/config.php
@@ -32,6 +32,9 @@ class Config extends \Ilch\Config\Install
     public function install()
     {
         $this->db()->queryMulti($this->getInstallSql());
+
+        $databaseConfig = new \Ilch\Config\Database($this->db());
+        $databaseConfig->set('away_adminNotification', 1);
     }
 
     public function uninstall()
@@ -60,7 +63,7 @@ class Config extends \Ilch\Config\Install
             `show` INT(11) NOT NULL,
             PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_away_groups` (
             `group_id` INT(11) NOT NULL,
             INDEX `FK_[prefix]_away_groups_[prefix]_groups` (`group_id`) USING BTREE,
@@ -68,8 +71,10 @@ class Config extends \Ilch\Config\Install
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;';
 
         if ($this->db()->ifTableExists('[prefix]_calendar_events')) {
-            return $installSql.'INSERT INTO `[prefix]_calendar_events` (`url`) VALUES ("away/aways/index/");';
+            $installSql.'INSERT INTO `[prefix]_calendar_events` (`url`) VALUES ("away/aways/index/");';
         }
+
+        return $installSql;
     }
 
     public function getUpdate($installedVersion)
@@ -87,12 +92,15 @@ class Config extends \Ilch\Config\Install
                     $this->db()->query(sprintf("UPDATE `[prefix]_modules_content` SET `description` = '%s' WHERE `key` = 'away' AND `locale` = '%s';", $value['description'], $key));
                 }
 
-                // Create new table for user groups to be notified on new entries.
+                // Create new table for user groups to be notified on new entries and enable notifications for administrators by default.
                 $this->db()->query('CREATE TABLE IF NOT EXISTS `[prefix]_away_groups` (
                         `group_id` INT(11) NOT NULL,
                         INDEX `FK_[prefix]_away_groups_[prefix]_groups` (`group_id`) USING BTREE,
                         CONSTRAINT `FK_[prefix]_away_groups_[prefix]_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
                         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;');
+
+                $databaseConfig = new \Ilch\Config\Database($this->db());
+                $databaseConfig->set('away_adminNotification', 1);
         }
     }
 }

--- a/application/modules/away/controllers/Index.php
+++ b/application/modules/away/controllers/Index.php
@@ -93,9 +93,9 @@ class Index extends \Ilch\Controller\Frontend
 
                     foreach ($users as $user) {
                         // Don't notify the user that just created the new entry.
-//                        if ($currentUserId === $user->getId()) {
-//                            continue;
-//                        }
+                        if ($currentUserId === $user->getId()) {
+                            continue;
+                        }
 
                         $notification = new UserNotificationModel();
                         $notification->setUserId($user->getId());
@@ -144,6 +144,7 @@ class Index extends \Ilch\Controller\Frontend
             if ($this->getConfig()->get('away_userNotification')) {
                 $userNotificationsMapper = new UserNotificationsMapper();
                 $awayGroupMapper = new AwayGroupMapper();
+                $userMapper = new UserMapper();
 
                 $notifications = [];
                 $userGroups = $awayGroupMapper->getGroups();

--- a/application/modules/away/controllers/admin/Index.php
+++ b/application/modules/away/controllers/admin/Index.php
@@ -7,7 +7,10 @@
 namespace Modules\Away\Controllers\Admin;
 
 use Modules\Away\Mappers\Away as AwayMapper;
+use Modules\Away\Mappers\Groups as AwayGroupMapper;
+use Modules\User\Mappers\Notifications as UserNotificationsMapper;
 use Modules\User\Mappers\User as UserMapper;
+use Modules\User\Models\Notification as UserNotificationModel;
 
 class Index extends \Ilch\Controller\Admin
 {
@@ -19,6 +22,12 @@ class Index extends \Ilch\Controller\Admin
                 'active' => true,
                 'icon' => 'fa fa-th-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+            ],
+            [
+                'name' => 'settings',
+                'active' => false,
+                'icon' => 'fa fa-cogs',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
             ]
         ];
 
@@ -38,11 +47,9 @@ class Index extends \Ilch\Controller\Admin
                 ->add($this->getTranslator()->trans('menuAway'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('manage'), ['action' => 'index']);
 
-        if ($this->getRequest()->getPost('check_aways')) {
-            if ($this->getRequest()->getPost('action') == 'delete') {
-                foreach ($this->getRequest()->getPost('check_aways') as $id) {
-                    $awayMapper->delete($id);
-                }
+        if ($this->getRequest()->getPost('check_aways') && $this->getRequest()->getPost('action') === 'delete') {
+            foreach ($this->getRequest()->getPost('check_aways') as $id) {
+                $awayMapper->delete($id);
             }
         }
 
@@ -50,7 +57,7 @@ class Index extends \Ilch\Controller\Admin
         $aways = $awayMapper->getAway();
 
         foreach ($aways as $away) {
-            if (!array_key_exists($away->getUserId(), $userCache)) {
+            if (!\array_key_exists($away->getUserId(), $userCache)) {
                 $userCache[$away->getUserId()] = $userMapper->getUserById($away->getUserId());
             }
         }
@@ -64,6 +71,35 @@ class Index extends \Ilch\Controller\Admin
         if ($this->getRequest()->isSecure()) {
             $awayMapper = new AwayMapper();
             $awayMapper->update($this->getRequest()->getParam('id'));
+
+            if ($this->getConfig()->get('away_userNotification')) {
+                $userNotificationsMapper = new UserNotificationsMapper();
+                $awayGroupMapper = new AwayGroupMapper();
+
+                $notifications = [];
+                $userGroups = $awayGroupMapper->getGroups();
+                $users = $userMapper->getUserListByGroupId($userGroups, 1);
+                // Users might be in several groups. Remove duplicates so each user only gets one notification.
+                $users = array_unique($users, SORT_REGULAR);
+                $currentUserId = $this->getUser()->getId();
+
+                foreach ($users as $user) {
+                    // Don't notify the user that just changed the entry.
+                    if ($currentUserId === $user->getId()) {
+                        continue;
+                    }
+
+                    $notification = new UserNotificationModel();
+                    $notification->setUserId($user->getId());
+                    $notification->setModule('away');
+                    $notification->setMessage($this->getLayout()->getTrans('awayChangedEntryMessage'));
+                    $notification->setURL($this->getLayout()->getUrl(['module' => 'away', 'controller' => 'index', 'action' => 'index']));
+                    $notification->setType('awayChangedEntry');
+                    $notifications[] = $notification;
+                }
+
+                $userNotificationsMapper->addNotifications($notifications);
+            }
 
             $this->addMessage('saveSuccess');
         }

--- a/application/modules/away/controllers/admin/Index.php
+++ b/application/modules/away/controllers/admin/Index.php
@@ -75,6 +75,7 @@ class Index extends \Ilch\Controller\Admin
             if ($this->getConfig()->get('away_userNotification')) {
                 $userNotificationsMapper = new UserNotificationsMapper();
                 $awayGroupMapper = new AwayGroupMapper();
+                $userMapper = new UserMapper();
 
                 $notifications = [];
                 $userGroups = $awayGroupMapper->getGroups();

--- a/application/modules/away/controllers/admin/Settings.php
+++ b/application/modules/away/controllers/admin/Settings.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Away\Controllers\Admin;
+
+use Ilch\Validation;
+use Modules\User\Mappers\Group as GroupMapper;
+use Modules\Away\Mappers\Groups as AwayGroupsMapper;
+
+class Settings extends \Ilch\Controller\Admin
+{
+    public function init()
+    {
+        $items = [
+            [
+                'name' => 'manage',
+                'active' => false,
+                'icon' => 'fa fa-th-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+            ],
+            [
+                'name' => 'settings',
+                'active' => true,
+                'icon' => 'fa fa-cogs',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
+            ]
+        ];
+
+        $this->getLayout()->addMenu
+        (
+            'menuAway',
+            $items
+        );
+    }
+
+    public function indexAction()
+    {
+        $groupMapper = new GroupMapper();
+        $awayGroupsMapper = new AwayGroupsMapper();
+
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('menuAway'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('manage'), ['action' => 'index']);
+
+        if ($this->getRequest()->isPost()) {
+            $rules = [
+                'userNotification' => 'numeric|integer|min:0|max:1',
+                'adminNotification' => 'numeric|integer|min:0|max:1',
+            ];
+
+            if ($this->getRequest()->getPost('userNotification')) {
+                $rules['notifyGroups'] = 'required';
+            }
+
+            $validation = Validation::create($this->getRequest()->getPost(), $rules);
+
+            if ($validation->isValid()) {
+                $this->getConfig()->set('away_userNotification', $this->getRequest()->getPost('userNotification'));
+                $this->getConfig()->set('away_adminNotification', $this->getRequest()->getPost('adminNotification'));
+
+                if ($this->getRequest()->getPost('notifyGroups')) {
+                    $awayGroupsMapper->save($this->getRequest()->getPost('notifyGroups'));
+                }
+
+                $this->redirect()
+                    ->withMessage('saveSuccess')
+                    ->to(['action' => 'index']);
+            }
+
+            $this->addMessage($validation->getErrorBag()->getErrorMessages(), 'danger', true);
+            $this->redirect()
+                ->withInput()
+                ->withErrors($validation->getErrorBag())
+                ->to(['action' => 'index']);
+        }
+
+        $groups = $awayGroupsMapper->getGroups();
+
+        if ($groups === null) {
+            $groups = [1,2];
+        }
+
+        $userGroupList = $groupMapper->getGroupList();
+
+        // Remove the user group 'guest'.
+        foreach ($userGroupList as $index => $userGroup) {
+            if ($userGroup->getId() === 3) {
+                array_splice($userGroupList, $index, 1);
+                break;
+            }
+        }
+
+        $this->getView()->set('userNotification', $this->getConfig()->get('away_userNotification'))
+            ->set('notifyGroups', $this->getConfig()->get('away_notifyGroups'))
+            ->set('adminNotification', $this->getConfig()->get('away_adminNotification'))
+            ->set('groups', $groups)
+            ->set('userGroupList', $userGroupList);
+    }
+}

--- a/application/modules/away/mappers/Away.php
+++ b/application/modules/away/mappers/Away.php
@@ -62,9 +62,7 @@ class Away extends \Ilch\Mapper
 
     public function existsTable($table)
     {
-        $module = $this->db()->ifTableExists('[prefix]_'.$table);
-
-        return $module;
+        return $this->db()->ifTableExists('[prefix]_'.$table);
     }
 
     /**

--- a/application/modules/away/mappers/Groups.php
+++ b/application/modules/away/mappers/Groups.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ * @since 1.5.0
+ */
+
+namespace Modules\Away\Mappers;
+
+class Groups extends \Ilch\Mapper
+{
+    /**
+     * Get all groups that are subscribed to notifications.
+     *
+     * @return array|null
+     */
+    public function getGroups()
+    {
+        return $this->db()->select('*')
+            ->from('away_groups')
+            ->execute()
+            ->fetchList();
+    }
+
+    /**
+     * Save groups to be notified in case of a new entry or changes to it.
+     * Replaces current groups with the ones provided.
+     *
+     * @param array $groups
+     * @return int
+     */
+    public function save(array $groups): int
+    {
+        $affectedRows = 0;
+        $this->db()->truncate('away_groups');
+        $chunks = array_chunk($groups, 25);
+
+        foreach ($chunks as $chunk) {
+            $affectedRows += $this->db()->insert('away_groups')
+                ->columns(['group_id'])
+                ->values($chunk)
+                ->execute();
+        }
+
+        return $affectedRows;
+    }
+
+    /**
+     * Add new groups to be notified.
+     * Only adds new groups.
+     *
+     * @param array $groups
+     * @return int
+     */
+    public function addGroups(array $groups): int
+    {
+        $affectedRows = 0;
+        $existingGroups = $this->getGroups();
+        $groupsToAdd = array_diff($groups, $existingGroups);
+        $chunks = array_chunk($groupsToAdd, 25);
+
+        foreach ($chunks as $chunk) {
+            $affectedRows += $this->db()->insert('away_groups')
+                ->columns(['group_id'])
+                ->values($chunk)
+                ->execute();
+        }
+
+        return $affectedRows;
+    }
+}

--- a/application/modules/away/translations/de.php
+++ b/application/modules/away/translations/de.php
@@ -6,6 +6,9 @@
 
 return [
     'menuAway' => 'Abwesenheitsliste',
+    'adminNotification' => 'Administratoren bei neuen Eintrag benachrichtigen',
+    'userNotification' => 'Benutzergruppen bei neuen Eintrag benachrichtigen',
+    'notifyGroups' => 'Zu benachrichtigende Benutzergruppen',
     'menuEntry' => 'Eintragen',
     'noAway' => 'Keine Einträge vorhanden',
     'from' => 'Von',
@@ -21,4 +24,10 @@ return [
     'addButton' => 'Eintragen',
     'calendarShow' => 'Im Kalender anzeigen?',
     'unknown' => 'Unbekannt',
+    'awayAdminNewEntry' => 'Neuer Eintrag',
+    'awayAdminNewEntryMessage' => 'Neuer Eintrag wartet auf Freigabe.',
+    'awayNewEntry' => 'Neuer Eintrag',
+    'awayNewEntryMessage' => 'Neuer Eintrag in Abwesenheitsliste.',
+    'awayChangedEntry' => 'Status eines Eintrages geändert',
+    'awayChangedEntryMessage' => 'Der Status eines Eintrages in der Abwesenheitsliste hat sich geändert.',
 ];

--- a/application/modules/away/translations/de.php
+++ b/application/modules/away/translations/de.php
@@ -7,7 +7,7 @@
 return [
     'menuAway' => 'Abwesenheitsliste',
     'adminNotification' => 'Administratoren bei neuen Eintrag benachrichtigen',
-    'userNotification' => 'Benutzergruppen bei neuen Eintrag benachrichtigen',
+    'userNotification' => 'Benutzergruppen benachrichtigen',
     'notifyGroups' => 'Zu benachrichtigende Benutzergruppen',
     'menuEntry' => 'Eintragen',
     'noAway' => 'Keine Einträge vorhanden',

--- a/application/modules/away/translations/en.php
+++ b/application/modules/away/translations/en.php
@@ -6,6 +6,9 @@
 
 return [
     'menuAway' => 'Away list',
+    'adminNotification' => 'Notify administrators of new entries',
+    'userNotification' => 'Notify users of new entries',
+    'notifyGroups' => 'Notify these user groups',
     'menuEntry' => 'Entry',
     'noAway' => 'No entries available',
     'from' => 'From',
@@ -21,4 +24,10 @@ return [
     'addButton' => 'Entry',
     'calendarShow' => 'Show in the calendar?',
     'unknown' => 'unknown',
+    'awayAdminNewEntry' => 'New entry',
+    'awayAdminNewEntryMessage' => 'New entry waiting for approval.',
+    'awayNewEntry' => 'New entry',
+    'awayNewEntryMessage' => 'New entry in the away list.',
+    'awayChangedEntry' => 'Status of entry changed',
+    'awayChangedEntryMessage' => 'The status of an entry in the away list has changed.',
 ];

--- a/application/modules/away/translations/en.php
+++ b/application/modules/away/translations/en.php
@@ -7,7 +7,7 @@
 return [
     'menuAway' => 'Away list',
     'adminNotification' => 'Notify administrators of new entries',
-    'userNotification' => 'Notify users of new entries',
+    'userNotification' => 'Notify users',
     'notifyGroups' => 'Notify these user groups',
     'menuEntry' => 'Entry',
     'noAway' => 'No entries available',

--- a/application/modules/away/views/admin/index/index.php
+++ b/application/modules/away/views/admin/index/index.php
@@ -50,7 +50,7 @@
                             <?php endif; ?>
                             <?php $startDate = new \Ilch\Date($away->getStart()); ?>
                             <?php $endDate = new \Ilch\Date($away->getEnd()); ?>
-                            <?php if ($away->getStart() >= date('Y-m-d') OR $away->getEnd() >= date('Y-m-d')): ?>
+                            <?php if ($away->getStart() >= date('Y-m-d') || $away->getEnd() >= date('Y-m-d')): ?>
                                 <td style="color: #008000;"><?=$startDate->format('d.m.Y', true) ?> - <?=$endDate->format('d.m.Y', true) ?></td>
                             <?php else: ?>
                                 <td style="color: #ff0000;"><?=$startDate->format('d.m.Y', true) ?> - <?=$endDate->format('d.m.Y', true) ?></td>

--- a/application/modules/away/views/admin/settings/index.php
+++ b/application/modules/away/views/admin/settings/index.php
@@ -1,0 +1,57 @@
+<h1><?=$this->getTrans('settings') ?></h1>
+<form class="form-horizontal" method="POST">
+    <?=$this->getTokenField() ?>
+    <div class="form-group <?=$this->validation()->hasError('adminNotification') ? 'has-error' : '' ?>">
+        <div class="col-lg-2 control-label">
+            <?=$this->getTrans('adminNotification') ?>
+        </div>
+        <div class="col-lg-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="adminNotification-on" name="adminNotification" value="1" <?php if ($this->get('adminNotification') === '1') { echo 'checked="checked"'; } ?> />
+                <label for="adminNotification-on" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('on') ?></label>
+                <input type="radio" class="flipswitch-input" id="adminNotification-off" name="adminNotification" value="0" <?php if ($this->get('adminNotification') !== '1') { echo 'checked="checked"'; } ?> />
+                <label for="adminNotification-off" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('off') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+        </div>
+    </div>
+    <div class="form-group <?=$this->validation()->hasError('userNotification') ? 'has-error' : '' ?>">
+        <div class="col-lg-2 control-label">
+            <?=$this->getTrans('userNotification') ?>
+        </div>
+        <div class="col-lg-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="userNotification-on" name="userNotification" value="1" <?php if ($this->get('userNotification') === '1') { echo 'checked="checked"'; } ?> />
+                <label for="userNotification-on" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('on') ?></label>
+                <input type="radio" class="flipswitch-input" id="userNotification-off" name="userNotification" value="0" <?php if ($this->get('userNotification') !== '1') { echo 'checked="checked"'; } ?> />
+                <label for="userNotification-off" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('off') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+        </div>
+    </div>
+    <div id="notifyGroupsDiv" class="form-group <?=$this->validation()->hasError('notifyGroups') ? 'has-error' : '' ?> <?php if ($this->get('userNotification') !== '1') { echo 'hidden'; } ?>">
+        <label for="notifyGroups" class="col-lg-2 control-label">
+            <?=$this->getTrans('notifyGroups') ?>
+        </label>
+        <div class="col-lg-4">
+            <select class="chosen-select form-control" id="notifyGroups" name="notifyGroups[]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>
+                <?php foreach ($this->get('userGroupList') as $groupList): ?>
+                    <option value="<?=$groupList->getId() ?>"<?=(in_array($groupList->getId(), $this->get('groups'))) ? ' selected' : '' ?>><?=$groupList->getName() ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+    </div>
+    <?=$this->getSaveBar() ?>
+</form>
+
+<script>
+    $('#notifyGroups').chosen();
+
+    $('[name="userNotification"]').click(function () {
+        if ($(this).val() == "1") {
+            $('#notifyGroupsDiv').removeClass('hidden');
+        } else {
+            $('#notifyGroupsDiv').addClass('hidden');
+        }
+    });
+</script>

--- a/application/modules/away/views/aways/index.php
+++ b/application/modules/away/views/aways/index.php
@@ -8,7 +8,7 @@ if ($this->get('awayList')) {
         $e['title'] = $this->escape($awayList->getReason());
         $e['start'] = $awayList->getStart().' 00:00:00';
         $e['end'] = $awayList->getEnd().' 23:59:59';
-        if ($awayList->getStatus() == 0 OR $awayList->getStatus() == 2) {
+        if ($awayList->getStatus() == 0 || $awayList->getStatus() == 2) {
             $e['color'] = '#DF0101';
         } else {
             $e['color'] = '#04B404';

--- a/application/modules/away/views/index/index.php
+++ b/application/modules/away/views/index/index.php
@@ -41,7 +41,7 @@ if ($this->getUser()) {
                             </td>
                             <?php $startDate = new \Ilch\Date($away->getStart()); ?>
                             <?php $endDate = new \Ilch\Date($away->getEnd()); ?>
-                            <?php if ($away->getStart() >= date('Y-m-d') OR $away->getEnd() >= date('Y-m-d')): ?>
+                            <?php if ($away->getStart() >= date('Y-m-d') || $away->getEnd() >= date('Y-m-d')): ?>
                                 <?php $style = 'color: #008000; border-right: 1px solid #dddddd; border-left: 1px solid #dddddd;'?>
                             <?php else: ?>
                                 <?php $style = 'color: #ff0000; border-right: 1px solid #dddddd; border-left: 1px solid #dddddd;'?>
@@ -69,7 +69,7 @@ if ($this->getUser()) {
                             <td>
                                 <?php if ($this->getUser()): ?>
                                     <?php if ($userCheck->isAdmin()): ?>
-                                        <?php if ($away->getStart() >= date('Y-m-d') OR $away->getEnd() >= date('Y-m-d')): ?>
+                                        <?php if ($away->getStart() >= date('Y-m-d') || $away->getEnd() >= date('Y-m-d')): ?>
                                             <?php if ($away->getStatus() == 1): ?>
                                                 <a href="<?=$this->getUrl(['action' => 'update', 'id' => $away->getId()], null, true) ?>">
                                                     <span class="fa fa-check-square-o text-info"></span>
@@ -85,7 +85,7 @@ if ($this->getUser()) {
                             </td>
                             <td>
                                 <?php if ($this->getUser()): ?>
-                                    <?php if ($away->getUserId() == $this->getUser()->getId() OR $userCheck->isAdmin()): ?>
+                                    <?php if ($userCheck->isAdmin() || $away->getUserId() == $this->getUser()->getId()): ?>
                                         <?=$this->getDeleteIcon(['action' => 'del', 'id' => $away->getId()]) ?>
                                     <?php endif; ?>
                                 <?php endif; ?>
@@ -108,7 +108,7 @@ if ($this->getUser()) {
 <?php if ($this->getUser()): ?>
     <form class="form-horizontal" method="POST" action="">
         <?=$this->getTokenField() ?>
-        <h1><?=$this->getTrans('menuEntry'); ?></h1>
+        <h1><?=$this->getTrans('menuEntry') ?></h1>
 
         <div class="form-group <?=in_array('reason', $this->get('errorFields')) ? 'has-error' : '' ?>">
             <label for="reason" class="col-lg-2 control-label">
@@ -181,7 +181,7 @@ if ($this->getUser()) {
 <?php endif; ?>
 
 <script src="<?=$this->getStaticUrl('js/datetimepicker/js/bootstrap-datetimepicker.min.js') ?>" charset="UTF-8"></script>
-<?php if (substr($this->getTranslator()->getLocale(), 0, 2) != 'en'): ?>
+<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0): ?>
     <script src="<?=$this->getStaticUrl('js/datetimepicker/js/locales/bootstrap-datetimepicker.'.substr($this->getTranslator()->getLocale(), 0, 2).'.js') ?>" charset="UTF-8"></script>
 <?php endif; ?>
 <script>

--- a/tests/libraries/ilch/Database/Mysql/InsertTest.php
+++ b/tests/libraries/ilch/Database/Mysql/InsertTest.php
@@ -79,11 +79,35 @@ class InsertTest extends \PHPUnit\Framework\TestCase
         self::assertEquals($expected, $this->out->generateSql());
     }
 
+    public function testGenerateSqlForValuesMultipleRowsOneColumn()
+    {
+        $this->out->into('Test')
+            ->columns(['super'])
+            ->values(['data', 'data2', 'data3']);
+
+        $expected = 'INSERT INTO `[prefix]_Test` '
+            . '(`super`) VALUES ("data"),("data2"),("data3")';
+
+        self::assertEquals($expected, $this->out->generateSql());
+    }
+
     public function testGenerateSqlForValuesMultipleRowsInvalidCount()
     {
         $this->out->into('Test')
             ->columns(['super', 'next'])
             ->values([['data'], ['data2', 'fieldData2']]);
+
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('count of values does not fit the count of columns');
+
+        $this->out->generateSql();
+    }
+
+    public function testGenerateSqlForValuesMultipleRowsMoreValuesThanColums()
+    {
+        $this->out->into('Test')
+            ->columns(['super'])
+            ->values([['data1', 'fieldData1'], ['data2', 'fieldData2']]);
 
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('count of values does not fit the count of columns');

--- a/tests/modules/away/_files/mysql_database.yml
+++ b/tests/modules/away/_files/mysql_database.yml
@@ -1,0 +1,5 @@
+away_groups:
+  -
+    group_id: 1
+  -
+    group_id: 2

--- a/tests/modules/away/mappers/GroupsTest.php
+++ b/tests/modules/away/mappers/GroupsTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Modules\Away\Mappers;
+
+use PHPUnit\Ilch\DatabaseTestCase;
+use PHPUnit\Ilch\PhpunitDataset;
+use Modules\Admin\Config\Config as AdminConfig;
+use Modules\Away\Config\Config as ModuleConfig;
+use Modules\Away\Mappers\Groups as GroupMapper;
+use Modules\User\Config\Config as UserConfig;
+
+class GroupsTest extends DatabaseTestCase
+{
+    /**
+     * @var GroupMapper
+     */
+    protected $out;
+    protected $phpunitDataset;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
+        $this->out = new GroupMapper();
+    }
+
+    /**
+     * Tests if getGroups() returns all groups.
+     */
+    public function testGetGroups()
+    {
+        self::assertCount(2, $this->out->getGroups());
+    }
+
+    /**
+     * Tests if the groups get saved.
+     */
+    public function testSave()
+    {
+        $affectedRows = $this->out->save([1,2,3]);
+        $groups = $this->out->getGroups();
+
+        self::assertEquals(3, $affectedRows);
+        self::assertEquals([1,2,3], $groups);
+        self::assertCount(3, $groups);
+    }
+
+    /**
+     * Tests if the new group gets added properly.
+     */
+    public function addGroups()
+    {
+        $affectedRows = $this->out->addGroups([3]);
+        $groups = $this->out->getGroups();
+
+        self::assertEquals(3, $affectedRows);
+        self::assertEquals([1,2,3], $groups);
+        self::assertCount(3, $groups);
+    }
+
+    /**
+     * Returns database schema sql statements to initialize database
+     *
+     * @return string
+     */
+    protected static function getSchemaSQLQueries()
+    {
+        $config = new ModuleConfig();
+        $userConfig = new UserConfig();
+        $adminConfig = new AdminConfig();
+
+        return $adminConfig->getInstallSql().$userConfig->getInstallSql().$config->getInstallSql();
+    }
+}


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/18415497/133886676-fa180732-1a64-4920-a80d-6ca84db45c1d.png)

- Added optional notifications of administrators and/or user groups in case of new entries or changed status of entries in the away list. By default notifications for administrators are enabled (notification in the admincenter).
- Added unit tests for the new "groups" mapper
- QueryBuilder: Inserting multiple rows of just one column failed.
- QueryBuilder: Added a few more unit tests.

Fixes #459 

ToDo:
- ~~More notifications?~~

Asking for feedback.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [X] Opera
- [ ] Edge
- [ ] IE
