### PR TITLE
Add unit tests for more validators

### DIFF
--- a/application/libraries/Ilch/Validation/Validators/Integer.php
+++ b/application/libraries/Ilch/Validation/Validators/Integer.php
@@ -31,7 +31,7 @@ class Integer extends Base
      * @var string
      * @since 2.1.43
      */
-    protected $invertErrorKey = 'validation.errors.required.dontBeInteger';
+    protected $invertErrorKey = 'validation.errors.integer.dontBeInteger';
 
     /**
      * Runs the validation.

--- a/application/libraries/Ilch/Validation/Validators/Same.php
+++ b/application/libraries/Ilch/Validation/Validators/Same.php
@@ -31,7 +31,7 @@ class Same extends Base
      * @var string
      * @since 2.1.43
      */
-    protected $invertErrorKey = 'validation.errors.required.fieldsMatch';
+    protected $invertErrorKey = 'validation.errors.same.fieldsMatch';
 
     /**
      * Minimum parameter count needed.

--- a/application/libraries/Ilch/Validation/Validators/Unique.php
+++ b/application/libraries/Ilch/Validation/Validators/Unique.php
@@ -33,7 +33,7 @@ class Unique extends Base
      * @var string
      * @since 2.1.43
      */
-    protected $invertErrorKey = 'validation.errors.required.valueNotExists';
+    protected $invertErrorKey = 'validation.errors.unique.valueNotExists';
 
     /**
      * Minimum parameter count needed.

--- a/application/libraries/Ilch/Validation/Validators/Unique.php
+++ b/application/libraries/Ilch/Validation/Validators/Unique.php
@@ -59,7 +59,7 @@ class Unique extends Base
 
         $whereLeft = 'LOWER(`'.$column.'`)';
         $whereMiddle = '=';
-        $whereRight = $db->escape(strtolower($this->getValue()), true);
+        $whereRight = $db->escape($this->getValue(), true);
 
         $where = new \Ilch\Database\Mysql\Expression\Comparison($whereLeft, $whereMiddle, $whereRight);
 

--- a/application/libraries/Ilch/Validation/Validators/Unique.php
+++ b/application/libraries/Ilch/Validation/Validators/Unique.php
@@ -59,7 +59,7 @@ class Unique extends Base
 
         $whereLeft = 'LOWER(`'.$column.'`)';
         $whereMiddle = '=';
-        $whereRight = $db->escape($this->getValue(), true);
+        $whereRight = $db->escape(strtolower($this->getValue()), true);
 
         $where = new \Ilch\Database\Mysql\Expression\Comparison($whereLeft, $whereMiddle, $whereRight);
 

--- a/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
+++ b/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
@@ -14,6 +14,8 @@ use stdClass;
  */
 class CaptchaTest extends TestCase
 {
+    protected $backupGlobals = false;
+
     /**
      * @dataProvider dpForTestValidator
      *
@@ -70,9 +72,6 @@ class CaptchaTest extends TestCase
         $data->field = 'fieldName';
         $data->parameters = [''];
         $data->input = ['fieldName' => $value];
-        if (session_status() !== PHP_SESSION_ACTIVE) {
-            session_start();
-        }
         $_SESSION['captcha'] = 'test';
         return $data;
     }

--- a/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
+++ b/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
@@ -14,8 +14,6 @@ use stdClass;
  */
 class CaptchaTest extends TestCase
 {
-    protected $backupGlobals = false;
-
     /**
      * @dataProvider dpForTestValidator
      *
@@ -26,6 +24,7 @@ class CaptchaTest extends TestCase
      */
     public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
     {
+        $_SESSION['captcha'] = 'test';
         $validator = new Captcha($data);
         $validator->run();
         self::assertSame($expectedIsValid, $validator->isValid());
@@ -72,7 +71,6 @@ class CaptchaTest extends TestCase
         $data->field = 'fieldName';
         $data->parameters = [''];
         $data->input = ['fieldName' => $value];
-        $_SESSION['captcha'] = 'test';
         return $data;
     }
 }

--- a/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
+++ b/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Ilch\Validation\Validators;
+
+use PHPUnit\Ilch\TestCase;
+use stdClass;
+
+/**
+ * Tests for the captcha validator
+ */
+class CaptchaTest extends TestCase
+{
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Captcha($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            'valid' => [
+                'data'                    => $this->createData('test'),
+                'expectedIsValid'         => true
+            ],
+            'invalid captcha' => [
+                'data'                    => $this->createData('abc'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.captcha.wrongCaptcha',
+                'expectedErrorParameters' => []
+            ],
+            'invalid empty' => [
+                'data'                    => $this->createData(''),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.captcha.wrongCaptcha',
+                'expectedErrorParameters' => []
+            ]
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     *
+     * @param string $value
+     * @return stdClass
+     */
+    private function createData(string $value): stdClass
+    {
+        $data = new stdClass();
+        $data->field = 'fieldName';
+        $data->parameters = [''];
+        $data->input = ['fieldName' => $value];
+        $_SESSION['captcha'] = 'test';
+        return $data;
+    }
+}

--- a/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
+++ b/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
@@ -70,6 +70,9 @@ class CaptchaTest extends TestCase
         $data->field = 'fieldName';
         $data->parameters = [''];
         $data->input = ['fieldName' => $value];
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
         $_SESSION['captcha'] = 'test';
         return $data;
     }

--- a/tests/libraries/ilch/Validation/Validators/DateTest.php
+++ b/tests/libraries/ilch/Validation/Validators/DateTest.php
@@ -7,18 +7,22 @@
 namespace Ilch\Validation\Validators;
 
 use PHPUnit\Ilch\TestCase;
+use stdClass;
 
+/**
+ * Tests for the date validator
+ */
 class DateTest extends TestCase
 {
     /**
      * @dataProvider dpForTestValidator
      *
-     * @param \stdClass $data
+     * @param stdClass $data
      * @param bool $expectedIsValid
      * @param string $expectedErrorKey
      * @param array $expectedErrorParameters
      */
-    public function testValidator($data, $expectedIsValid, $expectedErrorKey = '', $expectedErrorParameters = [])
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
     {
         $validator = new Date($data);
         $validator->run();
@@ -32,7 +36,7 @@ class DateTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator()
+    public function dpForTestValidator(): array
     {
         return [
             // date validations
@@ -80,13 +84,14 @@ class DateTest extends TestCase
 
     /**
      * Helper function for creating data object
+     *
      * @param string $value
      * @param string $parameter
-     * @return \stdClass
+     * @return stdClass
      */
-    private function createData($value, $parameter = 'Y-m-d')
+    private function createData(string $value, string $parameter = 'Y-m-d'): stdClass
     {
-        $data = new \stdClass();
+        $data = new stdClass();
         $data->field = 'fieldName';
         $data->parameters = [$parameter];
         $data->input = ['fieldName' => $value];

--- a/tests/libraries/ilch/Validation/Validators/EmailTest.php
+++ b/tests/libraries/ilch/Validation/Validators/EmailTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Ilch\Validation\Validators;
+
+use PHPUnit\Ilch\TestCase;
+use stdClass;
+
+/**
+ * Tests for the email validator
+ */
+class EmailTest extends TestCase
+{
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Email($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            // email validations
+            'email valid' => [
+                'data'                    => $this->createData('test@test.de'),
+                'expectedIsValid'         => true
+            ],
+            'empty email valid' => [
+                'data'                    => $this->createData(''),
+                'expectedIsValid'         => true
+            ],
+            'email invalid' => [
+                'data'                    => $this->createData('test'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
+                'expectedErrorParameters' => []
+            ],
+            'email invalid missing domain' => [
+                'data'                    => $this->createData('test@'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
+                'expectedErrorParameters' => []
+            ],
+            'email invalid missing name' => [
+                'data'                    => $this->createData('@test.de'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
+                'expectedErrorParameters' => []
+            ],
+            'email invalid space as name and domain' => [
+                'data'                    => $this->createData(' @ '),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
+                'expectedErrorParameters' => []
+            ],
+            'email invalid domain invalid' => [
+                'data'                    => $this->createData(' @.de'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
+                'expectedErrorParameters' => []
+            ],
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     *
+     * @param string $value
+     * @return stdClass
+     */
+    private function createData(string $value): stdClass
+    {
+        $data = new stdClass();
+        $data->field = 'fieldName';
+        $data->parameters = [''];
+        $data->input = ['fieldName' => $value];
+        return $data;
+    }
+}

--- a/tests/libraries/ilch/Validation/Validators/ExistsTest.php
+++ b/tests/libraries/ilch/Validation/Validators/ExistsTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Modules\Admin\Mappers;
+
+use Ilch\Validation\Validators\Exists;
+use PHPUnit\Ilch\DatabaseTestCase;
+use PHPUnit\Ilch\PhpunitDataset;
+use stdClass;
+
+/**
+ * Tests the Exists validator.
+ *
+ * @package ilch_phpunit
+ */
+class ExistsTest extends DatabaseTestCase
+{
+    protected $phpunitDataset;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
+    }
+
+    /**
+     * Returns database schema sql statements to initialize database
+     *
+     * @return string
+     */
+    protected static function getSchemaSQLQueries()
+    {
+        return 'CREATE TABLE IF NOT EXISTS `[prefix]_groups` (
+                `id` INT(11) NOT NULL AUTO_INCREMENT,
+                `name` VARCHAR(255) NOT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=2;';
+    }
+
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Exists($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            'existing table, column and value' => [
+                'data'                    => $this->createData(['groups', 'id'], '1'),
+                'expectedIsValid'         => true
+            ],
+            'existing table and column' => [
+                'data'                    => $this->createData(['groups', 'id']),
+                'expectedIsValid'         => true
+            ],
+            'existing table, other column' => [
+                'data'                    => $this->createData(['groups', 'name']),
+                'expectedIsValid'         => true
+            ],
+            'existing table, other column and value' => [
+                'data'                    => $this->createData(['groups', 'name'], 'admin'),
+                'expectedIsValid'         => true
+            ],
+            'existing table, two columns' => [
+                'data'                    => $this->createData(['groups', 'name', 'id']),
+                'expectedIsValid'         => true
+            ],
+            'existing table, other column and wrong value' => [
+                'data'                    => $this->createData(['groups', 'name'], 'star'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.exists.resourceNotFound',
+                'expectedErrorParameters' => []
+            ],
+            'existing table, column wrong value' => [
+                'data'                    => $this->createData(['groups', 'id'], '3'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.exists.resourceNotFound',
+                'expectedErrorParameters' => []
+            ],
+            // Returns true for a not existing column?
+            'existing table wrong column' => [
+                'data'                    => $this->createData(['groups', 'abc']),
+                'expectedIsValid'         => true
+            ],
+            //  MySQL Error: Unknown column 'abc' in 'field list'
+//            'existing table wrong column with value' => [
+//                'data'                    => $this->createData(['groups', 'abc'], '1'),
+//                'expectedIsValid'         => false,
+//                'expectedErrorKey'        => 'validation.errors.exists.resourceNotFound',
+//                'expectedErrorParameters' => []
+//            ],
+            // Returns true for a not existing table?
+            'wrong table' => [
+                'data'                    => $this->createData(['abc']),
+                'expectedIsValid'         => true
+            ],
+            'wrong table inverted' => [
+                'data'                    => $this->createData(['abc'], null, true),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.exists.resourceNotFound',
+                'expectedErrorParameters' => []
+            ],
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     *
+     * @param array $parameter
+     * @param string|null $value
+     * @param bool $invertResult
+     * @return stdClass
+     */
+    private function createData(array $parameter = [], string $value = null, bool $invertResult = false): stdClass
+    {
+        $data = new stdClass();
+        $data->field = 'fieldName';
+        $data->parameters = $parameter;
+        $data->input = ['fieldName' => $value];
+        $data->invertResult = $invertResult;
+        return $data;
+    }
+}

--- a/tests/libraries/ilch/Validation/Validators/IntegerTest.php
+++ b/tests/libraries/ilch/Validation/Validators/IntegerTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Ilch\Validation\Validators;
+
+use PHPUnit\Ilch\TestCase;
+use stdClass;
+
+/**
+ * Tests for the integer validator
+ */
+class IntegerTest extends TestCase
+{
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Integer($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            'valid integer' => [
+                'data'                    => $this->createData(1),
+                'expectedIsValid'         => true
+            ],
+            'valid integer string' => [
+                'data'                    => $this->createData('1'),
+                'expectedIsValid'         => true
+            ],
+            'valid integer empty' => [
+                'data'                    => $this->createData(''),
+                'expectedIsValid'         => true
+            ],
+            'invalid integer' => [
+                'data'                    => $this->createData(1.5),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.integer.mustBeInteger',
+                'expectedErrorParameters' => []
+            ],
+            'invalid integer string' => [
+                'data'                    => $this->createData('1.5'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.integer.mustBeInteger',
+                'expectedErrorParameters' => []
+            ],
+            'invalid integer invert' => [
+                'data'                    => $this->createData(1.5, true),
+                'expectedIsValid'         => true
+            ],
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     *
+     * @param mixed $value
+     * @param bool $invertResult
+     * @return stdClass
+     */
+    private function createData($value, bool $invertResult = false): stdClass
+    {
+        $data = new stdClass();
+        $data->field = 'fieldName';
+        $data->parameters = [''];
+        $data->invertResult = $invertResult;
+        $data->input = ['fieldName' => $value];
+        return $data;
+    }
+}

--- a/tests/libraries/ilch/Validation/Validators/MaxTest.php
+++ b/tests/libraries/ilch/Validation/Validators/MaxTest.php
@@ -7,18 +7,22 @@
 namespace Ilch\Validation\Validators;
 
 use PHPUnit\Ilch\TestCase;
+use stdClass;
 
+/**
+ * Tests for the max validator
+ */
 class MaxTest extends TestCase
 {
     /**
      * @dataProvider dpForTestValidator
      *
-     * @param \stdClass $data
+     * @param stdClass $data
      * @param bool $expectedIsValid
      * @param string $expectedErrorKey
      * @param array $expectedErrorParameters
      */
-    public function testValidator($data, $expectedIsValid, $expectedErrorKey = '', $expectedErrorParameters = [])
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
     {
         $validator = new Max($data);
         $validator->run();
@@ -32,7 +36,7 @@ class MaxTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator()
+    public function dpForTestValidator(): array
     {
         return [
             // string validations
@@ -87,14 +91,15 @@ class MaxTest extends TestCase
 
     /**
      * Helper function for creating data object
-     * @param string $value
+     *
+     * @param mixed $value
      * @param int $max
      * @param bool $forceString
-     * @return \stdClass
+     * @return stdClass
      */
-    private function createData($value, $max, $forceString = false)
+    private function createData($value, int $max, bool $forceString = false): stdClass
     {
-        $data = new \stdClass();
+        $data = new stdClass();
         $data->field = 'fieldName';
         $data->parameters = [$max];
         if ($forceString) {

--- a/tests/libraries/ilch/Validation/Validators/MinTest.php
+++ b/tests/libraries/ilch/Validation/Validators/MinTest.php
@@ -7,18 +7,22 @@
 namespace Ilch\Validation\Validators;
 
 use PHPUnit\Ilch\TestCase;
+use stdClass;
 
+/**
+ * Tests for the min validator
+ */
 class MinTest extends TestCase
 {
     /**
      * @dataProvider dpForTestValidator
      *
-     * @param \stdClass $data
+     * @param stdClass $data
      * @param bool $expectedIsValid
      * @param string $expectedErrorKey
      * @param array $expectedErrorParameters
      */
-    public function testValidator($data, $expectedIsValid, $expectedErrorKey = '', $expectedErrorParameters = [])
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
     {
         $validator = new Min($data);
         $validator->run();
@@ -32,21 +36,21 @@ class MinTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator()
+    public function dpForTestValidator(): array
     {
         return [
             // string validations
-            'string correct'                    => [
+            'string correct'              => [
                 'data'                    => $this->createData('abcdef', 5),
                 'expectedIsValid'         => true
             ],
-            'string too short'                  => [
+            'string too short'            => [
                 'data'                    => $this->createData('abcd', 5),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.min.string',
                 'expectedErrorParameters' => [5]
             ],
-            'number string as string correct'   => [
+            'number string as string correct' => [
                 'data'                    => $this->createData('12345', 5, true),
                 'expectedIsValid'         => true
             ],
@@ -57,44 +61,49 @@ class MinTest extends TestCase
                 'expectedErrorParameters' => [5]
             ],
             // numeric
-            'number (int) correct'              => [
+            'number (int) correct'        => [
                 'data'                    => $this->createData(5, 5),
                 'expectedIsValid'         => true
             ],
-            'number string correct'             => [
+            'number string correct'       => [
                 'data'                    => $this->createData('5', 5),
                 'expectedIsValid'         => true
             ],
-            'number too low'                    => [
+            'number too low'              => [
                 'data'                    => $this->createData('4', 5),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.min.numeric',
                 'expectedErrorParameters' => [5]
             ],
             //array
-            'array correct'                     => [
+            'array correct'               => [
                 'data'                    => $this->createData([1, 2, 3], 3),
                 'expectedIsValid'         => true
             ],
-            'array too small'                   => [
+            'array bigger than needed'    => [
                 'data'                    => $this->createData([1, 2, 3], 2),
-                'expectedIsValid'         => true,
+                'expectedIsValid'         => true
+            ],
+            'array too small'             => [
+                'data'                    => $this->createData([1, 2], 3),
+                'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.min.array',
-                'expectedErrorParameters' => [2]
+                'expectedErrorParameters' => [3]
             ],
         ];
     }
 
     /**
      * Helper function for creating data object
-     * @param string $value
+     *
+     * @param mixed $value
      * @param int $min
      * @param bool $forceString
-     * @return \stdClass
+     * @return stdClass
      */
-    private function createData($value, $min, $forceString = false)
+    private function createData($value, int $min, bool $forceString = false): stdClass
     {
-        $data = new \stdClass();
+        $data = new stdClass();
         $data->field = 'fieldName';
         $data->parameters = [$min];
         if ($forceString) {

--- a/tests/libraries/ilch/Validation/Validators/NumericTest.php
+++ b/tests/libraries/ilch/Validation/Validators/NumericTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Ilch\Validation\Validators;
+
+use PHPUnit\Ilch\TestCase;
+use stdClass;
+
+/**
+ * Tests for the numeric validator
+ */
+class NumericTest extends TestCase
+{
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Numeric($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            'valid numeric' => [
+                'data'                    => $this->createData(1),
+                'expectedIsValid'         => true
+            ],
+            'valid numeric string' => [
+                'data'                    => $this->createData('1'),
+                'expectedIsValid'         => true
+            ],
+            'valid numeric empty' => [
+                'data'                    => $this->createData(''),
+                'expectedIsValid'         => true
+            ],
+            'valid numeric float' => [
+                'data'                    => $this->createData(1.5),
+                'expectedIsValid'         => true
+            ],
+            'valid numeric float string' => [
+                'data'                    => $this->createData('1.5'),
+                'expectedIsValid'         => true
+            ],
+            'invalid numeric string' => [
+                'data'                    => $this->createData('a'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.numeric.mustBeNumeric',
+                'expectedErrorParameters' => []
+            ],
+            'valid numeric invert' => [
+                'data'                    => $this->createData(1.5, true),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.numeric.mustBeNumeric',
+                'expectedErrorParameters' => []
+            ],
+            'invalid numeric invert' => [
+                'data'                    => $this->createData('a', true),
+                'expectedIsValid'         => true
+            ],
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     * 
+     * @param string|int $value
+     * @param bool $invertResult
+     * @return stdClass
+     */
+    private function createData($value, bool $invertResult = false): stdClass
+    {
+        $data = new stdClass();
+        $data->field = 'fieldName';
+        $data->parameters = [''];
+        $data->invertResult = $invertResult;
+        $data->input = ['fieldName' => $value];
+        return $data;
+    }
+}

--- a/tests/libraries/ilch/Validation/Validators/RequiredTest.php
+++ b/tests/libraries/ilch/Validation/Validators/RequiredTest.php
@@ -10,9 +10,9 @@ use PHPUnit\Ilch\TestCase;
 use stdClass;
 
 /**
- * Tests for the numeric validator
+ * Tests for the required validator
  */
-class NumericTest extends TestCase
+class RequiredTest extends TestCase
 {
     /**
      * @dataProvider dpForTestValidator
@@ -24,7 +24,7 @@ class NumericTest extends TestCase
      */
     public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
     {
-        $validator = new Numeric($data);
+        $validator = new Required($data);
         $validator->run();
         self::assertSame($expectedIsValid, $validator->isValid());
         if (!empty($expectedErrorKey)) {
@@ -39,49 +39,27 @@ class NumericTest extends TestCase
     public function dpForTestValidator(): array
     {
         return [
-            'valid numeric' => [
-                'data'                    => $this->createData(1),
+            'valid' => [
+                'data'                    => $this->createData('test'),
                 'expectedIsValid'         => true
             ],
-            'valid numeric string' => [
-                'data'                    => $this->createData('1'),
-                'expectedIsValid'         => true
-            ],
-            'valid numeric empty' => [
+            'invalid' => [
                 'data'                    => $this->createData(''),
-                'expectedIsValid'         => true
-            ],
-            'valid numeric float' => [
-                'data'                    => $this->createData(1.5),
-                'expectedIsValid'         => true
-            ],
-            'valid numeric float string' => [
-                'data'                    => $this->createData('1.5'),
-                'expectedIsValid'         => true
-            ],
-            'invalid numeric string' => [
-                'data'                    => $this->createData('a'),
                 'expectedIsValid'         => false,
-                'expectedErrorKey'        => 'validation.errors.numeric.mustBeNumeric',
+                'expectedErrorKey'        => 'validation.errors.required.fieldIsRequired',
                 'expectedErrorParameters' => []
             ],
-            'valid numeric invert' => [
-                'data'                    => $this->createData(1.5, true),
-                'expectedIsValid'         => false,
-                'expectedErrorKey'        => 'validation.errors.numeric.mustBeNumeric',
-                'expectedErrorParameters' => []
-            ],
-            'invalid numeric invert' => [
-                'data'                    => $this->createData('a', true),
+            'invalid inverted' => [
+                'data'                    => $this->createData('', true),
                 'expectedIsValid'         => true
-            ],
+            ]
         ];
     }
 
     /**
      * Helper function for creating data object
      *
-     * @param string|int $value
+     * @param mixed $value
      * @param bool $invertResult
      * @return stdClass
      */

--- a/tests/libraries/ilch/Validation/Validators/SameTest.php
+++ b/tests/libraries/ilch/Validation/Validators/SameTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Ilch\Validation\Validators;
+
+use PHPUnit\Ilch\TestCase;
+use stdClass;
+
+/**
+ * Tests for the Same validator
+ */
+class SameTest extends TestCase
+{
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Same($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            'passwords are the same' => [
+                'data'                    => $this->createData('password', 'god', 'password_confirm', 'god'),
+                'expectedIsValid'         => true
+            ],
+            'password are not the same' => [
+                'data'                    => $this->createData('password', '123', 'password_confirm', 'god'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.same.fieldsDontMatch',
+                'expectedErrorParameters' => ['password_confirm']
+            ],
+            'strict comparison' => [
+                'data'                    => $this->createData('password', '123', 'password_confirm', 123, true),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.same.fieldsDontMatch',
+                'expectedErrorParameters' => ['password_confirm']
+            ],
+            'passwords are the same inverted' => [
+                'data'                    => $this->createData('password', 'god', 'password_confirm', 'god', null, true),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.same.fieldsDontMatch',
+                'expectedErrorParameters' => ['password_confirm']
+            ],
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     *
+     * @param string $firstField
+     * @param mixed $valueFirstField
+     * @param string $secondField
+     * @param mixed $valueSecondField
+     * @param mixed $strict
+     * @param bool $invertResult
+     * @return stdClass
+     */
+    private function createData(string $firstField, $valueFirstField, string $secondField, $valueSecondField, bool $strict = null, bool $invertResult = false): stdClass
+    {
+        $data = new stdClass();
+        $data->field = $firstField;
+        $data->parameters = [$secondField, $strict];
+        $data->invertResult = $invertResult;
+        $data->input = [$firstField => $valueFirstField, $secondField => $valueSecondField];
+        return $data;
+    }
+}

--- a/tests/libraries/ilch/Validation/Validators/SizeTest.php
+++ b/tests/libraries/ilch/Validation/Validators/SizeTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Ilch\Validation\Validators;
+
+use PHPUnit\Ilch\TestCase;
+use stdClass;
+
+/**
+ * Tests for the size validator
+ */
+class SizeTest extends TestCase
+{
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Size($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            // numeric
+            'valid' => [
+                'data'                    => $this->createData(3, 3),
+                'expectedIsValid'         => true
+            ],
+            'invalid' => [
+                'data'                    => $this->createData(3, 2),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.size.numeric',
+                'expectedErrorParameters' => [2]
+            ],
+            // array
+            'array valid' => [
+                'data'                    => $this->createData(['a', 'b', 'c'], 3),
+                'expectedIsValid'         => true
+            ],
+            'array invalid' => [
+                'data'                    => $this->createData(['a', 'b', 'c'], 2),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.size.array',
+                'expectedErrorParameters' => [2]
+            ],
+            'array empty invalid' => [
+                'data'                    => $this->createData([], 2),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.size.array',
+                'expectedErrorParameters' => [2]
+            ],
+            // string
+            'string valid' => [
+                'data'                    => $this->createData('abc', 3),
+                'expectedIsValid'         => true
+            ],
+            'numeric string valid' => [
+                'data'                    => $this->createData('123', 3, true),
+                'expectedIsValid'         => true
+            ],
+            'numeric string invalid force string false' => [
+                'data'                    => $this->createData('123', 3),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.size.numeric',
+                'expectedErrorParameters' => [3]
+            ],
+            'numeric string valid force string false' => [
+                'data'                    => $this->createData('123', 123),
+                'expectedIsValid'         => true
+            ],
+            'string invalid' => [
+                'data'                    => $this->createData('abc', 2),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.size.string',
+                'expectedErrorParameters' => [2]
+            ],
+//            'string empty invalid' => [
+//                'data'                    => $this->createData('', 2),
+//                'expectedIsValid'         => false,
+//                'expectedErrorKey'        => 'validation.errors.size.string',
+//                'expectedErrorParameters' => [2]
+//            ]
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     *
+     * @param mixed $value
+     * @param int $size
+     * @param bool $forceString
+     * @return stdClass
+     */
+    private function createData($value, int $size, bool $forceString = false): stdClass
+    {
+        $data = new stdClass();
+        $data->field = 'fieldName';
+        $data->parameters = [$size];
+        if ($forceString) {
+            $data->parameters[] = 'string';
+        }
+        $data->input = ['fieldName' => $value];
+        return $data;
+    }
+}

--- a/tests/libraries/ilch/Validation/Validators/UniqueTest.php
+++ b/tests/libraries/ilch/Validation/Validators/UniqueTest.php
@@ -67,30 +67,30 @@ class UniqueTest extends DatabaseTestCase
     {
         return [
             'unique value for name' => [
-                'data'                    => $this->createData(['groups'], 'Moderator'),
+                'data'                    => $this->createData(['groups'], 'moderator'),
                 'expectedIsValid'         => true
             ],
             'existing value for name ignored' => [
-                'data'                    => $this->createData(['groups', 'name', 1], 'Admin'),
+                'data'                    => $this->createData(['groups', 'name', 1], 'admin'),
                 'expectedIsValid'         => true
             ],
             'existing value for name ignore different id' => [
-                'data'                    => $this->createData(['groups', 'name', 2], 'Admin'),
+                'data'                    => $this->createData(['groups', 'name', 2], 'admin'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.unique.valueExists',
-                'expectedErrorParameters' => ['Admin']
+                'expectedErrorParameters' => ['admin']
             ],
             'existing value for name' => [
-                'data'                    => $this->createData(['groups'], 'Admin'),
+                'data'                    => $this->createData(['groups'], 'admin'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.unique.valueExists',
-                'expectedErrorParameters' => ['Admin']
+                'expectedErrorParameters' => ['admin']
             ],
             'unique value for name inverted' => [
-                'data'                    => $this->createData(['groups'], 'Moderator', true),
+                'data'                    => $this->createData(['groups'], 'moderator', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.unique.valueExists',
-                'expectedErrorParameters' => ['Moderator']
+                'expectedErrorParameters' => ['moderator']
             ],
         ];
     }

--- a/tests/libraries/ilch/Validation/Validators/UniqueTest.php
+++ b/tests/libraries/ilch/Validation/Validators/UniqueTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Modules\Admin\Mappers;
+
+use Ilch\Validation\Validators\Unique;
+use PHPUnit\Ilch\DatabaseTestCase;
+use PHPUnit\Ilch\PhpunitDataset;
+use stdClass;
+
+/**
+ * Tests the Unique validator.
+ *
+ * @package ilch_phpunit
+ */
+class UniqueTest extends DatabaseTestCase
+{
+    protected $phpunitDataset;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->phpunitDataset = new PhpunitDataset($this->db);
+        $this->phpunitDataset->loadFromFile(__DIR__ . '/../_files/mysql_database.yml');
+    }
+
+    /**
+     * Returns database schema sql statements to initialize database
+     *
+     * @return string
+     */
+    protected static function getSchemaSQLQueries()
+    {
+        return 'CREATE TABLE IF NOT EXISTS `[prefix]_groups` (
+                `id` INT(11) NOT NULL AUTO_INCREMENT,
+                `name` VARCHAR(255) NOT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=2;';
+    }
+
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Unique($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            'unique value for name' => [
+                'data'                    => $this->createData(['groups'], 'Moderator'),
+                'expectedIsValid'         => true
+            ],
+            'existing value for name ignored' => [
+                'data'                    => $this->createData(['groups', 'name', 1], 'Admin'),
+                'expectedIsValid'         => true
+            ],
+            'existing value for name ignore different id' => [
+                'data'                    => $this->createData(['groups', 'name', 2], 'Admin'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.unique.valueExists',
+                'expectedErrorParameters' => ['Admin']
+            ],
+            'existing value for name' => [
+                'data'                    => $this->createData(['groups'], 'Admin'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.unique.valueExists',
+                'expectedErrorParameters' => ['Admin']
+            ],
+            'unique value for name inverted' => [
+                'data'                    => $this->createData(['groups'], 'Moderator', true),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.unique.valueExists',
+                'expectedErrorParameters' => ['Moderator']
+            ],
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     *
+     * @param array $parameter
+     * @param string|null $value
+     * @param bool $invertResult
+     * @return stdClass
+     */
+    private function createData(array $parameter = [], string $value = null, bool $invertResult = false): stdClass
+    {
+        $data = new stdClass();
+        $data->field = 'name';
+        $data->parameters = $parameter;
+        $data->input = ['name' => $value];
+        $data->invertResult = $invertResult;
+        return $data;
+    }
+}

--- a/tests/libraries/ilch/Validation/Validators/UrlTest.php
+++ b/tests/libraries/ilch/Validation/Validators/UrlTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Ilch\Validation\Validators;
+
+use PHPUnit\Ilch\TestCase;
+use stdClass;
+
+/**
+ * Tests for the url validator
+ */
+class UrlTest extends TestCase
+{
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Url($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            'valid url domain with subdomain and protocol' => [
+                'data'                    => $this->createData('https://www.ilch.de'),
+                'expectedIsValid'         => true
+            ],
+            'valid url domain with subdomain and ftp protocol' => [
+                'data'                    => $this->createData('ftp://www.ilch.de'),
+                'expectedIsValid'         => true
+            ],
+            'invalid url domain with subdomain and invalid protocol' => [
+                'data'                    => $this->createData('invalid://www.ilch.de'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.url.noValidUrl',
+                'expectedErrorParameters' => []
+            ],
+            'invalid url no protocol' => [
+                'data'                    => $this->createData('ilch.de'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.url.noValidUrl',
+                'expectedErrorParameters' => []
+            ],
+            'invalid url domain with subdomain no protocol' => [
+                'data'                    => $this->createData('www.ilch.de'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.url.noValidUrl',
+                'expectedErrorParameters' => []
+            ],
+            'invalid url no domain' => [
+                'data'                    => $this->createData('ilch'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.url.noValidUrl',
+                'expectedErrorParameters' => []
+            ],
+            'empty string' => [
+                'data'                    => $this->createData(''),
+                'expectedIsValid'         => true
+            ],
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     *
+     * @param string $value
+     * @return stdClass
+     */
+    private function createData(string $value): stdClass
+    {
+        $data = new stdClass();
+        $data->field = 'fieldName';
+        $data->parameters = [''];
+        $data->input = ['fieldName' => $value];
+        $_SERVER['HTTP_HOST'] = '127.0.0.1';
+        return $data;
+    }
+}

--- a/tests/libraries/ilch/Validation/_files/mysql_database.yml
+++ b/tests/libraries/ilch/Validation/_files/mysql_database.yml
@@ -1,0 +1,8 @@
+groups:
+  -
+    id: 1
+    name: "Admin"
+
+  -
+    id: 2
+    name: "Guest"

--- a/tests/libraries/ilch/ValidationTest.php
+++ b/tests/libraries/ilch/ValidationTest.php
@@ -27,9 +27,9 @@ class ValidationTest extends TestCase
      *
      * @param array $params
      * @param bool $expected
-     * @param bool $expected
+     * @param bool $inverted
      */
-    public function testValidationWithSingleValidator(array $params, $expected, $inverted)
+    public function testValidationWithSingleValidator(array $params, bool $expected, bool $inverted)
     {
         $validation = Validation::create($params, ['testField' => ($inverted ? 'NOT' : '').'integer']);
 
@@ -42,7 +42,7 @@ class ValidationTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidationWithSingleValidator()
+    public function dpForTestValidationWithSingleValidator(): array
     {
         return [
             'int'                            => ['params' => ['testField' => 5], 'expected' => true, 'inverted' => false],
@@ -66,7 +66,7 @@ class ValidationTest extends TestCase
     public function testValidationWithValidatorChainWithBreakingChain(
         $validatorRules,
         array $params,
-        $expected,
+        bool $expected,
         array $expectedErrors = []
     ) {
         $validation = Validation::create($params, ['testField' => $validatorRules]);
@@ -131,7 +131,7 @@ class ValidationTest extends TestCase
     public function testValidationWithValidatorChainWithoutBreakingChain(
         $validatorRules,
         array $params,
-        $expected,
+        bool $expected,
         array $expectedErrors = []
     ) {
         $this->addTearDownCallback(
@@ -152,7 +152,7 @@ class ValidationTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidationWithValidatorChainWithoutBreakingChain()
+    public function dpForTestValidationWithValidatorChainWithoutBreakingChain(): array
     {
         return [
             '2 validators chained - correct'       => [

--- a/tests/libraries/ilch/ValidationTest.php
+++ b/tests/libraries/ilch/ValidationTest.php
@@ -198,6 +198,7 @@ class ValidationTest extends TestCase
         bool $expected,
         array $expectedErrors = []
     ) {
+        $_SESSION['captcha'] = 'test';
         // Needed for Url validator
         $_SERVER['HTTP_HOST'] = '127.0.0.1';
 
@@ -221,20 +222,20 @@ class ValidationTest extends TestCase
      */
     public function dpForTestValidationWithVariousValidators(): array
     {
-        // Excluding the validators Captcha, Grecaptcha, Integer (already covered above), Exists and Unique.
+        // Excluding the validators Grecaptcha, Integer (not inverted; already covered above), Exists and Unique.
         return [
-            // Integer validator inverted
-            'integer validator - valid inverted' => [
-                'validatorRules' => 'NOTinteger',
-                'params'         => ['testField' => 1.5],
+            // Captcha validator
+            'captcha validator - valid' => [
+                'validatorRules' => 'captcha',
+                'params'         => ['testField' => 'test'],
                 'expected'       => true
             ],
-            'integer validator - invalid inverted' => [
-                'validatorRules' => 'NOTinteger',
-                'params'         => ['testField' => 1],
+            'captcha validator - not valid' => [
+                'validatorRules' => 'captcha',
+                'params'         => ['testField' => 'a'],
                 'expected'       => false,
                 'expectedErrors' => [
-                    'testField' => ['validation.errors.integer.dontBeInteger']
+                    'testField' => ['validation.errors.captcha.wrongCaptcha']
                 ]
             ],
             // Date validator
@@ -281,6 +282,20 @@ class ValidationTest extends TestCase
                 'expected'       => false,
                 'expectedErrors' => [
                     'testField' => ['validation.errors.email.noValidEmail']
+                ]
+            ],
+            // Integer validator inverted
+            'integer validator - valid inverted' => [
+                'validatorRules' => 'NOTinteger',
+                'params'         => ['testField' => 1.5],
+                'expected'       => true
+            ],
+            'integer validator - invalid inverted' => [
+                'validatorRules' => 'NOTinteger',
+                'params'         => ['testField' => 1],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.integer.dontBeInteger']
                 ]
             ],
             // Max validator

--- a/tests/libraries/ilch/ValidationTest.php
+++ b/tests/libraries/ilch/ValidationTest.php
@@ -223,6 +223,20 @@ class ValidationTest extends TestCase
     {
         // Excluding the validators Captcha, Grecaptcha, Integer (already covered above), Exists and Unique.
         return [
+            // Integer validator inverted
+            'integer validator - valid inverted' => [
+                'validatorRules' => 'NOTinteger',
+                'params'         => ['testField' => 1.5],
+                'expected'       => true
+            ],
+            'integer validator - invalid inverted' => [
+                'validatorRules' => 'NOTinteger',
+                'params'         => ['testField' => 1],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.integer.dontBeInteger']
+                ]
+            ],
             // Date validator
             'date validator - valid' => [
                 'validatorRules' => 'date',
@@ -421,6 +435,19 @@ class ValidationTest extends TestCase
                     'testField' => ['validation.errors.numeric.mustBeNumeric']
                 ]
             ],
+            'Numeric validator - not valid inverted' => [
+                'validatorRules' => 'NOTnumeric',
+                'params'         => ['testField' => 1],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.required.dontBeNumeric']
+                ]
+            ],
+            'Numeric validator - valid inverted' => [
+                'validatorRules' => 'NOTnumeric',
+                'params'         => ['testField' => 'a'],
+                'expected'       => true
+            ],
             // Required validator
             'Required validator - valid' => [
                 'validatorRules' => 'required',
@@ -438,6 +465,19 @@ class ValidationTest extends TestCase
             'Required validator - valid numeric' => [
                 'validatorRules' => 'required',
                 'params'         => ['testField' => 1],
+                'expected'       => true
+            ],
+            'Required validator - not valid inverted' => [
+                'validatorRules' => 'NOTrequired',
+                'params'         => ['testField' => 'a'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.required.fieldIsNotRequired']
+                ]
+            ],
+            'Required validator - valid inverted' => [
+                'validatorRules' => 'NOTrequired',
+                'params'         => ['testField' => ''],
                 'expected'       => true
             ],
             // Same validator
@@ -462,6 +502,19 @@ class ValidationTest extends TestCase
                 'expected'       => false,
                 'expectedErrors' => [
                     'testField' => ['validation.errors.same.fieldsDontMatch']
+                ]
+            ],
+            'Same validator - valid inverted' => [
+                'validatorRules' => 'NOTsame:password',
+                'params'         => ['password' => 'a', 'testField' => 'b'],
+                'expected'       => true
+            ],
+            'Same validator - not valid inverted' => [
+                'validatorRules' => 'NOTsame:password',
+                'params'         => ['password' => 'a', 'testField' => 'a'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.same.fieldsMatch']
                 ]
             ],
             // Size validator

--- a/tests/libraries/ilch/ValidationTest.php
+++ b/tests/libraries/ilch/ValidationTest.php
@@ -184,6 +184,421 @@ class ValidationTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider dpForTestValidationWithVariousValidators
+     *
+     * @param string $validatorRules
+     * @param array $params
+     * @param bool $expected
+     * @param array $expectedErrors
+     */
+    public function testValidationWithVariousValidators(
+        $validatorRules,
+        array $params,
+        bool $expected,
+        array $expectedErrors = []
+    ) {
+        // Needed for Url validator
+        $_SERVER['HTTP_HOST'] = '127.0.0.1';
+
+        $this->addTearDownCallback(
+            function () {
+                Validation::setBreakChain(true);
+            }
+        );
+        Validation::setBreakChain(false);
+
+        $validation = Validation::create($params, ['testField' => $validatorRules]);
+
+        self::assertSame($expected, $validation->isValid());
+        if (!$expected) {
+            self::assertSame($expectedErrors, $validation->getErrorBag()->getErrors());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidationWithVariousValidators(): array
+    {
+        // Excluding the validators Captcha, Grecaptcha, Integer (already covered above), Exists and Unique.
+        return [
+            // Date validator
+            'date validator - valid' => [
+                'validatorRules' => 'date',
+                'params'         => ['testField' => '2023-04-29'],
+                'expected'       => true
+            ],
+            'date validator changed format - valid' => [
+                'validatorRules' => 'date:d.m.Y',
+                'params'         => ['testField' => '29.04.2023'],
+                'expected'       => true
+            ],
+            'date validator - not valid' => [
+                'validatorRules' => 'date',
+                'params'         => ['testField' => '60.04.2023'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.date.mustBeDate']
+                ]
+            ],
+            // Email validator
+            'Email validator - empty valid' => [
+                'validatorRules' => 'email',
+                'params'         => ['testField' => ''],
+                'expected'       => true
+            ],
+            'Required and Email validator - not valid' => [
+                'validatorRules' => 'required|email',
+                'params'         => ['testField' => ''],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.required.fieldIsRequired']
+                ]
+            ],
+            'Email validator - valid' => [
+                'validatorRules' => 'email',
+                'params'         => ['testField' => 'test@test.test'],
+                'expected'       => true
+            ],
+            'Email validator - not valid' => [
+                'validatorRules' => 'email',
+                'params'         => ['testField' => '@test.test'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.email.noValidEmail']
+                ]
+            ],
+            // Max validator
+            'Max validator - valid' => [
+                'validatorRules' => 'max:5',
+                'params'         => ['testField' => 5],
+                'expected'       => true
+            ],
+            'Max validator - valid value as string' => [
+                'validatorRules' => 'max:5',
+                'params'         => ['testField' => '5'],
+                'expected'       => true
+            ],
+            'Max validator - not valid' => [
+                'validatorRules' => 'max:5',
+                'params'         => ['testField' => 6],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.max.numeric']
+                ]
+            ],
+            'Max validator - valid array' => [
+                'validatorRules' => 'max:2',
+                'params'         => ['testField' => [1, 3]],
+                'expected'       => true
+            ],
+            'Max validator - valid array values as string' => [
+                'validatorRules' => 'max:2',
+                'params'         => ['testField' => ['1', '3']],
+                'expected'       => true
+            ],
+            'Max validator - not valid array' => [
+                'validatorRules' => 'max:2',
+                'params'         => ['testField' => [0, 1, 2]],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.max.array']
+                ]
+            ],
+            'Max validator - valid string' => [
+                'validatorRules' => 'max:5,string',
+                'params'         => ['testField' => 12345],
+                'expected'       => true
+            ],
+            'Max validator - valid string value as string' => [
+                'validatorRules' => 'max:5,string',
+                'params'         => ['testField' => '12345'],
+                'expected'       => true
+            ],
+            'Max validator - not valid string' => [
+                'validatorRules' => 'max:5,string',
+                'params'         => ['testField' => 123456],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.max.string']
+                ]
+            ],
+            // Min validator
+            'Min validator - valid' => [
+                'validatorRules' => 'min:5',
+                'params'         => ['testField' => 5],
+                'expected'       => true
+            ],
+            'Min validator - valid value as string' => [
+                'validatorRules' => 'min:5',
+                'params'         => ['testField' => '5'],
+                'expected'       => true
+            ],
+            'Min validator - not valid' => [
+                'validatorRules' => 'min:5',
+                'params'         => ['testField' => 4],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.min.numeric']
+                ]
+            ],
+            'Min validator - valid array' => [
+                'validatorRules' => 'min:2',
+                'params'         => ['testField' => [1, 3]],
+                'expected'       => true
+            ],
+            'Min validator - valid array values as string' => [
+                'validatorRules' => 'min:2',
+                'params'         => ['testField' => ['1', '3']],
+                'expected'       => true
+            ],
+            'Min validator - not valid array' => [
+                'validatorRules' => 'min:2',
+                'params'         => ['testField' => [3]],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.min.array']
+                ]
+            ],
+            'Min validator - valid string' => [
+                'validatorRules' => 'min:5,string',
+                'params'         => ['testField' => 12345],
+                'expected'       => true
+            ],
+            'Min validator - valid string value as string' => [
+                'validatorRules' => 'min:5,string',
+                'params'         => ['testField' => '12345'],
+                'expected'       => true
+            ],
+            'Min validator - not valid string' => [
+                'validatorRules' => 'min:5,string',
+                'params'         => ['testField' => 5678],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.min.string']
+                ]
+            ],
+            // Numeric validator
+            'Numeric validator - empty valid' => [
+                'validatorRules' => 'numeric',
+                'params'         => ['testField' => ''],
+                'expected'       => true
+            ],
+            'Required and Numeric validator - not valid' => [
+                'validatorRules' => 'required|numeric',
+                'params'         => ['testField' => ''],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.required.fieldIsRequired']
+                ]
+            ],
+            'Numeric validator - valid' => [
+                'validatorRules' => 'numeric',
+                'params'         => ['testField' => 1],
+                'expected'       => true
+            ],
+            'Numeric validator - valid float' => [
+                'validatorRules' => 'numeric',
+                'params'         => ['testField' => 1.5],
+                'expected'       => true
+            ],
+            'Numeric validator - valid string' => [
+                'validatorRules' => 'numeric',
+                'params'         => ['testField' => '1'],
+                'expected'       => true
+            ],
+            'Numeric validator - valid float string' => [
+                'validatorRules' => 'numeric',
+                'params'         => ['testField' => '1.5'],
+                'expected'       => true
+            ],
+            'Numeric validator - not valid' => [
+                'validatorRules' => 'numeric',
+                'params'         => ['testField' => 'a'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.numeric.mustBeNumeric']
+                ]
+            ],
+            // Required validator
+            'Required validator - valid' => [
+                'validatorRules' => 'required',
+                'params'         => ['testField' => 'a'],
+                'expected'       => true
+            ],
+            'Required validator - not valid' => [
+                'validatorRules' => 'required',
+                'params'         => ['testField' => ''],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.required.fieldIsRequired']
+                ]
+            ],
+            'Required validator - valid numeric' => [
+                'validatorRules' => 'required',
+                'params'         => ['testField' => 1],
+                'expected'       => true
+            ],
+            // Same validator
+            'Same validator - valid' => [
+                'validatorRules' => 'same:password',
+                'params'         => ['password' => 'a', 'testField' => 'a'],
+                'expected'       => true
+            ],
+            'Same validator - valid numeric' => [
+                'validatorRules' => 'same:password',
+                'params'         => ['password' => 1, 'testField' => 1],
+                'expected'       => true
+            ],
+            'Same validator - valid mixed' => [
+                'validatorRules' => 'same:password',
+                'params'         => ['password' => 1, 'testField' => '1'],
+                'expected'       => true
+            ],
+            'Same validator - not valid' => [
+                'validatorRules' => 'same:password',
+                'params'         => ['password' => 'a', 'testField' => 'b'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.same.fieldsDontMatch']
+                ]
+            ],
+            // Size validator
+            'Size validator - valid' => [
+                'validatorRules' => 'size:5',
+                'params'         => ['testField' => 5],
+                'expected'       => true
+            ],
+            'Size validator - valid value as string' => [
+                'validatorRules' => 'size:5',
+                'params'         => ['testField' => '5'],
+                'expected'       => true
+            ],
+            'Size validator - not valid' => [
+                'validatorRules' => 'size:5',
+                'params'         => ['testField' => 4],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.size.numeric']
+                ]
+            ],
+            'Size validator - valid array' => [
+                'validatorRules' => 'size:2',
+                'params'         => ['testField' => [1, 3]],
+                'expected'       => true
+            ],
+            'Size validator - valid array values as string' => [
+                'validatorRules' => 'size:2',
+                'params'         => ['testField' => ['1', '3']],
+                'expected'       => true
+            ],
+            'Size validator - not valid array too small' => [
+                'validatorRules' => 'size:2',
+                'params'         => ['testField' => [3]],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.size.array']
+                ]
+            ],
+            'Size validator - not valid array too big' => [
+                'validatorRules' => 'size:2',
+                'params'         => ['testField' => [1, 2, 3]],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.size.array']
+                ]
+            ],
+            'Size validator - valid string' => [
+                'validatorRules' => 'size:5,string',
+                'params'         => ['testField' => 12345],
+                'expected'       => true
+            ],
+            'Size validator - valid string value as string' => [
+                'validatorRules' => 'size:5,string',
+                'params'         => ['testField' => '12345'],
+                'expected'       => true
+            ],
+            'Size validator - not valid string too short' => [
+                'validatorRules' => 'size:5,string',
+                'params'         => ['testField' => 5678],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.size.string']
+                ]
+            ],
+            'Size validator - not valid string too big' => [
+                'validatorRules' => 'size:5,string',
+                'params'         => ['testField' => 456789],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.size.string']
+                ]
+            ],
+            // Url validator
+            'Url validator - empty valid' => [
+                'validatorRules' => 'url',
+                'params'         => ['testField' => ''],
+                'expected'       => true
+            ],
+            'Required and Url validator - not valid' => [
+                'validatorRules' => 'required|url',
+                'params'         => ['testField' => ''],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.required.fieldIsRequired']
+                ]
+            ],
+            'Url validator - not valid missing protocol' => [
+                'validatorRules' => 'url',
+                'params'         => ['testField' => 'ilch.de'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.url.noValidUrl']
+                ]
+            ],
+            'Url validator - not valid subdomain but missing protocol' => [
+                'validatorRules' => 'url',
+                'params'         => ['testField' => 'www.ilch.de'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.url.noValidUrl']
+                ]
+            ],
+            'Url validator - valid protocol' => [
+                'validatorRules' => 'url',
+                'params'         => ['testField' => 'https://ilch.de'],
+                'expected'       => true
+            ],
+            'Url validator - valid protocol ftp' => [
+                'validatorRules' => 'url',
+                'params'         => ['testField' => 'ftp://ilch.de'],
+                'expected'       => true
+            ],
+            'Url validator - valid subdomain protocol' => [
+                'validatorRules' => 'url',
+                'params'         => ['testField' => 'https://www.ilch.de'],
+                'expected'       => true
+            ],
+            'Url validator - not valid invalid protocol' => [
+                'validatorRules' => 'url',
+                'params'         => ['testField' => 'invalid://www.ilch.de'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.url.noValidUrl']
+                ]
+            ],
+            'Url validator - not valid' => [
+                'validatorRules' => 'url',
+                'params'         => ['testField' => '@test.test'],
+                'expected'       => false,
+                'expectedErrors' => [
+                    'testField' => ['validation.errors.url.noValidUrl']
+                ]
+            ],
+        ];
+    }
+
     public function testTranslation()
     {
         $this->addTearDownCallback(

--- a/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
+++ b/tests/modules/admin/mappers/LayoutAdvSettingsTest.php
@@ -25,6 +25,9 @@ class LayoutAdvSettingsTest extends DatabaseTestCase
     protected $out;
     protected $phpunitDataset;
 
+    /**
+     * Filling the config object with individual testcase data.
+     */
     public function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
# Description
- Write unit tests for most validators.
- Fixed $invertErrorKey in integer, same and unique validator (**therefore a different error key is now returned!**)

Fixes #661

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
