### PR TITLE
Change fa fa-picture-o to fa-regular fa-image

### DIFF
--- a/application/modules/admin/layouts/index.php
+++ b/application/modules/admin/layouts/index.php
@@ -182,7 +182,7 @@
                             </li>
                             <li <?php if ($this->getRequest()->getModuleName() === 'admin' && $this->getRequest()->getControllerName() === 'layouts') { echo 'class="active"'; } ?>>
                                 <a href="<?=$this->getUrl(['module' => 'admin', 'controller' => 'layouts', 'action' => 'index']) ?>">
-                                    <i class="fa fa-picture-o hidden-sm hidden-md"></i> <?=$this->getTrans('menuLayouts') ?>
+                                    <i class="fa-regular fa-image hidden-sm hidden-md"></i> <?=$this->getTrans('menuLayouts') ?>
                                 </a>
                             </li>
                         <?php endif; ?>

--- a/application/modules/admin/views/admin/layouts/settings.php
+++ b/application/modules/admin/views/admin/layouts/settings.php
@@ -21,7 +21,7 @@
                 </span>
                 <span class="input-group-addon">
                     <a href="javascript:media_1()" id="media">
-                        <i class="fa fa-picture-o"></i>
+                        <i class="fa-regular fa-image"></i>
                     </a>
                 </span>
             </div>
@@ -47,7 +47,7 @@
                 </span>
                 <span class="input-group-addon">
                     <a href="javascript:media_2()" id="media">
-                        <i class="fa fa-picture-o"></i>
+                        <i class="fa-regular fa-image"></i>
                     </a>
                 </span>
             </div>

--- a/application/modules/article/views/admin/index/treat.php
+++ b/application/modules/article/views/admin/index/treat.php
@@ -188,7 +188,7 @@ if ($this->get('article')) {
                        id="selectedImage"
                        name="image"
                        value="<?=$this->get('article') ? $this->escape($this->get('article')->getImage()) : $this->originalInput('image') ?>" />
-                <span class="input-group-addon"><a id="media" href="javascript:media()"><i class="fa fa-picture-o"></i></a></span>
+                <span class="input-group-addon"><a id="media" href="javascript:media()"><i class="fa-regular fa-image"></i></a></span>
             </div>
         </div>
     </div>

--- a/application/modules/article/views/admin/templates/treat.php
+++ b/application/modules/article/views/admin/templates/treat.php
@@ -77,7 +77,7 @@ if ($this->get('article') != '') {
                        id="selectedImage"
                        name="image"
                        value="<?=($this->get('article') != '') ? $this->escape($this->get('article')->getImage()) : $this->originalInput('image') ?>" />
-                <span class="input-group-addon"><a id="media" href="javascript:media()"><i class="fa fa-picture-o"></i></a></span>
+                <span class="input-group-addon"><a id="media" href="javascript:media()"><i class="fa-regular fa-image"></i></a></span>
             </div>
         </div>
     </div>

--- a/application/modules/awards/config/config.php
+++ b/application/modules/awards/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'awards',
-        'version' => '1.8.0',
+        'version' => '1.9.0',
         'icon_small' => 'fa-trophy',
         'author' => 'Veldscholten, Kevin',
         'link' => 'http://ilch.de',
@@ -25,8 +25,8 @@ class Config extends \Ilch\Config\Install
                 'description' => 'Here you can award users or teams an award.',
             ],
         ],
-        'ilchCore' => '2.1.16',
-        'phpVersion' => '5.6'
+        'ilchCore' => '2.1.48',
+        'phpVersion' => '7.3'
     ];
 
     public function install()

--- a/application/modules/awards/views/admin/index/treat.php
+++ b/application/modules/awards/views/admin/index/treat.php
@@ -60,7 +60,7 @@ if ($awards != '') {
                     <span class="fa fa-times"></span>
                 </span>
                 <span class="input-group-addon">
-                    <a id="media" href="javascript:media()"><i class="fa fa-picture-o"></i></a>
+                    <a id="media" href="javascript:media()"><i class="fa-regular fa-image"></i></a>
                 </span>
             </div>
         </div>

--- a/application/modules/downloads/config/config.php
+++ b/application/modules/downloads/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'downloads',
-        'version' => '1.13.1',
+        'version' => '1.13.2',
         'icon_small' => 'fa-arrow-circle-o-down',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -24,8 +24,8 @@ class Config extends \Ilch\Config\Install
                 'description' => 'You can create downloads and add information to them. Further you can add them to categories.',
             ],
         ],
-        'ilchCore' => '2.1.46',
-        'phpVersion' => '7.0'
+        'ilchCore' => '2.1.48',
+        'phpVersion' => '7.3'
     ];
 
     public function install()

--- a/application/modules/downloads/views/admin/file/treatfile.php
+++ b/application/modules/downloads/views/admin/file/treatfile.php
@@ -45,7 +45,7 @@ if ($file->getFileImage() != '') {
                                        name="fileImage"
                                        placeholder="<?=$this->getTrans('fileImageInfo') ?>"
                                        value="<?=$this->escape($file->getFileImage()) ?>" />
-                                <span class="input-group-addon"><a id="media" href="javascript:media()"><i class="fa fa-picture-o"></i></a></span>
+                                <span class="input-group-addon"><a id="media" href="javascript:media()"><i class="fa-regular fa-image"></i></a></span>
                             </div>
                         </div>
                     </div>

--- a/application/modules/link/config/config.php
+++ b/application/modules/link/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'link',
-        'version' => '1.9.0',
+        'version' => '1.10.0',
         'icon_small' => 'fa-external-link',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -24,8 +24,8 @@ class Config extends \Ilch\Config\Install
                 'description' => 'With this you can link other websites with banners and descriptions. Further they can be categorized.',
             ],
         ],
-        'ilchCore' => '2.1.16',
-        'phpVersion' => '5.6'
+        'ilchCore' => '2.1.48',
+        'phpVersion' => '7.3'
     ];
 
     public function install()

--- a/application/modules/link/views/admin/index/treatLink.php
+++ b/application/modules/link/views/admin/index/treatLink.php
@@ -47,7 +47,7 @@
                        name="banner"
                        placeholder="<?=$this->getTrans('httpOrMedia') ?>"
                        value="<?=($this->get('link') != '') ? $this->escape($this->get('link')->getBanner()) : $this->escape($this->get('post')['banner']) ?>" />
-                <span class="input-group-addon"><a id="media" href="javascript:media_1()"><i class="fa fa-picture-o"></i></a></span>
+                <span class="input-group-addon"><a id="media" href="javascript:media_1()"><i class="fa-regular fa-image"></i></a></span>
             </div>
         </div>
     </div>

--- a/application/modules/linkus/config/config.php
+++ b/application/modules/linkus/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'linkus',
-        'version' => '1.5.0',
+        'version' => '1.6.0',
         'icon_small' => 'fa-link',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -24,8 +24,8 @@ class Config extends \Ilch\Config\Install
                 'description' => 'Provides HTML code or BBCode for others to link to your website.',
             ],
         ],
-        'ilchCore' => '2.1.16',
-        'phpVersion' => '5.6'
+        'ilchCore' => '2.1.48',
+        'phpVersion' => '7.3'
     ];
 
     public function install()

--- a/application/modules/linkus/views/admin/index/treat.php
+++ b/application/modules/linkus/views/admin/index/treat.php
@@ -33,7 +33,7 @@
                        name="banner"
                        value="<?=($linkus != '') ? $this->escape($linkus->getBanner()) : $this->escape($this->get('post')['banner']) ?>"
                        readonly />
-                <span class="input-group-addon"><a id="media" href="javascript:media_1()"><i class="fa fa-picture-o"></i></a></span>
+                <span class="input-group-addon"><a id="media" href="javascript:media_1()"><i class="fa-regular fa-image"></i></a></span>
             </div>
         </div>
     </div>

--- a/application/modules/partner/config/config.php
+++ b/application/modules/partner/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'partner',
-        'version' => '1.11.0',
+        'version' => '1.12.0',
         'icon_small' => 'fa-handshake-o',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -34,8 +34,8 @@ class Config extends \Ilch\Config\Install
                 ]
             ]
         ],
-        'ilchCore' => '2.1.43',
-        'phpVersion' => '5.6'
+        'ilchCore' => '2.1.48',
+        'phpVersion' => '7.3'
     ];
 
     public function install()

--- a/application/modules/partner/views/admin/index/treat.php
+++ b/application/modules/partner/views/admin/index/treat.php
@@ -45,7 +45,7 @@
                        name="banner"
                        placeholder="<?=$this->getTrans('httpOrMedia') ?>"
                        value="<?=($this->get('partner') != '') ? $this->escape($this->get('partner')->getBanner()) : $this->escape($this->originalInput('banner')) ?>" />
-                <span class="input-group-addon"><a id="media" href="javascript:media_1()"><i class="fa fa-picture-o"></i></a></span>
+                <span class="input-group-addon"><a id="media" href="javascript:media_1()"><i class="fa-regular fa-image"></i></a></span>
             </div>
         </div>
     </div>

--- a/application/modules/user/views/profil/index.php
+++ b/application/modules/user/views/profil/index.php
@@ -56,7 +56,7 @@ foreach ($profil->getGroups() as $group) {
                     <a href="<?=$this->getUrl(['controller' => 'mail', 'action' => 'index', 'user' => $profil->getId()]) ?>" class="fa fa-envelope" title="<?=$this->getTrans('email') ?>"></a>
                 <?php endif; ?>
                 <?php if ($this->get('gallery') != 0 && $profil->getOptGallery() != 0 && $this->get('galleryAllowed') != 0): ?>
-                    <a href="<?=$this->getUrl(['controller' => 'gallery', 'action' => 'index', 'user' => $profil->getId()]) ?>" class="fa fa-picture-o" title="<?=$this->getTrans('gallery') ?>"></a>
+                    <a href="<?=$this->getUrl(['controller' => 'gallery', 'action' => 'index', 'user' => $profil->getId()]) ?>" class="fa-regular fa-image" title="<?=$this->getTrans('gallery') ?>"></a>
                 <?php endif; ?>
 
                 <?php foreach ($profileIconFields as $profileIconField) {

--- a/application/modules/war/config/config.php
+++ b/application/modules/war/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'war',
-        'version' => '1.15.2',
+        'version' => '1.15.3',
         'icon_small' => 'fa-shield',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -43,7 +43,7 @@ class Config extends \Ilch\Config\Install
                 ]
             ]
         ],
-        'ilchCore' => '2.1.43',
+        'ilchCore' => '2.1.48',
         'phpVersion' => '7.3'
     ];
 

--- a/application/modules/war/views/admin/enemy/treat.php
+++ b/application/modules/war/views/admin/enemy/treat.php
@@ -51,7 +51,7 @@
                        placeholder="<?=$this->getTrans('enemyImageInfo') ?>"
                        value="<?=$this->escape($this->originalInput('enemyImage', ($entrie->getId()?$entrie->getEnemyImage():''))) ?>" />
                 <span class="input-group-addon">
-                    <a id="media" href="javascript:media()"><i class="fa fa-picture-o"></i></a>
+                    <a id="media" href="javascript:media()"><i class="fa-regular fa-image"></i></a>
                 </span>
             </div>
         </div>

--- a/application/modules/war/views/admin/group/treat.php
+++ b/application/modules/war/views/admin/group/treat.php
@@ -39,7 +39,7 @@
                        placeholder="<?=$this->getTrans('groupImage') ?>"
                        value="<?=$this->escape($this->originalInput('groupImage', ($entrie->getId()?$entrie->getGroupImage():''))) ?>" />
                 <span class="input-group-addon">
-                    <a id="media" href="javascript:media_1()"><i class="fa fa-picture-o"></i></a>
+                    <a id="media" href="javascript:media_1()"><i class="fa-regular fa-image"></i></a>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
# Description
Looks like a simple conversion from "fa" to "fas" or "fa-solid" would break the icon.
Change it to FontAwesome v6 style and use the new name ("fa-regular fa-image").

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [X] Opera
- [ ] Edge
- [ ] IE
