### PR TITLE
Fixes away module

### DIFF
--- a/application/modules/away/config/config.php
+++ b/application/modules/away/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'away',
-        'version' => '1.5.0',
+        'version' => '1.6.0',
         'icon_small' => 'fa-calendar-times-o',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/away/config/config.php
+++ b/application/modules/away/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
     public $config = [
         'key' => 'away',
         'version' => '1.6.0',
-        'icon_small' => 'fa-calendar-times-o',
+        'icon_small' => 'fa-solid fa-calendar-xmark',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
         'official' => true,
@@ -25,8 +25,8 @@ class Config extends \Ilch\Config\Install
                 'description' => 'User can enter when they are away (e.g. on holidays). There is an overview of this and the entries can be mananged in the admincenter.',
             ],
         ],
-        'ilchCore' => '2.1.44',
-        'phpVersion' => '7.0'
+        'ilchCore' => '2.1.48',
+        'phpVersion' => '7.3'
     ];
 
     public function install()
@@ -102,6 +102,8 @@ class Config extends \Ilch\Config\Install
 
                 $databaseConfig = new \Ilch\Config\Database($this->db());
                 $databaseConfig->set('away_adminNotification', 1);
+            case "1.5.0":
+                $this->db()->query("UPDATE `[prefix]_modules` SET `icon_small` = 'fa-solid fa-calendar-xmark' WHERE `key` = 'away';");
         }
     }
 }

--- a/application/modules/away/controllers/Index.php
+++ b/application/modules/away/controllers/Index.php
@@ -36,29 +36,29 @@ class Index extends \Ilch\Controller\Frontend
         ];
 
         if ($this->getRequest()->getPost('saveAway')) {
-            $post = [
-                'reason' => trim($this->getRequest()->getPost('reason')),
-                'start' => new \Ilch\Date(trim($this->getRequest()->getPost('start'))),
-                'end' => new \Ilch\Date(trim($this->getRequest()->getPost('end'))),
-                'text' => trim($this->getRequest()->getPost('text')),
-                'calendarShow' => trim($this->getRequest()->getPost('calendarShow'))
-            ];
-
             Validation::setCustomFieldAliases([
                 'start' => 'when',
                 'end' => 'when',
                 'text' => 'description'
             ]);
 
-            $validation = Validation::create($post, [
+            $validation = Validation::create($this->getRequest()->getPost(), [
                 'reason' => 'required',
-                'start' => 'required',
-                'end' => 'required',
+                'start' => 'required|date:d.m.Y',
+                'end' => 'required|date:d.m.Y',
                 'text' => 'required',
                 'calendarShow' => 'numeric|integer|min:1|max:1'
             ]);
 
             if ($validation->isValid()) {
+                $post = [
+                    'reason' => trim($this->getRequest()->getPost('reason')),
+                    'start' => new \Ilch\Date(trim($this->getRequest()->getPost('start'))),
+                    'end' => new \Ilch\Date(trim($this->getRequest()->getPost('end'))),
+                    'text' => trim($this->getRequest()->getPost('text')),
+                    'calendarShow' => trim($this->getRequest()->getPost('calendarShow'))
+                ];
+
                 $awayModel = new AwayModel();
                 $awayModel->setUserId($this->getUser()->getId());
                 $awayModel->setReason($post['reason']);

--- a/application/modules/away/controllers/admin/Index.php
+++ b/application/modules/away/controllers/admin/Index.php
@@ -20,13 +20,13 @@ class Index extends \Ilch\Controller\Admin
             [
                 'name' => 'manage',
                 'active' => true,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
             ],
             [
                 'name' => 'settings',
                 'active' => false,
-                'icon' => 'fa fa-cogs',
+                'icon' => 'fa-solid fa-gears',
                 'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
             ]
         ];

--- a/application/modules/away/controllers/admin/Settings.php
+++ b/application/modules/away/controllers/admin/Settings.php
@@ -18,13 +18,13 @@ class Settings extends \Ilch\Controller\Admin
             [
                 'name' => 'manage',
                 'active' => false,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
             ],
             [
                 'name' => 'settings',
                 'active' => true,
-                'icon' => 'fa fa-cogs',
+                'icon' => 'fa-solid fa-gears',
                 'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
             ]
         ];

--- a/application/modules/away/views/admin/index/index.php
+++ b/application/modules/away/views/admin/index/index.php
@@ -35,11 +35,11 @@
                             <td>
                                 <?php if ($away->getStatus() == 1): ?>
                                     <a href="<?=$this->getUrl(['action' => 'update', 'id' => $away->getId()], null, true) ?>">
-                                        <span class="fa fa-check-square-o text-info"></span>
+                                        <span class="fa-regular fa-square-check text-info"></span>
                                     </a>
                                 <?php else: ?>
                                     <a href="<?=$this->getUrl(['action' => 'update', 'id' => $away->getId()], null, true) ?>">
-                                        <span class="fa fa-square-o text-info"></span>
+                                        <span class="fa-regular fa-square text-info"></span>
                                     </a>
                                 <?php endif; ?>
                             </td>

--- a/application/modules/away/views/index/index.php
+++ b/application/modules/away/views/index/index.php
@@ -52,7 +52,7 @@ if ($this->getUser()) {
                                     <div><?=$this->getTrans($startDate->format('l', true)) ?></div>
                                     <div class="shortdate"><?=$this->getTrans($startDate->format('F', true)).$startDate->format(', Y', true) ?></div>
                                 </div>
-                                <div class="agenda-arrow"><i class="fa fa-chevron-right"></i></div>
+                                <div class="agenda-arrow"><i class="fa-solid fa-chevron-right"></i></div>
                                 <div>
                                     <div class="dayofmonth"><?=$endDate->format('d', true) ?></div>
                                     <div><?=$this->getTrans($endDate->format('l', true)) ?></div>
@@ -72,11 +72,11 @@ if ($this->getUser()) {
                                         <?php if ($away->getStart() >= date('Y-m-d') || $away->getEnd() >= date('Y-m-d')): ?>
                                             <?php if ($away->getStatus() == 1): ?>
                                                 <a href="<?=$this->getUrl(['action' => 'update', 'id' => $away->getId()], null, true) ?>">
-                                                    <span class="fa fa-check-square-o text-info"></span>
+                                                    <span class="fa-regular fa-square-check text-info"></span>
                                                 </a>
                                             <?php else: ?>
                                                 <a href="<?=$this->getUrl(['action' => 'update', 'id' => $away->getId()], null, true) ?>">
-                                                    <span class="fa fa-square-o text-info"></span>
+                                                    <span class="fa-regular fa-square text-info"></span>
                                                 </a>
                                             <?php endif; ?>
                                         <?php endif; ?>
@@ -134,7 +134,7 @@ if ($this->getUser()) {
                        size="16"
                        readonly>
                 <span class="input-group-addon">
-                    <span class="fa fa-calendar"></span>
+                    <span class="fa-solid fa-calendar"></span>
                 </span>
             </div>
             <div class="col-lg-3 input-group ilch-date date form_datetime">
@@ -145,7 +145,7 @@ if ($this->getUser()) {
                        size="16"
                        readonly>
                 <span class="input-group-addon">
-                    <span class="fa fa-calendar"></span>
+                    <span class="fa-solid fa-calendar"></span>
                 </span>
             </div>
         </div>

--- a/application/modules/away/views/index/index.php
+++ b/application/modules/away/views/index/index.php
@@ -122,7 +122,7 @@ if ($this->getUser()) {
                        value="<?=($this->get('post') != '') ? $this->get('post')['reason'] : '' ?>" />
             </div>
         </div>
-        <div class="form-group <?=(in_array('start', $this->get('errorFields')) or in_array('end', $this->get('errorFields'))) ? 'has-error' : '' ?>">
+        <div class="form-group <?=in_array('when', $this->get('errorFields')) ? 'has-error' : '' ?>">
             <label for="start" class="col-md-2 control-label">
                 <?=$this->getTrans('when') ?>:
             </label>


### PR DESCRIPTION
# Description
- Fix deprecation warning "trim(): Passing null to parameter of type string is deprecated"
- Convert FontAwesome style classes to FontAwesome 6

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [X] Firefox
