### PR TITLE
Add confirmation prompt to delete action

### DIFF
--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'forum',
-        'version' => '1.30.1',
+        'version' => '1.31.0',
         'icon_small' => 'fa-list',
         'author' => 'Stantin Thomas',
         'link' => 'https://ilch.de',
@@ -442,6 +442,7 @@ class Config extends \Ilch\Config\Install
             case "1.28.0":
             case "1.29.0":
             case "1.30.0":
+            case "1.30.1":
         }
     }
 }

--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -167,7 +167,8 @@ class Showposts extends \Ilch\Controller\Frontend
         $topicId = (int)$this->getRequest()->getParam('topicid');
         $forumId = (int)$this->getRequest()->getParam('forumid');
         $countPosts = $forumMapper->getCountPostsByTopicId($topicId);
-        if ($this->getUser() && $this->getUser()->isAdmin()) {
+
+        if ($this->getUser() && $this->getUser()->isAdmin() && $this->getRequest()->isSecure()) {
             $postMapper->deleteById($postId);
             if ($countPosts === '1') {
                 $topicMapper->deleteById($topicId);
@@ -177,7 +178,7 @@ class Showposts extends \Ilch\Controller\Frontend
             $this->redirect(['controller' => 'showposts', 'action' => 'index', 'topicid' => $topicId]);
         }
 
-        $this->addMessage('noAccess', 'danger');
+        $this->addMessage('noAccessDelete', 'danger');
         $this->redirect(['controller' => 'showposts', 'action' => 'index', 'topicid' => $topicId, 'forumid' => $forumId]);
     }
 

--- a/application/modules/forum/translations/de.php
+++ b/application/modules/forum/translations/de.php
@@ -140,4 +140,5 @@ return [
     'clock' => 'Uhr',
     'read' => 'gelesen',
     'unread' => 'ungelesen',
+    'confirmDeletePost' => 'Möchten Sie diesen Beitrag wirklich löschen?',
 ];

--- a/application/modules/forum/translations/en.php
+++ b/application/modules/forum/translations/en.php
@@ -140,4 +140,5 @@ return [
     'clock' => 'o\'clock',
     'read' => 'read',
     'unread' => 'unread',
+    'confirmDeletePost' => 'Do you really want to delete this post?',
 ];

--- a/application/modules/forum/views/showposts/index.php
+++ b/application/modules/forum/views/showposts/index.php
@@ -114,7 +114,7 @@ if ($forumPrefix->getPrefix() != '' && $topicpost->getTopicPrefix() > 0) {
                                     <?php if ($this->getUser()): ?>
                                         <?php if ($this->getUser()->isAdmin()): ?>
                                             <p class="delete-post">
-                                                <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'delete', 'id' => $post->getId(), 'topicid' => $this->getRequest()->getParam('topicid'), 'forumid' => $forum->getId()]) ?>" class="btn btn-primary btn-xs">
+                                                <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'delete', 'id' => $post->getId(), 'topicid' => $this->getRequest()->getParam('topicid'), 'forumid' => $forum->getId()], null, true) ?>" id="delete" class="btn btn-primary btn-xs">
                                                     <span class="btn-label">
                                                         <i class="fa fa-trash"></i>
                                                     </span><?=$this->getTrans('delete') ?>
@@ -350,6 +350,10 @@ $(document).ready(function() {
         $('#rememberPostStatus').empty();
         $('#rememberPostStatus').removeAttr("class");
         $('#note').val("");
+    });
+
+    $("a[id='delete']").click(function(){
+        return confirm('<?=$this->getTrans('confirmDeletePost') ?>');
     });
 });
 </script>


### PR DESCRIPTION
# Description
Add confirmation prompt to delete action. Further use a token for the delete action.

Fixes #500
Fixes #620

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [X] Opera
- [ ] Edge
- [ ] IE
