### PR TITLE
Add flood protection for comments

### DIFF
--- a/application/libraries/Ilch/Comments.php
+++ b/application/libraries/Ilch/Comments.php
@@ -414,6 +414,9 @@ function slideReply(thechosenone) {
         $isExcludedFromFloodProtection = is_in_array(array_keys($this->getUser($userId)->getGroups()), explode(',', $config->get('comment_excludeFloodProtection')));
 
         if ($config->get('comment_floodInterval') > 0 && !$isExcludedFromFloodProtection && ($dateCreated >= date('Y-m-d H:i:s', time()-$config->get('comment_floodInterval')))) {
+            $translator = new \Ilch\Translator();
+            $translator->load(APPLICATION_PATH.'/modules/comment/translations/');
+            $_SESSION['messages'][] = ['text' => $translator->trans('floodError'), 'type' => 'danger'];
             return false;
         }
 

--- a/application/libraries/Ilch/Comments.php
+++ b/application/libraries/Ilch/Comments.php
@@ -78,11 +78,11 @@ class Comments
                                         $obj->escape($user->getName()).'
                                     </a>
                                     <p class="text-muted small">
-                                        <i class="fa fa-clock-o" title="'.$obj->getTrans('commentDateTime').'"></i> '.$commentDate->format('d.m.Y - H:i', true).'
+                                        <i class="fa-regular fa-clock" title="'.$obj->getTrans('commentDateTime').'"></i> '.$commentDate->format('d.m.Y - H:i', true).'
                                     </p>
                                 </div>
                                 <div class="pull-right text-muted small">
-                                    <i class="fa fa-reply fa-flip-vertical"></i> '.$user_rep->getName().'
+                                    <i class="fa-solid fa-reply fa-flip-vertical"></i> '.$user_rep->getName().'
                                 </div>
                             </div>
                             <p>'.nl2br($obj->escape($fk_comment->getText())).'</p>
@@ -91,20 +91,20 @@ class Comments
                 $commentsHtml .= '
                                 <div class="btn-group">
                                     <a class="btn btn-sm btn-default btn-hover-success" href="'.$obj->getUrl(['id' => $id, 'commentId' => $fk_comment->getId(), 'key' => 'up']).'" title="'.$obj->getTrans('iLike').'">
-                                        <i class="fa fa-thumbs-up"></i> '.$obj->escape($fk_comment->getUp()).'
+                                        <i class="fa-solid fa-thumbs-up"></i> '.$obj->escape($fk_comment->getUp()).'
                                     </a>
                                     <a class="btn btn-sm btn-default btn-hover-danger" href="'.$obj->getUrl(['id' => $id, 'commentId' => $fk_comment->getId(), 'key' => 'down']).'" title="'.$obj->getTrans('notLike').'">
-                                        <i class="fa fa-thumbs-down"></i> '.$obj->escape($fk_comment->getDown()).'
+                                        <i class="fa-solid fa-thumbs-down"></i> '.$obj->escape($fk_comment->getDown()).'
                                     </a>
                                 </div>';
             } else {
                 $commentsHtml .= '
                                 <div class="btn-group">
                                     <button class="btn btn-sm btn-default btn-success">
-                                        <i class="fa fa-thumbs-up"></i> '.$obj->escape($fk_comment->getUp()).'
+                                        <i class="fa-solid fa-thumbs-up"></i> '.$obj->escape($fk_comment->getUp()).'
                                     </button>
                                     <button class="btn btn-sm btn-default btn-danger">
-                                        <i class="fa fa-thumbs-down"></i> '.$obj->escape($fk_comment->getDown()).'
+                                        <i class="fa-solid fa-thumbs-down"></i> '.$obj->escape($fk_comment->getDown()).'
                                     </button>
                                 </div>';
             }
@@ -112,7 +112,7 @@ class Comments
             if ($obj->getUser() && $config->get('comment_reply') == 1 && $req < $config->get('comment_nesting')-1) {
                 $commentsHtml .= '
                                 <a href="javascript:slideReply(\'reply_'.$fk_comment->getId().'\');" class="btn btn-sm btn-default btn-hover-primary">
-                                    <i class="fa fa-reply"></i> '.$obj->getTrans('reply').'
+                                    <i class="fa-solid fa-reply"></i> '.$obj->getTrans('reply').'
                                 </a>';
             }
 
@@ -140,11 +140,11 @@ class Comments
                                                         $obj->escape($obj->getUser()->getName()).'
                                                     </a>
                                                     <p class="text-muted small">
-                                                        <i class="fa fa-clock-o" title="'.$obj->getTrans('commentDateTime').'"></i> '.$nowDate->format('d.m.Y - H:i', true).'
+                                                        <i class="fa-regular fa-clock" title="'.$obj->getTrans('commentDateTime').'"></i> '.$nowDate->format('d.m.Y - H:i', true).'
                                                     </p>
                                                 </div>
                                                 <div class="pull-right text-muted small">
-                                                    <i class="fa fa-reply fa-flip-vertical"></i> '.$user->getName().'
+                                                    <i class="fa-solid fa-reply fa-flip-vertical"></i> '.$user->getName().'
                                                 </div>
                                             </div>
                                             <p>
@@ -238,7 +238,7 @@ class Comments
                 $layout->escape($layout->getUser()->getName()).'
                                         </a>
                                         <p class="text-muted small">
-                                            <i class="fa fa-clock-o" title="'.$layout->getTrans('commentDateTime').'"></i> '.$nowDate->format('d.m.Y - H:i', true).'
+                                            <i class="fa-regular fa-clock" title="'.$layout->getTrans('commentDateTime').'"></i> '.$nowDate->format('d.m.Y - H:i', true).'
                                         </p>
                                     </div>
                                     <p>
@@ -282,7 +282,7 @@ class Comments
                                 <div>
                                     <a href="'.$layout->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId()]).'" title="'.$layout->escape($user->getName()).'">'.$layout->escape($user->getName()).'</a>
                                     <p class="text-muted small">
-                                        <i class="fa fa-clock-o" title="'.$layout->getTrans('commentDateTime').'"></i> '.$commentDate->format('d.m.Y - H:i', true).'
+                                        <i class="fa-regular fa-clock" title="'.$layout->getTrans('commentDateTime').'"></i> '.$commentDate->format('d.m.Y - H:i', true).'
                                     </p>
                                 </div>
                                 <p>'.nl2br($layout->escape($comment->getText())).'</p>
@@ -292,20 +292,20 @@ class Comments
                 $commentsHtml .= '
                                     <div class="btn-group">
                                         <a class="btn btn-sm btn-default btn-hover-success" href="'.$layout->getUrl(['id' => $object->getId(), 'commentId' => $comment->getId(), 'key' => 'up']).'" title="'.$layout->getTrans('iLike').'">
-                                            <i class="fa fa-thumbs-up"></i> '.$comment->getUp().'
+                                            <i class="fa-solid fa-thumbs-up"></i> '.$comment->getUp().'
                                         </a>
                                         <a class="btn btn-sm btn-default btn-hover-danger" href="'.$layout->getUrl(['id' => $object->getId(), 'commentId' => $comment->getId(), 'key' => 'down']).'" title="'.$layout->getTrans('notLike').'">
-                                            <i class="fa fa-thumbs-down"></i> '.$comment->getDown().'
+                                            <i class="fa-solid fa-thumbs-down"></i> '.$comment->getDown().'
                                         </a>
                                     </div>';
             } else {
                 $commentsHtml .= '
                                     <div class="btn-group">
                                         <button class="btn btn-sm btn-default btn-success">
-                                            <i class="fa fa-thumbs-up"></i> '.$comment->getUp().'
+                                            <i class="fa-solid fa-thumbs-up"></i> '.$comment->getUp().'
                                         </button>
                                         <button class="btn btn-sm btn-default btn-danger">
-                                            <i class="fa fa-thumbs-down"></i> '.$comment->getDown().'
+                                            <i class="fa-solid fa-thumbs-down"></i> '.$comment->getDown().'
                                         </button>
                                     </div>';
             }
@@ -313,7 +313,7 @@ class Comments
             if ($layout->getUser() && $config->get('comment_reply') == 1 && $config->get('comment_nesting') > 0) {
                 $commentsHtml .= '
                                     <a href="javascript:slideReply(\'reply_'.$comment->getId().'\');" class="btn btn-sm btn-default btn-hover-primary">
-                                        <i class="fa fa-reply"></i> '.$layout->getTrans('reply').'
+                                        <i class="fa-solid fa-reply"></i> '.$layout->getTrans('reply').'
                                     </a>';
             }
             $commentsHtml .= '
@@ -337,11 +337,11 @@ class Comments
                                                                 $layout->escape($layout->getUser()->getName()).'
                                                             </a>
                                                             <p class="text-muted small">
-                                                                <i class="fa fa-clock-o" title="'.$layout->getTrans('commentDateTime').'"></i> '.$nowDate->format('d.m.Y - H:i', true).'
+                                                                <i class="fa-regular fa-clock" title="'.$layout->getTrans('commentDateTime').'"></i> '.$nowDate->format('d.m.Y - H:i', true).'
                                                             </p>
                                                         </div>
                                                         <div class="pull-right text-muted small">
-                                                            <i class="fa fa-reply fa-flip-vertical"></i> '.$layout->escape($user->getName()).'
+                                                            <i class="fa-solid fa-reply fa-flip-vertical"></i> '.$layout->escape($user->getName()).'
                                                         </div>
                                                     </div>
                                                     <p>
@@ -401,10 +401,22 @@ function slideReply(thechosenone) {
      * @param string $key key for the comment e.g. "article/index/show/id/1"
      * @param string $text text of the comment
      * @param int $userId id of the user.
+     * @return bool true if sucessfully saved. currently false if it triggered the flooding protection.
      * @since 2.1.37
+     * @since 2.1.50 boolean return value. true if sucessfully saved. false if it triggered the flooding protection.
      */
-    public function saveComment(string $key, string $text, int $userId)
+    public function saveComment(string $key, string $text, int $userId): bool
     {
+        $commentMapper = new CommentMapper();
+
+        $config = Registry::get('config');
+        $dateCreated = $commentMapper->getDateOfLastCommentByUserId($userId);
+        $isExcludedFromFloodProtection = is_in_array(array_keys($this->getUser($userId)->getGroups()), explode(',', $config->get('comment_excludeFloodProtection')));
+
+        if ($config->get('comment_floodInterval') > 0 && !$isExcludedFromFloodProtection && ($dateCreated >= date('Y-m-d H:i:s', time()-$config->get('comment_floodInterval')))) {
+            return false;
+        }
+
         $splittedKey = explode('/', $key);
         $fkId = null;
 
@@ -414,7 +426,6 @@ function slideReply(thechosenone) {
             }
         }
 
-        $commentMapper = new CommentMapper();
         $date = new Date();
         $commentModel = new CommentModel();
         $commentModel->setKey($key);
@@ -425,6 +436,8 @@ function slideReply(thechosenone) {
         $commentModel->setDateCreated($date);
         $commentModel->setUserId($userId);
         $commentMapper->save($commentModel);
+
+        return true;
     }
 
     /**

--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -881,6 +881,11 @@ class Config extends \Ilch\Config\Install
             case "2.1.48":
                 replaceVendorDirectory();
                 break;
+            case "2.1.49":
+                $databaseConfig = new \Ilch\Config\Database($this->db());
+                $databaseConfig->set('comment_floodInterval', '0');
+                $databaseConfig->set('comment_excludeFloodProtection', '1');
+                break;
         }
 
         return 'Update function executed.';

--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -883,7 +883,7 @@ class Config extends \Ilch\Config\Install
                 break;
             case "2.1.49":
                 $databaseConfig = new \Ilch\Config\Database($this->db());
-                $databaseConfig->set('comment_floodInterval', '0');
+                $databaseConfig->set('comment_floodInterval', '10');
                 $databaseConfig->set('comment_excludeFloodProtection', '1');
                 break;
         }

--- a/application/modules/comment/config/config.php
+++ b/application/modules/comment/config/config.php
@@ -43,7 +43,7 @@ class Config extends \Ilch\Config\Install
         $databaseConfig->set('comment_reply', '1');
         $databaseConfig->set('comment_nesting', '5');
         $databaseConfig->set('comment_box_comments_limit', '5');
-        $databaseConfig->set('comment_floodInterval', '0');
+        $databaseConfig->set('comment_floodInterval', '10');
         $databaseConfig->set('comment_excludeFloodProtection', '1');
     }
 

--- a/application/modules/comment/config/config.php
+++ b/application/modules/comment/config/config.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'comment',
-        'icon_small' => 'fa-comments-o',
+        'icon_small' => 'fa-regular fa-comments',
         'system_module' => true,
         'hide_menu' => true,
         'languages' => [
@@ -43,6 +43,8 @@ class Config extends \Ilch\Config\Install
         $databaseConfig->set('comment_reply', '1');
         $databaseConfig->set('comment_nesting', '5');
         $databaseConfig->set('comment_box_comments_limit', '5');
+        $databaseConfig->set('comment_floodInterval', '0');
+        $databaseConfig->set('comment_excludeFloodProtection', '1');
     }
 
     public function getInstallSql()

--- a/application/modules/comment/controllers/admin/Index.php
+++ b/application/modules/comment/controllers/admin/Index.php
@@ -18,13 +18,13 @@ class Index extends \Ilch\Controller\Admin
             [
                 'name' => 'manage',
                 'active' => true,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
             ],
             [
                 'name' => 'settings',
                 'active' => false,
-                'icon' => 'fa fa-cogs',
+                'icon' => 'fa-solid fa-gears',
                 'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
             ]
         ];

--- a/application/modules/comment/mappers/Comment.php
+++ b/application/modules/comment/mappers/Comment.php
@@ -293,9 +293,9 @@ class Comment extends \Ilch\Mapper
      * Get the id of a comment with a specific fk_id.
      *
      * @param int $fk_id
-     * @return int $id
+     * @return int|null id
      */
-    public function getCommentIdbyFKid(int $fk_id): int
+    public function getCommentIdbyFKid(int $fk_id): ?int
     {
         return $this->db()->select('id', 'comments', ['fk_id' => $fk_id])
             ->execute()

--- a/application/modules/comment/mappers/Comment.php
+++ b/application/modules/comment/mappers/Comment.php
@@ -16,7 +16,7 @@ class Comment extends \Ilch\Mapper
      * @param string $key
      * @return CommentModel[]|array
      */
-    public function getCommentsByKey($key)
+    public function getCommentsByKey(string $key): array
     {
         $key = $this->addMissingSlashIfNeeded($key);
 
@@ -51,7 +51,7 @@ class Comment extends \Ilch\Mapper
      * @param string $key
      * @return CommentModel[]|array
      */
-    public function getCommentsLikeKey($key)
+    public function getCommentsLikeKey(string $key): array
     {
         $key = $this->addMissingSlashIfNeeded($key);
 
@@ -82,10 +82,10 @@ class Comment extends \Ilch\Mapper
     /**
      * Get comments by specific id.
      *
-     * @param integer $id
+     * @param int $id
      * @return CommentModel|null
      */
-    public function getCommentById($id)
+    public function getCommentById(int $id): ?CommentModel
     {
         $commentRow = $this->db()->select('*')
             ->from('comments')
@@ -114,10 +114,10 @@ class Comment extends \Ilch\Mapper
     /**
      * Get comments by fkid
      *
-     * @param integer $fkid
+     * @param int $fkid
      * @return array
      */
-    public function getCommentsByFKid($fkid)
+    public function getCommentsByFKid(int $fkid): array
     {
         $commentsArray = $this->db()->select('*')
             ->from('comments')
@@ -147,10 +147,10 @@ class Comment extends \Ilch\Mapper
     /**
      * Get comments.
      *
-     * @param integer $limit
+     * @param int|null $limit
      * @return CommentModel[]
      */
-    public function getComments($limit = null)
+    public function getComments(int $limit = null): array
     {
         $select = $this->db()->select('*')
             ->from('comments')
@@ -185,9 +185,9 @@ class Comment extends \Ilch\Mapper
      * Gets the count of all comments with given $key.
      *
      * @param string $key
-     * @return integer
+     * @return int
      */
-    public function getCountComments($key)
+    public function getCountComments(string $key): int
     {
         $key = $this->addMissingSlashIfNeeded($key);
 
@@ -196,6 +196,30 @@ class Comment extends \Ilch\Mapper
             ->where(['key LIKE' => $key.'%'])
             ->execute()
             ->fetchCell();
+    }
+
+    /**
+     * Get date of last comment of a user.
+     *
+     * @param int $userId
+     * @return int|string
+     * @since 2.1.50
+     */
+    public function getDateOfLastCommentByUserId(int $userId)
+    {
+        $select = $this->db()->select('date_created')
+            ->from('comments')
+            ->where(['user_id' => $userId])
+            ->order(['id' => 'DESC'])
+            ->limit(1)
+            ->execute()
+            ->fetchCell();
+
+        if (empty($select)) {
+            return 0;
+        }
+
+        return $select;
     }
 
     /**
@@ -241,9 +265,9 @@ class Comment extends \Ilch\Mapper
     /**
      * Delete comment.
      *
-     * @param integer $id
+     * @param int $id
      */
-    public function delete($id)
+    public function delete(int $id)
     {
         do {
             $this->db()->delete('comments')
@@ -258,7 +282,7 @@ class Comment extends \Ilch\Mapper
      *
      * @param string $key
      */
-    public function deleteByKey($key)
+    public function deleteByKey(string $key)
     {
         $this->db()->delete('comments')
             ->where(['key LIKE' => $key.'%'])
@@ -268,10 +292,11 @@ class Comment extends \Ilch\Mapper
     /**
      * Get the id of a comment with a specific fk_id.
      *
-     * @param integer $fk_id
-     * @return integer $id
+     * @param int $fk_id
+     * @return int $id
      */
-    public function getCommentIdbyFKid($fk_id) {
+    public function getCommentIdbyFKid(int $fk_id): int
+    {
         return $this->db()->select('id', 'comments', ['fk_id' => $fk_id])
             ->execute()
             ->fetchCell();
@@ -283,7 +308,7 @@ class Comment extends \Ilch\Mapper
      * @param string $key
      * @return string key with slash at the end
      */
-    private function addMissingSlashIfNeeded($key)
+    private function addMissingSlashIfNeeded(string $key): string
     {
         if (!(strlen($key) - (strrpos($key, '/')) === 0)) {
             // Add missing slash at the end to usually terminate the id.

--- a/application/modules/comment/translations/de.php
+++ b/application/modules/comment/translations/de.php
@@ -16,4 +16,7 @@ return [
     'acceptReply' => 'Antworten auf Kommentare erlauben?',
     'CommentCommentInfoText' => 'Eine zu tiefe Kommentar-Verschachtelung kann dazu führen, dass die Kommentare zu klein dargestellt werden.',
     'boxCommentsLimit' => 'Anzahl an Einträgen',
+    'floodInterval' => 'Wartezeit zwischen zwei Kommentaren (Sekunden)',
+    'excludeFloodProtection' => 'Wartezeit ignorieren für',
+    'floodError' => 'Sie können einen Kommentar nicht so schnell nach Ihrem letzten schreiben.',
 ];

--- a/application/modules/comment/translations/en.php
+++ b/application/modules/comment/translations/en.php
@@ -16,4 +16,7 @@ return [
     'acceptReply' => 'Allow replies on comments?',
     'CommentCommentInfoText' => 'A too deep nesting of comments may result in comments displayed too small.',
     'boxCommentsLimit' => 'Number of entries',
+    'floodInterval' => 'Flood interval (seconds)',
+    'excludeFloodProtection' => 'Exclude from flood interval',
+    'floodError' => 'You cannot make another comment so soon after your last.',
 ];

--- a/application/modules/comment/views/admin/settings/index.php
+++ b/application/modules/comment/views/admin/settings/index.php
@@ -1,6 +1,6 @@
 <h1><?=$this->getTrans('settings') ?>
     <a class="badge" data-toggle="modal" data-target="#infoModal">
-        <i class="fa fa-info" ></i>
+        <i class="fa-solid fa-info" ></i>
     </a>
 </h1>
 <form class="form-horizontal" method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
@@ -32,6 +32,48 @@
                    value="<?=$this->get('comment_nesting') ?>">
         </div>
     </div>
+    <div class="form-group">
+        <label for="floodIntervalInput" class="col-lg-2 control-label">
+            <?=$this->getTrans('floodInterval') ?>:
+        </label>
+        <div class="col-lg-1">
+            <input type="number"
+                   class="form-control"
+                   id="floodIntervalInput"
+                   name="floodInterval"
+                   min="0"
+                   value="<?=$this->escape($this->get('floodInterval')) ?>" />
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="excludeFloodProtection" class="col-lg-2 control-label">
+            <?=$this->getTrans('excludeFloodProtection') ?>:
+        </label>
+        <div class="col-lg-4">
+            <select class="chosen-select form-control"
+                    id="excludeFloodProtection"
+                    name="groups[]"
+                    data-placeholder="<?=$this->getTrans('excludeFloodProtection') ?>"
+                    multiple>
+                <?php
+                foreach ($this->get('groupList') as $group) {
+                    ?>
+                    <option value="<?=$group->getId() ?>"
+                        <?php
+                        foreach ($this->get('excludeFloodProtection') as $assignedGroup) {
+                            if ($group->getId() == $assignedGroup) {
+                                echo 'selected="selected"';
+                                break;
+                            }
+                        } ?>>
+                        <?=$this->escape($group->getName()) ?>
+                    </option>
+                    <?php
+                }
+                ?>
+            </select>
+        </div>
+    </div>
     <h2><?=$this->getTrans('boxSettings') ?></h2>
     <div class="form-group">
         <label for="boxCommentsLimit" class="col-lg-2 control-label">
@@ -50,3 +92,7 @@
 </form>
 
 <?=$this->getDialog('infoModal', $this->getTrans('info'), $this->getTrans('CommentCommentInfoText')) ?>
+
+<script>
+    $('#excludeFloodProtection').chosen();
+</script>


### PR DESCRIPTION
# Description
- Add a flood protection for comments. This prevents a user (which might be a bot) from creating a lot of comments in a short time. It is enabled by default with a value of 10 seconds.
- FontAwesome 6 adjustments
- Code Style

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
- [ ] IE
