### PR TITLE
Benutzergruppen im Frontend anzeigen

### DIFF
--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -59,7 +59,8 @@ class Config extends \Ilch\Config\Install
             ->set('usergallery_allowed', '1')
             ->set('usergallery_uploadpath', 'application/modules/user/static/upload/gallery/')
             ->set('usergallery_filetypes', 'jpg jpeg png gif')
-            ->set('userdeletetime', '5');
+            ->set('userdeletetime', '5')
+            ->set('userGroupList_allowed', '0');
 
         $userMapper = new UserMapper();
         $groupMapper = new GroupMapper();
@@ -591,6 +592,8 @@ class Config extends \Ilch\Config\Install
                     CONSTRAINT `FK_[prefix]_users_notifications_permission_[prefix]_modules` FOREIGN KEY (`module`) REFERENCES `[prefix]_modules` (`key`) ON UPDATE NO ACTION ON DELETE CASCADE,
                     CONSTRAINT `FK_[prefix]_users_notifications_permission_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
+                $databaseConfig = new \Ilch\Config\Database($this->db());
+                $databaseConfig = new \Ilch\Config\Database($this->db('userGroupList_allowed','0'));
                 break;
         }
     }

--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -593,7 +593,7 @@ class Config extends \Ilch\Config\Install
                     CONSTRAINT `FK_[prefix]_users_notifications_permission_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
                 $databaseConfig = new \Ilch\Config\Database($this->db());
-                $databaseConfig = new \Ilch\Config\Database($this->db('userGroupList_allowed','0'));
+                $databaseConfig->set('userGroupList_allowed','0');
                 break;
         }
     }


### PR DESCRIPTION
In der Mitgliederliste im Frontend werden die Benutzergruppen mit angezeigt in welcher die User sind. 
Bei Bedarf kann die Ansicht in den Settings  ein -/ ausgeschaltet werden.

Ein User im Forum hatte sich dieses gewünscht :)