### PR TITLE
Update optimize_vendor.php

### DIFF
--- a/build/optimize_vendor.php
+++ b/build/optimize_vendor.php
@@ -103,9 +103,10 @@ $directories = [
     ],
     'npm-asset' => [
         'keep' => [
-            'jquery/dist/',
+            'jquery/dist/jquery.min.js',
             'jquery/LICENSE.txt',
-            'jquery-ui/dist/',
+            'jquery-ui/dist/themes/',
+            'jquery-ui/dist/jquery-ui.min.js',
             'jquery-ui/LICENSE.txt',
         ]
     ],


### PR DESCRIPTION
# Description
Only keep jquery.min.js, jquery-ui.min.js and the themes.
This gets rid of about 1.3 MB for production.

Plugins that might use the non minified versions of these files or jquery.slim break.

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)