### PR TITLE
Build pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,9 @@
 *.sh eol=lf
 
 # Files to ignore for archive creation
+/.github export-ignore
 /development export-ignore
+/build export-ignore
 /tests export-ignore
 /.travis.yml export-ignore
 /phpcs.xml export-ignore

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - build-pipeline # TODO: remove
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - build-pipeline
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
@@ -45,7 +44,7 @@ jobs:
           path: |
             Ilch-2.zip
       - name: Upload archive to ilch.de
-        if: ${{ github.ref_name == 'build-pipeline' }}
+        if: ${{ github.ref_name == 'master' }}
         uses: wlixcc/SFTP-Deploy-Action@v1.2.4
         with:
           username: 'ilch2'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - build-pipeline
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
@@ -37,12 +38,22 @@ jobs:
         run: |
           git archive --format=zip HEAD > Ilch-2.zip
           zip -q -r Ilch-2.zip vendor
-      - name: Archive production artifacts
+      - name: Archive artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ilch2-zip
           path: |
             Ilch-2.zip
+      - name: Upload archive to ilch.de
+        if: ${{ github.ref_name == 'build-pipeline' }}
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+        with:
+          username: 'ilch2'
+          server: 'ilch.de'
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          local_path: './Ilch-2.zip'
+          remote_path: '/versions/master.zip'
+          sftpArgs: '-o ConnectTimeout=5'
 
   create-draft:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,7 @@ jobs:
           server: 'ilch.de'
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
           local_path: './Ilch-2.zip'
+          sftp_only: true
           remote_path: '/versions/master.zip'
           sftpArgs: '-o ConnectTimeout=5'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - build-pipeline # TODO: remove
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
@@ -37,7 +36,7 @@ jobs:
       - name: Create archive
         run: |
           git archive --format=zip HEAD > Ilch-2.zip
-          zip -r Ilch-2.zip vendor
+          zip -q -r Ilch-2.zip vendor
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -58,7 +57,7 @@ jobs:
         id: prepare-release
         run: |
           mv Ilch-2.zip Ilch-${{ github.ref_name }}.zip
-          echo "VERSION=${${{ github.ref_name }}/v/}" >> $GITHUB_OUTPUT
+          echo "VERSION=${GITHUB_REF_NAME/v/}" >> $GITHUB_OUTPUT
       - name: Create release draft
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,66 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - build-pipeline # TODO: remove before merge
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          tools: composer
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-php${{ matrix.php-versions }}
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-dev --optimize-autoloader --no-interaction
+      - name: Optimize vendor
+        run: php build/optimize_vendor.php
+      - name: Create archive
+        run: zip -r . Ilch-v2-master.zip
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ilch2-zip
+          path: |
+            Ilch-2.zip
+
+  create-draft:
+    runs-on: ubuntu-20.04
+    needs: [build]
+    if: ${{ github.ref_type == 'tag' }}
+    steps:
+      - name: Download a single artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ilch2-zip
+      - name: Prepare release
+        id: prepare-release
+        run: |
+          mv Ilch-2.zip Ilch-${{ github.ref_name }}.zip
+          echo "VERSION=${${{ github.ref_name }}/v/}" >> $GITHUB_OUTPUT
+      - name: Create release draft
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ format('Ilch-{0}.zip', github.ref_name) }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          name: ${{ format('Version {0}', steps.prepare-release.outputs.VERSION) }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - build-pipeline # TODO: remove before merge
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
@@ -35,7 +34,9 @@ jobs:
       - name: Optimize vendor
         run: php build/optimize_vendor.php
       - name: Create archive
-        run: zip -r . Ilch-v2-master.zip
+        run: |
+          git archive --format=zip HEAD > Ilch-2.zip
+          zip -r Ilch-2.zip vendor
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
# Description

* add GitHub action
  * that creates a Ilch2 archive (on the master branch, should be possible to trigger manually for other branches)
    * There is a limitation when downloading the archive from GitHub actions page, that it is inside a zip folder -> https://github.com/actions/upload-artifact#zipped-artifact-downloads
    * also artifacts will be deleted after 90 days
  * create a release draft when a tag in the form v1.2.3 or v1.2.3-alpha-1 is created
    * archive is attached to that release draft -> example: https://github.com/IlchCMS/Ilch-2.0/releases/tag/untagged-3ed336c0f196dc4998e1

Closes #592 