### PR TITLE
Fix case mismatch in function name

### DIFF
--- a/application/libraries/Ilch/Transfer.php
+++ b/application/libraries/Ilch/Transfer.php
@@ -476,7 +476,7 @@ class Transfer
 
                 // Execute getUpdate() in config.php if needed.
                 if ($thisFileName == $thisFileDir.'/config.php') {
-                    invalidateOPCache($thisFileName, true);
+                    invalidateOpcache($thisFileName, true);
                     include $thisFileName;
 
                     $configClass = str_replace(array('.php', 'application', '/'), array('', '', "\\"), $thisFileName);


### PR DESCRIPTION
# Description
Fix case mismatch in function name.
Class names as well as function/method names are case-insensitive, but it is considered good practice to use them as they appear in their declaration.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
