### PR TITLE
Update to CKEditor 4.21.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -73,16 +73,16 @@
         },
         {
             "name": "ckeditor/ckeditor",
-            "version": "4.20.2",
+            "version": "4.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ckeditor/ckeditor4-releases.git",
-                "reference": "8cc8f1b065f93d90c305c2609fec4e4215dd20ba"
+                "reference": "af71d07caa2172c53e0e426250e3b0189137915b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ckeditor/ckeditor4-releases/zipball/8cc8f1b065f93d90c305c2609fec4e4215dd20ba",
-                "reference": "8cc8f1b065f93d90c305c2609fec4e4215dd20ba",
+                "url": "https://api.github.com/repos/ckeditor/ckeditor4-releases/zipball/af71d07caa2172c53e0e426250e3b0189137915b",
+                "reference": "af71d07caa2172c53e0e426250e3b0189137915b",
                 "shasum": ""
             },
             "type": "library",
@@ -117,7 +117,7 @@
                 "source": "https://github.com/ckeditor/ckeditor4",
                 "wiki": "https://ckeditor.com/docs/ckeditor4/latest/"
             },
-            "time": "2023-02-15T12:55:37+00:00"
+            "time": "2023-03-22T10:37:38+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",


### PR DESCRIPTION
# Description

> A cross-site scripting vulnerability has been discovered affecting Iframe Dialog and Media Embed plugins.
https://github.com/ckeditor/ckeditor4/blob/master/CHANGES.md

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
