### PR TITLE
Various fixes

### DIFF
--- a/application/libraries/Ilch/Comments.php
+++ b/application/libraries/Ilch/Comments.php
@@ -27,10 +27,10 @@ class Comments
         if (!isset($this->userCache[$userId])) {
             $userMapper = new UserMapper();
             $this->userCache[$userId] = $userMapper->getUserById($userId);
-        }
 
-        if (!isset($this->userCache[$userId])) {
-            return $userMapper->getDummyUser();
+            if (!isset($this->userCache[$userId])) {
+                return $userMapper->getDummyUser();
+            }
         }
 
         return $this->userCache[$userId];

--- a/application/libraries/Ilch/Mail.php
+++ b/application/libraries/Ilch/Mail.php
@@ -338,7 +338,7 @@ class Mail
      */
     public function addStringAttachment($string, $filename)
     {
-        $this->stringAttachments[] = ['string' => $path, 'filename' => $name];
+        $this->stringAttachments[] = ['string' => $string, 'filename' => $filename];
         return $this;
     }
 

--- a/application/modules/article/mappers/Category.php
+++ b/application/modules/article/mappers/Category.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -51,6 +51,10 @@ class Category extends \Ilch\Mapper
     {
         $cats = $this->getCategories(['id' => $id]);
 
+        if ($cats == null) {
+            return false;
+        }
+
         return reset($cats);
     }
 
@@ -72,6 +76,7 @@ class Category extends \Ilch\Mapper
      * Inserts or updates category model.
      *
      * @param CategoryModel $category
+     * @return int id of the category
      */
     public function save(CategoryModel $category)
     {
@@ -80,13 +85,15 @@ class Category extends \Ilch\Mapper
                 ->values(['name' => $category->getName()])
                 ->where(['id' => $category->getId()])
                 ->execute();
+
+            return $category->getId();
         } else {
             $lastSort = $this->db()->select('MAX(`sort`) AS maxSort')
                 ->from('articles_cats')
                 ->execute()
                 ->fetchAssoc();
 
-            $this->db()->insert('articles_cats')
+            return $this->db()->insert('articles_cats')
                 ->values(['name' => $category->getName(), 'sort' => $lastSort['maxSort']+1])
                 ->execute();
         }
@@ -96,10 +103,11 @@ class Category extends \Ilch\Mapper
      * Deletes category with given id.
      *
      * @param integer $id
+     * @return int affectedRows
      */
     public function delete($id)
     {
-        $this->db()->delete('articles_cats')
+        return (int)$this->db()->delete('articles_cats')
             ->where(['id' => $id])
             ->execute();
     }

--- a/application/modules/article/mappers/Category.php
+++ b/application/modules/article/mappers/Category.php
@@ -63,10 +63,11 @@ class Category extends \Ilch\Mapper
      *
      * @param int $catId
      * @param int $key
+     * @return int affectedRows
      */
     public function sort($catId, $key)
     {
-        $this->db()->update('articles_cats')
+        return (int)$this->db()->update('articles_cats')
             ->values(['sort' => $key])
             ->where(['id' => $catId])
             ->execute();

--- a/application/modules/article/views/admin/templates/treat.php
+++ b/application/modules/article/views/admin/templates/treat.php
@@ -101,7 +101,7 @@ if ($this->get('article') != '') {
         <div class="col-lg-4">
             <textarea class="form-control" 
                       id="description" 
-                      name="description"><?=if ($this->get('article') != '') ? $this->escape($this->get('article')->getDescription()) : ''?></textarea>
+                      name="description"><?=($this->get('article') != '') ? $this->escape($this->get('article')->getDescription()) : '' ?></textarea>
         </div>
     </div>
     <div class="form-group">

--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -22,7 +22,7 @@ class Config extends \Ilch\Config\Install
             ],
             'en_EN' => [
                 'name' => 'Forum',
-                'description' => 'The forum module supplied ex works with many functions of a forum.',
+                'description' => 'The by default supplied forum module with many functions of a forum.',
             ],
         ],
         'boxes' => [
@@ -373,7 +373,7 @@ class Config extends \Ilch\Config\Install
                 $this->db()->query('INSERT INTO `[prefix]_emails` (`moduleKey`, `type`, `desc`, `text`, `locale`) VALUES
                         ("forum", "post_reportedPost_mail", "Ein Beitrag wurde gemeldet", "<p>Hallo <b>{name}</b>,</p>
                               <p>&nbsp;</p>
-                              <p>Ein Beitrag im Forum auf <i>{sitetitle}</i> wurde gemeldet.</p>
+                              <p>ein Beitrag im Forum auf <i>{sitetitle}</i> wurde gemeldet.</p>
                               <p>Sie bekommen diese E-Mail, weil Sie entweder Administrator oder Adminrechte für das Forum haben.</p>
                               <p>Um direkt einen Blick auf den betreffenden Beitrag zu werfen, klicken Sie bitte auf folgenden Link:</p>
                               <a href=\"{url}\">Verwalte gemeldete Beiträge</a>

--- a/application/modules/forum/controllers/Rememberedposts.php
+++ b/application/modules/forum/controllers/Rememberedposts.php
@@ -28,7 +28,12 @@ class Rememberedposts extends \Ilch\Controller\Frontend
             }
         }
 
-        $this->getView()->set('rememberedPosts', $rememberMapper->getRememberedPostsByUserId($this->getUser()->getId()));
+        if ($this->getUser()) {
+            $this->getView()->set('rememberedPosts', $rememberMapper->getRememberedPostsByUserId($this->getUser()->getId()));
+        } else {
+            // Return nothing if it is a guest or a not logged in user.
+            $this->getView()->set('rememberedPosts', []);
+        }
     }
 
     public function rememberAction()

--- a/application/modules/linkus/views/admin/index/index.php
+++ b/application/modules/linkus/views/admin/index/index.php
@@ -25,7 +25,7 @@
                             <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $linkus->getId()]) ?></td>
                             <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $linkus->getId()]) ?></td>
                             <td>
-                                <img src="<?=$this->getBaseUrl($this->escape($linkus->getBanner())) ?>" alt="<?=$this->escape($linkus->getTitle()) ?>" title="<?=$this->escape($linkus->getTitle()) ?>"></a>
+                                <img src="<?=$this->getBaseUrl($this->escape($linkus->getBanner())) ?>" alt="<?=$this->escape($linkus->getTitle()) ?>" title="<?=$this->escape($linkus->getTitle()) ?>">
                                 <br />
                                 &raquo; <?=$this->escape($linkus->getTitle()) ?>
                             </td>

--- a/tests/modules/article/_files/categories_table.yml
+++ b/tests/modules/article/_files/categories_table.yml
@@ -1,0 +1,9 @@
+articles_cats:
+  -
+    id: 1
+    name: "TestName1"
+    sort: 0
+  -
+    id: 2
+    name: "TestName2"
+    sort: 1

--- a/tests/modules/article/mappers/ArticleTest.php
+++ b/tests/modules/article/mappers/ArticleTest.php
@@ -37,14 +37,14 @@ class ArticleTest extends DatabaseTestCase
     /**
      * Tests if getArticles() returns all articles from the database.
      */
-    public function testgetArticlesAllRows()
+    public function testGetArticlesAllRows()
     {
         $articles = $this->articleMapper->getArticles();
 
         self::assertCount(3, $articles);
     }
 
-    public function testgetArticles()
+    public function testGetArticles()
     {
         $articles = $this->articleMapper->getArticles();
 
@@ -111,7 +111,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[2]->getVotes());
     }
 
-    public function testgetArticlesByAccess()
+    public function testGetArticlesByAccess()
     {
         $articles = $this->articleMapper->getArticlesByAccess('1,2,3');
 
@@ -178,28 +178,28 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[2]->getVotes());
     }
 
-    public function testgetArticlesByAccessArray()
+    public function testGetArticlesByAccessArray()
     {
         $articles = $this->articleMapper->getArticlesByAccess([1, 2, 3]);
 
         self::assertCount(3, $articles);
     }
 
-    public function testgetArticlesByAccessGuest()
+    public function testGetArticlesByAccessGuest()
     {
         $articles = $this->articleMapper->getArticlesByAccess([3]);
 
         self::assertCount(1, $articles);
     }
 
-    public function testgetArticlesByAccessGuestDefault()
+    public function testGetArticlesByAccessGuestDefault()
     {
         $articles = $this->articleMapper->getArticlesByAccess();
 
         self::assertCount(1, $articles);
     }
 
-    public function testgetArticlesByCats()
+    public function testGetArticlesByCats()
     {
         $articles = $this->articleMapper->getArticlesByCats('1');
 
@@ -246,14 +246,14 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[1]->getVotes());
     }
 
-    public function testgetArticlesByCatsNoResult()
+    public function testGetArticlesByCatsNoResult()
     {
         $articles = $this->articleMapper->getArticlesByCats('0');
 
         self::assertNull($articles);
     }
 
-    public function testgetArticlesByCatsAccess()
+    public function testGetArticlesByCatsAccess()
     {
         $articles = $this->articleMapper->getArticlesByCatsAccess('1', '1,2,3');
 
@@ -300,28 +300,28 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[1]->getVotes());
     }
 
-    public function testgetArticlesByCatsAccessArray()
+    public function testGetArticlesByCatsAccessArray()
     {
         $articles = $this->articleMapper->getArticlesByCatsAccess('1', [1, 2, 3]);
 
         self::assertCount(2, $articles);
     }
 
-    public function testgetArticlesByCatsAccessGuest()
+    public function testGetArticlesByCatsAccessGuest()
     {
         $articles = $this->articleMapper->getArticlesByCatsAccess('2', [3]);
 
         self::assertCount(1, $articles);
     }
 
-    public function testgetArticlesByCatsAccessGuestDefault()
+    public function testGetArticlesByCatsAccessGuestDefault()
     {
         $articles = $this->articleMapper->getArticlesByCatsAccess('2');
 
         self::assertCount(1, $articles);
     }
 
-    public function testgetArticlesByKeyword()
+    public function testGetArticlesByKeyword()
     {
         $articles = $this->articleMapper->getArticlesByKeyword('keyword1');
 
@@ -388,14 +388,14 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[2]->getVotes());
     }
 
-    public function testgetArticlesByKeywordNoResult()
+    public function testGetArticlesByKeywordNoResult()
     {
         $articles = $this->articleMapper->getArticlesByKeyword('NotExisting');
 
         self::assertNull($articles);
     }
 
-    public function testgetArticlesByKeywordAccess()
+    public function testGetArticlesByKeywordAccess()
     {
         $articles = $this->articleMapper->getArticlesByKeywordAccess('keyword1', '1,2,3');
 
@@ -462,14 +462,14 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[2]->getVotes());
     }
 
-    public function testgetArticlesByKeywordAccessGuest()
+    public function testGetArticlesByKeywordAccessGuest()
     {
         $articles = $this->articleMapper->getArticlesByKeywordAccess('keyword1', '3');
 
         self::assertCount(1, $articles);
     }
 
-    public function testgetArticlesByDate()
+    public function testGetArticlesByDate()
     {
         $articles = $this->articleMapper->getArticlesByDate(new \Ilch\Date('2021-05-09'));
 
@@ -516,7 +516,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[1]->getVotes());
     }
 
-    public function testgetArticlesByDatePagination()
+    public function testGetArticlesByDatePagination()
     {
         $pagination = new Pagination();
 
@@ -568,7 +568,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[1]->getVotes());
     }
 
-    public function testgetArticlesByDateAccess()
+    public function testGetArticlesByDateAccess()
     {
         $articles = $this->articleMapper->getArticlesByDateAccess(new \Ilch\Date('2021-05-09'), '1,2,3');
 
@@ -615,66 +615,66 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[1]->getVotes());
     }
 
-    public function testgetArticlesByDateAccessNoResult()
+    public function testGetArticlesByDateAccessNoResult()
     {
         $articles = $this->articleMapper->getArticlesByDateAccess(new \Ilch\Date('2021-05-09'), '3');
 
         self::assertNull($articles);
     }
 
-    public function testgetArticlesByDateAccessGuest()
+    public function testGetArticlesByDateAccessGuest()
     {
         $articles = $this->articleMapper->getArticlesByDateAccess(new \Ilch\Date('2021-05-09'), '2');
 
         self::assertCount(1, $articles);
     }
 
-    public function testgetCountArticlesByCatId()
+    public function testGetCountArticlesByCatId()
     {
         self::assertSame(2, $this->articleMapper->getCountArticlesByCatId("1"));
     }
 
-    public function testgetCountArticlesByCatIdNotExisting()
+    public function testGetCountArticlesByCatIdNotExisting()
     {
         self::assertSame(0, $this->articleMapper->getCountArticlesByCatId("3"));
     }
 
-    public function testgetCountArticlesByCatIdAccess()
+    public function testGetCountArticlesByCatIdAccess()
     {
         self::assertSame(2, $this->articleMapper->getCountArticlesByCatIdAccess("1", '1,2,3'));
     }
 
-    public function testgetCountArticlesByCatIdNotExistingAccess()
+    public function testGetCountArticlesByCatIdNotExistingAccess()
     {
         self::assertSame(0, $this->articleMapper->getCountArticlesByCatIdAccess("3"));
     }
 
-    public function testgetCountArticlesByMonthYear()
+    public function testGetCountArticlesByMonthYear()
     {
         self::assertSame(3, $this->articleMapper->getCountArticlesByMonthYear("2021-05-10 08:10:38"));
     }
 
-    public function testgetCountArticlesByMonthYearNotExisting()
+    public function testGetCountArticlesByMonthYearNotExisting()
     {
         self::assertSame(0, $this->articleMapper->getCountArticlesByMonthYear("2000-01-01 08:10:38"));
     }
 
-    public function testgetCountArticlesByMonthYearAccess()
+    public function testGetCountArticlesByMonthYearAccess()
     {
         self::assertSame(3, $this->articleMapper->getCountArticlesByMonthYearAccess("2021-05-10 08:10:38", '1,2,3'));
     }
 
-    public function testgetCountArticlesByMonthYearAccessGuest()
+    public function testGetCountArticlesByMonthYearAccessGuest()
     {
         self::assertSame(1, $this->articleMapper->getCountArticlesByMonthYearAccess("2021-05-10 08:10:38"));
     }
 
-    public function testgetCountArticlesByMonthYearAccessNotExisting()
+    public function testGetCountArticlesByMonthYearAccessNotExisting()
     {
         self::assertSame(0, $this->articleMapper->getCountArticlesByMonthYearAccess("2000-01-01 08:10:38"));
     }
 
-    public function testgetArticleDateList()
+    public function testGetArticleDateList()
     {
         $articles = $this->articleMapper->getArticleDateList(3);
 
@@ -683,7 +683,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
     }
 
-    public function testgetArticleDateListAccess()
+    public function testGetArticleDateListAccess()
     {
         $articles = $this->articleMapper->getArticleDateListAccess('1,2,3', 3);
 
@@ -702,7 +702,7 @@ class ArticleTest extends DatabaseTestCase
 //        self::assertSame('2021-05-10 08:10:38', $articles[0]->getDateCreated());
 //    }
 
-    public function testgetArticleByIdLocale()
+    public function testGetArticleByIdLocale()
     {
         $article = $this->articleMapper->getArticleByIdLocale(3);
 
@@ -727,14 +727,14 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $article->getVotes());
     }
 
-    public function testgetArticleByIdLocaleNotExisting()
+    public function testGetArticleByIdLocaleNotExisting()
     {
         $articles = $this->articleMapper->getArticleByIdLocale(0);
 
         self::assertNull($articles);
     }
 
-    public function testgetKeywordsList()
+    public function testGetKeywordsList()
     {
         $articles = $this->articleMapper->getKeywordsList(2);
 
@@ -744,7 +744,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
     }
 
-    public function testgetKeywordsListAccess()
+    public function testGetKeywordsListAccess()
     {
         $articles = $this->articleMapper->getKeywordsListAccess('1,2,3', 2);
 
@@ -754,7 +754,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('keyword1, keyword2', $articles[1]->getKeywords());
     }
 
-    public function testgetKeywordsListAccessGuest()
+    public function testGetKeywordsListAccessGuest()
     {
         $articles = $this->articleMapper->getKeywordsListAccess('3', 2);
 
@@ -763,19 +763,19 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('keyword1, keyword2', $articles[0]->getKeywords());
     }
 
-    public function testkeywordExists()
+    public function testKeywordExists()
     {
         self::assertTrue($this->articleMapper->keywordExists('keyword1'));
         self::assertTrue($this->articleMapper->keywordExists('keyword2'));
 
     }
 
-    public function testkeywordExistsNotExisting()
+    public function testKeywordExistsNotExisting()
     {
         self::assertFalse($this->articleMapper->keywordExists('notexisting'));
     }
 
-    public function testgetArticlePermas()
+    public function testGetArticlePermas()
     {
         $permas = $this->articleMapper->getArticlePermas();
 
@@ -786,14 +786,14 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('testtitle3.html', $permas['testtitle3.html']['perma']);
     }
 
-    public function testgetTopArticleNoTopArticle()
+    public function testGetTopArticleNoTopArticle()
     {
         $articles = $this->articleMapper->getTopArticle();
 
         self::assertNull($articles);
     }
 
-    public function testgetTopArticle()
+    public function testGetTopArticle()
     {
         $this->articleMapper->setTopArticle(1, 1);
         $article = $this->articleMapper->getTopArticle();
@@ -818,7 +818,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $article->getVotes());
     }
 
-    public function testgetTopArticles()
+    public function testGetTopArticles()
     {
         $this->articleMapper->setTopArticle(1, 1);
         $this->articleMapper->setTopArticle(2, 1);
@@ -865,7 +865,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('', $articles[1]->getVotes());
     }
 
-    public function testsaveVisits()
+    public function testSaveVisits()
     {
         $model = new ArticleModel();
 
@@ -880,7 +880,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame(20, $article->getVisits());
     }
 
-    public function testsaveVisitsEmptyVisits()
+    public function testSaveVisitsEmptyVisits()
     {
         $model = new ArticleModel();
 
@@ -894,7 +894,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame(1, $article->getVisits());
     }
 
-    public function testsaveNewArticle()
+    public function testSaveNewArticle()
     {
         $model = new ArticleModel();
         $model->setCatId(1);
@@ -935,7 +935,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('1,2,3', $article->getVotes());
     }
 
-    public function testsaveUpdateExistingArticle()
+    public function testSaveUpdateExistingArticle()
     {
         $model = new ArticleModel();
         $model->setId(1);
@@ -978,7 +978,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('1,2,3', $article->getVotes());
     }
 
-    public function testsaveExistingArticleNewLocale()
+    public function testSaveExistingArticleNewLocale()
     {
         $model = new ArticleModel();
         $model->setId(1);
@@ -1019,7 +1019,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('1,2,3', $article->getVotes());
     }
 
-    public function testsaveVotes()
+    public function testSaveVotes()
     {
         $this->articleMapper->saveVotes(1, 1);
         $this->articleMapper->saveVotes(1, 2);
@@ -1029,7 +1029,7 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('1,2,', $article->getVotes());
     }
 
-    public function testgetVotes()
+    public function testGetVotes()
     {
         $this->articleMapper->saveVotes(1, 1);
         $this->articleMapper->saveVotes(1, 2);
@@ -1037,12 +1037,12 @@ class ArticleTest extends DatabaseTestCase
         self::assertSame('1,2,', $this->articleMapper->getVotes(1));
     }
 
-    public function testgetVotesNoVotes()
+    public function testGetVotesNoVotes()
     {
         self::assertSame('', $this->articleMapper->getVotes(1));
     }
 
-    public function testdelete()
+    public function testDelete()
     {
         self::assertSame(1, $this->articleMapper->delete(1));
 

--- a/tests/modules/article/mappers/CategoryTest.php
+++ b/tests/modules/article/mappers/CategoryTest.php
@@ -33,7 +33,7 @@ class CategoryTest extends DatabaseTestCase
         $this->categoryMapper = new CategoryMapper();
     }
 
-    public function testgetCategories()
+    public function testGetCategories()
     {
         $categories = $this->categoryMapper->getCategories();
 
@@ -44,7 +44,7 @@ class CategoryTest extends DatabaseTestCase
         self::assertSame('TestName2', $categories[1]->getName());
     }
 
-    public function testgetCategoryById()
+    public function testGetCategoryById()
     {
         $category = $this->categoryMapper->getCategoryById(1);
 
@@ -52,14 +52,44 @@ class CategoryTest extends DatabaseTestCase
         self::assertSame('TestName1', $category->getName());
     }
 
-    public function testgetCategoryByIdInvalid()
+    public function testGetCategoryByIdInvalid()
     {
         $category = $this->categoryMapper->getCategoryById(0);
 
         self::assertFalse($category);
     }
 
-    public function testsave()
+    public function testSortInvalidId()
+    {
+        $affectedRows = $this->categoryMapper->sort(-1, 2);
+        $categories = $this->categoryMapper->getCategories();
+
+        self::assertSame(0, $affectedRows);
+    }
+
+    public function testSort()
+    {
+        $affectedRows = $this->categoryMapper->sort(1, 2);
+        $categories = $this->categoryMapper->getCategories();
+
+        self::assertSame(1, $affectedRows);
+        self::assertCount(2, $categories);
+        self::assertSame(2, $categories[0]->getId());
+        self::assertSame(1, $categories[1]->getId());
+    }
+
+    public function testSortReturnValueNotId()
+    {
+        $affectedRows = $this->categoryMapper->sort(2, 3);
+        $categories = $this->categoryMapper->getCategories();
+
+        self::assertSame(1, $affectedRows);
+        self::assertCount(2, $categories);
+        self::assertSame(1, $categories[0]->getId());
+        self::assertSame(2, $categories[1]->getId());
+    }
+
+    public function testSave()
     {
         $model = new CategoryModel();
 
@@ -73,7 +103,7 @@ class CategoryTest extends DatabaseTestCase
         self::assertSame('TestName3', $category->getName());
     }
 
-    public function testdelete()
+    public function testDelete()
     {
         $affectedRows = $this->categoryMapper->delete(2);
         $category = $this->categoryMapper->getCategoryById(2);

--- a/tests/modules/article/mappers/CategoryTest.php
+++ b/tests/modules/article/mappers/CategoryTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Modules\Article\Mappers;
+
+use PHPUnit\Ilch\DatabaseTestCase;
+use Modules\Article\Mappers\Category as CategoryMapper;
+use Modules\Article\Models\Category as CategoryModel;
+use Modules\Article\Config\Config as ModuleConfig;
+use Modules\User\Config\Config as UserConfig;
+use Modules\Admin\Config\Config as AdminConfig;
+use PHPUnit\Ilch\PhpunitDataset;
+
+/**
+ * Tests the category mapper class.
+ *
+ * @package ilch_phpunit
+ */
+class CategoryTest extends DatabaseTestCase
+{
+    protected $phpunitDataset;
+    private $categoryMapper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/categories_table.yml');
+
+        $this->categoryMapper = new CategoryMapper();
+    }
+
+    public function testgetCategories()
+    {
+        $categories = $this->categoryMapper->getCategories();
+
+        self::assertCount(2, $categories);
+        self::assertSame(1, $categories[0]->getId());
+        self::assertSame('TestName1', $categories[0]->getName());
+        self::assertSame(2, $categories[1]->getId());
+        self::assertSame('TestName2', $categories[1]->getName());
+    }
+
+    public function testgetCategoryById()
+    {
+        $category = $this->categoryMapper->getCategoryById(1);
+
+        self::assertSame(1, $category->getId());
+        self::assertSame('TestName1', $category->getName());
+    }
+
+    public function testgetCategoryByIdInvalid()
+    {
+        $category = $this->categoryMapper->getCategoryById(0);
+
+        self::assertFalse($category);
+    }
+
+    public function testsave()
+    {
+        $model = new CategoryModel();
+
+        $model->setName('TestName3');
+
+        $id = $this->categoryMapper->save($model);
+        $category = $this->categoryMapper->getCategoryById(3);
+
+        self::assertSame(3, $id);
+        self::assertSame(3, $category->getId());
+        self::assertSame('TestName3', $category->getName());
+    }
+
+    public function testdelete()
+    {
+        $affectedRows = $this->categoryMapper->delete(2);
+        $category = $this->categoryMapper->getCategoryById(2);
+
+        self::assertEquals(1, $affectedRows);
+        self::assertFalse($category);
+    }
+
+    /**
+     * Returns database schema sql statements to initialize database
+     *
+     * @return string
+     */
+    protected static function getSchemaSQLQueries()
+    {
+        $config = new ModuleConfig();
+        $configUser = new UserConfig();
+        $configAdmin = new AdminConfig();
+
+        return $configAdmin->getInstallSql() . $configUser->getInstallSql() . $config->getInstallSql();
+    }
+}

--- a/tests/modules/article/mappers/TemplateTest.php
+++ b/tests/modules/article/mappers/TemplateTest.php
@@ -34,7 +34,7 @@ class TemplateTest extends DatabaseTestCase
         $this->templateMapper = new TemplateMapper();
     }
 
-    public function testgetTemplates()
+    public function testGetTemplates()
     {
         $templates = $this->templateMapper->getTemplates();
 
@@ -77,7 +77,7 @@ class TemplateTest extends DatabaseTestCase
         self::assertSame('', $templates[2]->getImageSource());
     }
 
-    public function testgetTemplatesLocale()
+    public function testGetTemplatesLocale()
     {
         $templates = $this->templateMapper->getTemplates('en_EN');
 
@@ -96,7 +96,7 @@ class TemplateTest extends DatabaseTestCase
         self::assertSame('', $templates[0]->getImageSource());
     }
 
-    public function testgetTemplatesEmptyString()
+    public function testGetTemplatesEmptyString()
     {
         $templates = $this->templateMapper->getTemplates('');
 
@@ -127,7 +127,7 @@ class TemplateTest extends DatabaseTestCase
         self::assertSame('', $templates[1]->getImageSource());
     }
 
-    public function testgetTemplatesPagination()
+    public function testGetTemplatesPagination()
     {
         $pagination = new Pagination();
 
@@ -162,7 +162,7 @@ class TemplateTest extends DatabaseTestCase
         self::assertSame('', $templates[1]->getImageSource());
     }
 
-    public function testgetTemplateById()
+    public function testGetTemplateById()
     {
         $template = $this->templateMapper->getTemplateById(1);
 
@@ -179,14 +179,14 @@ class TemplateTest extends DatabaseTestCase
         self::assertSame('', $template->getImageSource());
     }
 
-    public function testgetTemplateByIdNull()
+    public function testGetTemplateByIdNull()
     {
         $template = $this->templateMapper->getTemplateById(0);
 
         self::assertNull($template);
     }
 
-    public function testsave()
+    public function testSave()
     {
         $model = new ArticleModel();
 
@@ -220,7 +220,7 @@ class TemplateTest extends DatabaseTestCase
         self::assertSame('', $template->getImageSource());
     }
 
-    public function testdelete()
+    public function testDelete()
     {
         $affectedRows = $this->templateMapper->delete(3);
         $template = $this->templateMapper->getTemplateById(3);


### PR DESCRIPTION
# Description
- Fix "Call to a member function getId() on null" in the forum module
- Fix the usage of reset() on null instead of an array in the category mapper of the article module
- Add some unit tests for the category mapper
- Add return values to the function delete() and save() in the category mapper (return id or affected rows).
- Fix wrong argument names in addStringAttachment()
- Other small fixes

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# This PR has been tested in the following browsers:
- [X] Opera
