### PR TITLE
Update Translator.php

### DIFF
--- a/application/libraries/Ilch/Translator.php
+++ b/application/libraries/Ilch/Translator.php
@@ -22,7 +22,7 @@ class Translator
      * Key as the short locale, value as the translations array from the
      * translations file.
      *
-     * @var mixed[]
+     * @var array
      */
     private $translations = [];
 
@@ -53,9 +53,9 @@ class Translator
     /**
      * Sets the locale to use for the request.
      *
-     * @param string $locale
+     * @param string|null $locale
      */
-    public function __construct($locale = null)
+    public function __construct(string $locale = null)
     {
         // If a setting is given, set the locale to the given one.
         if ($locale !== null) {
@@ -66,10 +66,10 @@ class Translator
     /**
      * Loads a translation array for the set locale from the given directory.
      *
-     * @param  string  $transDir The directory where the translation resides.
-     * @return boolean True if the translations got loaded, false if not.
+     * @param string $transDir The directory where the translation resides.
+     * @return bool True if the translations got loaded, false if not.
      */
-    public function load($transDir)
+    public function load(string $transDir): bool
     {
         if (!is_dir($transDir)) {
             return false;
@@ -104,7 +104,7 @@ class Translator
      * @param [, mixed $args [, mixed $... ]]
      * @return string
      */
-    public function trans($key)
+    public function trans(string $key): string
     {
         $translatedText = $key;
 
@@ -121,9 +121,7 @@ class Translator
 
         $arguments = func_get_args();
         $arguments[0] = $translatedText;
-        $translatedText = sprintf(...$arguments);
-
-        return $translatedText;
+        return sprintf(...$arguments);
     }
 
     /**
@@ -139,15 +137,13 @@ class Translator
      * @return string
      * @since 2.1.32
      */
-    public function transOtherLayout($layoutKey, $key)
+    public function transOtherLayout(string $layoutKey, string $key): string
     {
         $translatedText = $this->translationsLayout[$key] ?? $key;
 
         $arguments = array_slice(func_get_args(), 1);
         $arguments[0] = $translatedText;
-        $translatedText = sprintf(...$arguments);
-
-        return $translatedText;
+        return sprintf(...$arguments);
     }
 
     /**
@@ -162,7 +158,7 @@ class Translator
     /**
      * Returns the translation array.
      */
-    public function getTranslations()
+    public function getTranslations(): array
     {
         return $this->translations;
     }
@@ -172,7 +168,7 @@ class Translator
      *
      * @return array
      */
-    public function getLocaleList()
+    public function getLocaleList(): array
     {
         return [
             'en_EN' => 'English',
@@ -183,10 +179,10 @@ class Translator
     /**
      * Shortens the locale so only the first to characters get returned.
      *
-     * @param  string $locale
+     * @param string $locale
      * @return string
      */
-    public function shortenLocale($locale)
+    public function shortenLocale(string $locale): string
     {
         return substr($locale, 0, 2);
     }
@@ -196,7 +192,7 @@ class Translator
      *
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->locale;
     }
@@ -204,10 +200,10 @@ class Translator
     /**
      * Sets the locale used for the translation.
      *
-     * @param string
+     * @param string $locale
      * @param bool $reloadTranslations
      */
-    public function setLocale($locale, $reloadTranslations = false)
+    public function setLocale(string $locale, bool $reloadTranslations = false)
     {
         $this->locale = $locale;
         if ($reloadTranslations) {
@@ -225,7 +221,7 @@ class Translator
      * @param string $currencyCode (ISO 4217)
      * @return string
      */
-    public function getFormattedCurrency($amount, $currencyCode)
+    public function getFormattedCurrency(float $amount, string $currencyCode): string
     {
         $numberFormatter = new \NumberFormatter($this->getLocale(), \NumberFormatter::CURRENCY);
         $returnValue = $numberFormatter->formatCurrency($amount, $currencyCode);
@@ -248,7 +244,7 @@ class Translator
      * @return bool
      * @since 2.1.31
      */
-    private function isCallFromLayout()
+    private function isCallFromLayout(): bool
     {
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4);
 

--- a/application/modules/admin/mappers/Page.php
+++ b/application/modules/admin/mappers/Page.php
@@ -6,6 +6,8 @@
 
 namespace Modules\Admin\Mappers;
 
+use Ilch\Date;
+use Ilch\Pagination;
 use Modules\Admin\Models\Page as EntriesModel;
 
 class Page extends \Ilch\Mapper
@@ -16,7 +18,7 @@ class Page extends \Ilch\Mapper
     /**
      * returns if the module is installed.
      *
-     * @return boolean
+     * @return bool
      */
     public function checkDB(): bool
     {
@@ -28,10 +30,10 @@ class Page extends \Ilch\Mapper
      *
      * @param array $where
      * @param array $orderBy
-     * @param \Ilch\Pagination|null $pagination
+     * @param Pagination|null $pagination
      * @return array|null
      */
-    public function getEntriesBy($where = [], $orderBy = ['p.id' => 'DESC'], $pagination = null)
+    public function getEntriesBy(array $where = [], array $orderBy = ['p.id' => 'DESC'], Pagination $pagination = null): ?array
     {
         $select = $this->db()->select()
             ->fields(['p.id', 'p.date_created'])
@@ -50,20 +52,20 @@ class Page extends \Ilch\Mapper
             $result = $select->execute();
         }
 
-        $entryArray = $result->fetchRows();
-        if (empty($entryArray)) {
+        $entriesRows = $result->fetchRows();
+        if (empty($entriesRows)) {
             return null;
         }
-        $entrys = [];
+        $entries = [];
 
-        foreach ($entryArray as $entries) {
+        foreach ($entriesRows as $entryRow) {
             $entryModel = new EntriesModel();
 
-            $entryModel->setByArray($entries);
-
-            $entrys[] = $entryModel;
+            $entryModel->setByArray($entryRow);
+            $entries[] = $entryModel;
         }
-        return $entrys;
+
+        return $entries;
     }
 
     /**
@@ -73,7 +75,7 @@ class Page extends \Ilch\Mapper
      * @param array $orderBy
      * @return array
      */
-    public function getPageList(string $locale = '', $orderBy = ['p.id' => 'DESC'])
+    public function getPageList(string $locale = '', array $orderBy = ['p.id' => 'DESC']): ?array
     {
         return $this->getEntriesBy(['pc.locale' => $this->db()->escape($locale)], $orderBy);
     }
@@ -85,12 +87,12 @@ class Page extends \Ilch\Mapper
      * @param string $locale
      * @return EntriesModel|null
      */
-    public function getPageByIdLocale(int $id, string $locale = '')
+    public function getPageByIdLocale(int $id, string $locale = ''): ?EntriesModel
     {
-        $entrys = $this->getEntriesBy(['p.id' => $id, 'pc.locale' => $this->db()->escape($locale)], []);
+        $page = $this->getEntriesBy(['p.id' => $id, 'pc.locale' => $this->db()->escape($locale)], []);
 
-        if (!empty($entrys)) {
-            return reset($entrys);
+        if (!empty($page)) {
+            return reset($page);
         }
 
         return null;
@@ -101,7 +103,7 @@ class Page extends \Ilch\Mapper
      *
      * @return array|null
      */
-    public function getPagePermas()
+    public function getPagePermas(): ?array
     {
         $permas = $this->db()->select()
             ->fields(['page_id', 'locale', 'perma'])
@@ -160,7 +162,7 @@ class Page extends \Ilch\Mapper
             }
             return $page->getId();
         } else {
-            $date = new \Ilch\Date();
+            $date = new Date();
             $pageId = $this->db()->insert($this->tablename)
                 ->values(['date_created' => $date->toDb()])
                 ->execute();


### PR DESCRIPTION
# Description
Some small code improvements made while investigating warnings of phpcompatibility.

```
122 | WARNING | Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value. The parameter "$key" was used, and possibly changed (by reference), on line 109.
146 | WARNING | Since PHP 7.0, functions inspecting arguments, like func_get_args(), no longer report the original value as passed to a parameter, but will instead provide the current value. The parameter "$key" was used, and possibly changed (by reference), on line 144.
```

$key is assigned to $translatedText as default value in case there is no translation for that key. Later, while func_get_args() is called we use $translatedText instead of $key, because it probably has a translated text. Either that or the original value of $key as we assigned it as default value earlier. Leaving the code as is instead of assigning the translated text to $key and removing the usage of $translatedText. This seems to be clearer to me than having a translation stored in $key at some point.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)