### PR TITLE
Update vagrant and fix unit test

### DIFF
--- a/development/vagrant/Vagrantfile
+++ b/development/vagrant/Vagrantfile
@@ -6,9 +6,9 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if Vagrant.has_plugin?("vagrant-vbguest")
-    config.vm.box = "generic/debian10"
+    config.vm.box = "generic/debian11"
   else
-    config.vm.box = "debian/contrib-buster64"
+    config.vm.box = "debian/contrib-bullseye64"
   end
 
   config.vm.network "forwarded_port", guest: 80, host: 8080

--- a/development/vagrant/scripts/install.sh
+++ b/development/vagrant/scripts/install.sh
@@ -42,7 +42,7 @@ echo "CREATE DATABASE ilch2; CREATE DATABASE ilch2test;" | mysql -uroot -proot
 apt-get -y install php php-curl php-gd php-intl php-mbstring php-mysql php-xdebug php-xml php-zip libapache2-mod-php
 
 # configure xdebug fore remote debugging
-cat /vagrant/development/vagrant/xdebug.ini | tee -a /etc/php/7.3/mods-available/xdebug.ini > /dev/null
+cat /vagrant/development/vagrant/xdebug.ini | tee -a /etc/php/7.4/mods-available/xdebug.ini > /dev/null
 
 # configure web server
 cp -f /vagrant/development/vagrant/000-default.conf /etc/apache2/sites-available/

--- a/development/vagrant/scripts/install_mailhog.sh
+++ b/development/vagrant/scripts/install_mailhog.sh
@@ -11,13 +11,13 @@ chown mail:mail /opt/mailhog
 wget -q -O /opt/mailhog/mailhog https://github.com/mailhog/MailHog/releases/download/${VERSION}/MailHog_linux_amd64
 chmod +x /opt/mailhog/mailhog
 
-cat > /etc/php/7.3/mods-available/mailhog.ini <<'EOF'
+cat > /etc/php/7.4/mods-available/mailhog.ini <<'EOF'
 ; Mailhog replacement for sendmail -t -i
 sendmail_path = "/opt/mailhog/mailhog sendmail"
 EOF
 
-ln -s /etc/php/7.3/mods-available/mailhog.ini /etc/php/7.3/apache2/conf.d/20-mailhog.ini
-ln -s /etc/php/7.3/mods-available/mailhog.ini /etc/php/7.3/cli/conf.d/20-mailhog.ini
+ln -s /etc/php/7.4/mods-available/mailhog.ini /etc/php/7.4/apache2/conf.d/20-mailhog.ini
+ln -s /etc/php/7.4/mods-available/mailhog.ini /etc/php/7.4/cli/conf.d/20-mailhog.ini
 
 cat > /etc/init.d/mailhog <<'EOF'
 #! /bin/sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,14 +15,14 @@ Hier gibts Antworten [PHPUnit](http://phpunit.de/manual/current/en/)
         * Für Datenbanktests werden entsprechende Configeinträge benötigt!
 
         ```php
-		<?php
-		// Config for tests
-		$config["dbEngine"] = "Mysql";
-		$config["dbHost"] = "localhost";
-		$config["dbUser"] = "root";
-		$config["dbPassword"] = "root";
-		$config["dbName"] = "ilch2test";
-		$config["dbPrefix"] = "";
+        <?php
+        // Config for tests
+        $config["dbEngine"] = "Mysql";
+        $config["dbHost"] = "localhost";
+        $config["dbUser"] = "root";
+        $config["dbPassword"] = "root";
+        $config["dbName"] = "ilch2test";
+        $config["dbPrefix"] = "";
         ```
 
 3. **xDebug auf dem Server aktivieren.**

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,13 +15,14 @@ Hier gibts Antworten [PHPUnit](http://phpunit.de/manual/current/en/)
         * Für Datenbanktests werden entsprechende Configeinträge benötigt!
 
         ```php
-        // Config for tests
-        $config["dbEngine"] = "Mysql";
-        $config["dbHost"] = "localhost";
-        $config["dbUser"] = "ilch2test";
-        $config["dbPassword"] = "ilch2test";
-        $config["dbName"] = "ilch2test";
-        $config["dbPrefix"] = "";
+		<?php
+		// Config for tests
+		$config["dbEngine"] = "Mysql";
+		$config["dbHost"] = "localhost";
+		$config["dbUser"] = "root";
+		$config["dbPassword"] = "root";
+		$config["dbName"] = "ilch2test";
+		$config["dbPrefix"] = "";
         ```
 
 3. **xDebug auf dem Server aktivieren.**

--- a/tests/libraries/ilch/RouterTest.php
+++ b/tests/libraries/ilch/RouterTest.php
@@ -37,9 +37,9 @@ class RouterTest extends TestCase
         $pattern = Router::DEFAULT_REGEX_PATTERN;
         $pattern = '#^' . $pattern . '$#i';
 
-        self::assertMatchesRegularExpression($pattern, 'module/controller');
-        self::assertMatchesRegularExpression($pattern, 'module/controller/action');
-        self::assertMatchesRegularExpression($pattern, 'module/controller/action/param1/value1/param2/value2');
+        self::assertRegExp($pattern, 'module/controller');
+        self::assertRegExp($pattern, 'module/controller/action');
+        self::assertRegExp($pattern, 'module/controller/action/param1/value1/param2/value2');
     }
 
     public function testParamConvertingIntoArray()


### PR DESCRIPTION
# Description

- Update Vagrant to Debian 11.
- assertMatchesRegularExpression() is not available in older versions of PHPUnit. Vagrant and GitHub Actions use PHPUnit in version 5.7.27
- Wrong username and password in readme for running unit tests

> 1) Ilch\RouterTest::testDefaultRegexpPattern
> Error: Call to undefined method Ilch\RouterTest::assertMatchesRegularExpression()
>
> /vagrant/tests/libraries/ilch/RouterTest.php:40
> /vagrant/vendor/sminnee/phpunit/phpunit:51

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

@hhunderter 
Wie führst du Unittests aus? Nutzt du eine neuere Version von PHPUnit?
