### PR TITLE
Code Fixes

### DIFF
--- a/application/libraries/Ilch/Layout/Helper/AdminHmenu/Model.php
+++ b/application/libraries/Ilch/Layout/Helper/AdminHmenu/Model.php
@@ -8,6 +8,8 @@ namespace Ilch\Layout\Helper\AdminHmenu;
 
 class Model
 {
+    protected $layout;
+
     /**
      * @var array
      */

--- a/application/libraries/Ilch/Layout/Helper/Menu/Model.php
+++ b/application/libraries/Ilch/Layout/Helper/Menu/Model.php
@@ -11,6 +11,8 @@ use Modules\Admin\Models\MenuItem;
 
 class Model
 {
+    protected $layout;
+
     /**
      * Id of the menu.
      *

--- a/application/modules/admin/models/Module.php
+++ b/application/modules/admin/models/Module.php
@@ -8,6 +8,9 @@ namespace Modules\Admin\Models;
 
 class Module extends \Ilch\Model
 {
+
+    protected $content = [];
+
     /**
      * Key of the module.
      *


### PR DESCRIPTION
Installation von 2.1.45 unter PHP 8.2 hatte einige Fehler die hiermit gefixt werden.

```
Deprecated: Creation of dynamic property Ilch\Layout\Helper\Menu\Model::$layout is deprecated in application\libraries\Ilch\Layout\Helper\Menu\Model.php on line 52
Deprecated: Creation of dynamic property Modules\Admin\Models\Module::$content is deprecated in application\modules\admin\models\Module.php on line 213
Deprecated: Creation of dynamic property Ilch\Layout\Helper\AdminHmenu\Model::$layout is deprecated in application\libraries\Ilch\Layout\Helper\AdminHmenu\Model.php on line 23
```