### PR TITLE
QueryBuilder: Support functions in group by and remove sortorder

### DIFF
--- a/application/libraries/Ilch/Database/Mysql/Select.php
+++ b/application/libraries/Ilch/Database/Mysql/Select.php
@@ -11,17 +11,17 @@ use Ilch\Database\Mysql as DB;
 class Select extends QueryBuilder
 {
     /**
-     * @var integer|null
+     * @var int|null
      */
     protected $limit;
 
     /**
-     * @var integer|null
+     * @var int|null
      */
     protected $offset;
 
     /**
-     * @var integer|null
+     * @var int|null
      */
     protected $page;
 
@@ -51,7 +51,7 @@ class Select extends QueryBuilder
     /**
      * Create Select Statement Query Builder
      *
-     * @param \Ilch\Database\Mysql $db
+     * @param DB $db
      * @param array|string|null $fields
      * @param string|null $table table without prefix
      * @param array|null $where conditions @see QueryBuilder::where()
@@ -59,12 +59,12 @@ class Select extends QueryBuilder
      * @param array|int|null $limit
      */
     public function __construct(
-        DB $db,
-        $fields = null,
-        $table = null,
-        $where = null,
-        array $orderBy = null,
-        $limit = null
+        DB     $db,
+               $fields = null,
+        string $table = null,
+        array  $where = null,
+        array  $orderBy = null,
+               $limit = null
     ) {
         parent::__construct($db);
 
@@ -89,9 +89,9 @@ class Select extends QueryBuilder
      * Adds table to query builder.
      *
      * @param string|array $table table without prefix (as array with alias as key)
-     * @return \Ilch\Database\Mysql\Select
+     * @return Select
      */
-    public function from($table)
+    public function from($table): Select
     {
         $this->table = $table;
 
@@ -102,12 +102,12 @@ class Select extends QueryBuilder
      * Adds fields to query builder.
      *
      * @param array|string $fields
-     * @param boolean $replace [default: true]
+     * @param bool $replace [default: true]
      *
-     * @return \Ilch\Database\Mysql\Select
+     * @return Select
      * @throws \InvalidArgumentException for invalid $fields parameter
      */
-    public function fields($fields, $replace = true)
+    public function fields($fields, bool $replace = true): Select
     {
         if ($fields === '*') {
             return $this;
@@ -128,9 +128,9 @@ class Select extends QueryBuilder
      * Adds order to query builder.
      *
      * @param array $order [field => direction]
-     * @return \Ilch\Database\Mysql\Select
+     * @return Select
      */
-    public function order(array $order)
+    public function order(array $order): Select
     {
         $this->order = $order;
 
@@ -140,9 +140,9 @@ class Select extends QueryBuilder
     /**
      * Sets page for query builder (offset will be used first)
      * @param int $page
-     * @return \Ilch\Database\Mysql\Select
+     * @return Select
      */
-    public function page($page)
+    public function page(int $page): Select
     {
         $this->page = (int) $page;
         return $this;
@@ -151,10 +151,10 @@ class Select extends QueryBuilder
     /**
      * Adds limit to query builder.
      *
-     * @param array|integer $limit if array -> [offset, limit]
-     * @return \Ilch\Database\Mysql\Select
+     * @param array|int $limit if array -> [offset, limit]
+     * @return Select
      */
-    public function limit($limit)
+    public function limit($limit): Select
     {
         if (\is_array($limit)) {
             $limitCount = \count($limit);
@@ -175,9 +175,9 @@ class Select extends QueryBuilder
      * Sets offset for query builder
      *
      * @param int $offset
-     * @return \Ilch\Database\Mysql\Select
+     * @return Select
      */
-    public function offset($offset)
+    public function offset(int $offset): Select
     {
         $this->offset = (int) $offset;
         return $this;
@@ -187,9 +187,9 @@ class Select extends QueryBuilder
      * Adds a join to the query (builder)
      *
      * @param Expression\Join $join
-     * @return \Ilch\Database\Mysql\Select
+     * @return Select
      */
-    public function addJoin(Expression\Join $join)
+    public function addJoin(Expression\Join $join): Select
     {
         $this->joins[] = $join;
         return $this;
@@ -200,7 +200,7 @@ class Select extends QueryBuilder
      * @param string $type
      * @return Expression\Join
      */
-    public function createJoin($table, $type = Expression\Join::INNER)
+    public function createJoin($table, string $type = Expression\Join::INNER): Expression\Join
     {
         return new Expression\Join($table, $type);
     }
@@ -211,10 +211,10 @@ class Select extends QueryBuilder
      * @param string|array $table
      * @param string|array $conditions
      * @param string $type
-     * @param array $fields
-     * @return \Ilch\Database\Mysql\Select
+     * @param array|null $fields
+     * @return Select
      */
-    public function join($table, $conditions, $type = Expression\Join::INNER, array $fields = null)
+    public function join($table, $conditions, string $type = Expression\Join::INNER, array $fields = null): Select
     {
         $join = $this->createJoin($table, $type);
         if (\is_string($conditions)) {
@@ -231,10 +231,10 @@ class Select extends QueryBuilder
      * Add GROUP BY to the query (builder)
      *
      * @param array $fields ['field' => 'DESC|ASC', 'field2']
-     * @param boolean $replace
-     * @return \Ilch\Database\Mysql\Select
+     * @param bool $replace
+     * @return Select
      */
-    public function group(array $fields, $replace = true)
+    public function group(array $fields, bool $replace = true): Select
     {
         if ($replace) {
             $this->groupByFields = $fields;
@@ -246,10 +246,10 @@ class Select extends QueryBuilder
     }
 
     /**
-     * @param $useFoundRows
-     * @return \Ilch\Database\Mysql\Select
+     * @param bool $useFoundRows
+     * @return Select
      */
-    public function useFoundRows($useFoundRows = true)
+    public function useFoundRows(bool $useFoundRows = true): Select
     {
         $this->useFoundRows = (bool) $useFoundRows;
         return $this;
@@ -258,9 +258,9 @@ class Select extends QueryBuilder
     /**
      * Execute the generated query
      *
-     * @return \Ilch\Database\Mysql\Result
+     * @return Result
      */
-    public function execute()
+    public function execute(): Result
     {
         $result = new Result($this->db->query($this->generateSql()), $this->db);
 
@@ -279,7 +279,7 @@ class Select extends QueryBuilder
      * @return array
      * @since 2.1.43
      */
-    private function generateSqlForJoins($fields): array
+    private function generateSqlForJoins(array $fields): array
     {
         $joinSql = [];
 
@@ -341,7 +341,7 @@ class Select extends QueryBuilder
      * @throws \RuntimeException if sql could not be generated
      * @throws \InvalidArgumentException if invalid parts were configured
      */
-    public function generateSql()
+    public function generateSql(): string
     {
         if (empty($this->table)) {
             throw new \RuntimeException('table must be set');
@@ -391,10 +391,10 @@ class Select extends QueryBuilder
     /**
      * Create the field part for the given array.
      *
-     * @param  array $fields
+     * @param array $fields
      * @return string
      */
-    protected function getFieldsSql($fields)
+    protected function getFieldsSql(array $fields): string
     {
         if (empty($fields)) {
             return '*';
@@ -404,9 +404,7 @@ class Select extends QueryBuilder
 
         foreach ($fields as $key => $value) {
             if (!$value instanceof Expression\Expression) {
-                if (strpos($value, '(') !== false) {
-                    $value = $value;
-                } else {
+                if (strpos($value, '(') === false) {
                     $value = $this->db->quote($value);
                 }
             }
@@ -427,7 +425,7 @@ class Select extends QueryBuilder
      *
      * @return string
      */
-    protected function getTableSql($table)
+    protected function getTableSql($table): string
     {
         if (\is_array($table)) {
             $tableName = reset($table);
@@ -452,7 +450,7 @@ class Select extends QueryBuilder
      * @return array
      * @throws \InvalidArgumentException
      */
-    protected function createFieldsArray($fields)
+    protected function createFieldsArray($fields): array
     {
         if (\is_string($fields)) {
             //function like COUNT()
@@ -478,8 +476,9 @@ class Select extends QueryBuilder
     /**
      * @return string
      * @throws \InvalidArgumentException
+     * @since 2.1.50 supports for functions in group by
      */
-    protected function generateGroupBySql()
+    protected function generateGroupBySql(): string
     {
         $sql = '';
         // add GROUP BY to sql
@@ -509,7 +508,7 @@ class Select extends QueryBuilder
      * @throws \InvalidArgumentException
      * @since 2.1.43
      */
-    protected function generateOrderBySql()
+    protected function generateOrderBySql(): string
     {
         $sql = '';
         // add ORDER BY to sql

--- a/tests/libraries/ilch/Database/Mysql/InsertTest.php
+++ b/tests/libraries/ilch/Database/Mysql/InsertTest.php
@@ -23,7 +23,7 @@ class InsertTest extends \PHPUnit\Framework\TestCase
 
         $db = $this->getMockBuilder('\Ilch\Database\Mysql')
             ->disableOriginalConstructor()
-            ->setMethods(['escape', 'getLastInsertId'])
+            ->onlyMethods(['escape', 'getLastInsertId'])
             ->getMockForAbstractClass();
         $db->method('escape')
             ->willReturnCallback(function ($value, $addQuotes = false) {

--- a/tests/libraries/ilch/Database/Mysql/SelectTest.php
+++ b/tests/libraries/ilch/Database/Mysql/SelectTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch_phpunit
  */
 
@@ -22,7 +22,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
 
         $db = $this->getMockBuilder('\Ilch\Database\Mysql')
             ->disableOriginalConstructor()
-            ->setMethods(['escape'])
+            ->onlyMethods(['escape'])
             ->getMockForAbstractClass();
         $db->method('escape')
             ->willReturnCallback(function ($value, $addQuotes = false) {
@@ -46,10 +46,10 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dpForTable
      *
-     * @param string $table
+     * @param string|string[] $table
      * @param string $expectedSqlPart
      */
-    public function testGenerateSqlForTable($table, $expectedSqlPart)
+    public function testGenerateSqlForTable($table, string $expectedSqlPart)
     {
         $this->out->from($table);
 
@@ -61,7 +61,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForTable()
+    public function dpForTable(): array
     {
         return [
             'simple tablename' => [
@@ -85,7 +85,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * @param string|array $fields
      * @param string $expectedSqlPart
      */
-    public function testGenerateSqlForFields($fields, $expectedSqlPart)
+    public function testGenerateSqlForFields($fields, string $expectedSqlPart)
     {
         $this->out->from('Test')
             ->fields($fields);
@@ -98,7 +98,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForFields()
+    public function dpForFields(): array
     {
         return [
             'string all' => [
@@ -144,9 +144,9 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      *
      * @param array|callable $where
      * @param string $expectedSqlPart
-     * @param string $type
+     * @param string|null $type
      */
-    public function testGenerateSqlForWhere($where, $expectedSqlPart, $type = null)
+    public function testGenerateSqlForWhere($where, string $expectedSqlPart, string $type = null)
     {
         if (\is_callable($where)) {
             $where = $where($this->out);
@@ -169,7 +169,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * Data provider for testGenerateSqlForWhere
      * @return array
      */
-    public function dpForWhere()
+    public function dpForWhere(): array
     {
         return [
             'simple condition'  => [
@@ -243,7 +243,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      *
      * @param string $operator
      */
-    public function testGenerateSqlForWhereWithSpecialOperator($operator)
+    public function testGenerateSqlForWhereWithSpecialOperator(string $operator)
     {
         $this->out->from('Test')
             ->where(['field1 ' . $operator => 5]);
@@ -258,7 +258,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * Operator data provider
      * @return array
      */
-    public function dpOperators()
+    public function dpOperators(): array
     {
         return [['='], ['<='], ['>='], ['<'], ['>'], ['!='], ['<>'], ['LIKE'], ['NOT LIKE']];
     }
@@ -266,12 +266,12 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dpForOrWhere
      *
-     * @param array $where
-     * @param string $type
+     * @param array|bool $where
+     * @param string|bool $type
      * @param array $orWhere
      * @param string $expectedSqlPart
      */
-    public function testGenerateSqlForOrWhere($where, $type, $orWhere, $expectedSqlPart)
+    public function testGenerateSqlForOrWhere($where, $type, array $orWhere, string $expectedSqlPart)
     {
         $this->out->from('Test');
         if (!empty($where)) {
@@ -288,7 +288,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForOrWhere()
+    public function dpForOrWhere(): array
     {
         return [
             'with empty where and single condition' => [
@@ -324,7 +324,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * @param array $order
      * @param string $expectedSqlPart
      */
-    public function testGenerateSqlForOrderBy(array $order, $expectedSqlPart)
+    public function testGenerateSqlForOrderBy(array $order, string $expectedSqlPart)
     {
         $this->out->from('Test')
             ->order($order);
@@ -337,7 +337,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForTestGenerateSqlForOrderBy()
+    public function dpForTestGenerateSqlForOrderBy(): array
     {
         return [
             'field without table' => [
@@ -354,10 +354,10 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dpForLimit
      *
-     * @param integer|array $limit
+     * @param int|array $limit
      * @param string $expectedSqlPart
      */
-    public function testGenerateSqlForLimitWithInteger($limit, $expectedSqlPart)
+    public function testGenerateSqlForLimitWithInteger($limit, string $expectedSqlPart)
     {
         $this->out->from('Test')
             ->limit($limit);
@@ -371,7 +371,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForLimit()
+    public function dpForLimit(): array
     {
         return [
             'with integer'  => [
@@ -400,10 +400,10 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dpForLimitWithPage
      *
-     * @param integer $page
-     * @param integer $expectedOffset
+     * @param int $page
+     * @param int $expectedOffset
      */
-    public function testGenerateSqlForLimitWithPage($page, $expectedOffset)
+    public function testGenerateSqlForLimitWithPage(int $page, int $expectedOffset)
     {
         $this->out->from('Test')
             ->limit(10)
@@ -419,7 +419,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * Data provider for testGenerateSqlForLimitWithPage
      * @return array
      */
-    public function dpForLimitWithPage()
+    public function dpForLimitWithPage(): array
     {
         //expected offset for limit 10
         return [
@@ -438,7 +438,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * @param array $groupByFields
      * @param string $expectedSqlPart
      */
-    public function testGenerateSqlWithGroup($groupByFields, $expectedSqlPart)
+    public function testGenerateSqlWithGroup(array $groupByFields, string $expectedSqlPart)
     {
         $this->out->from('Test')
             ->group($groupByFields);
@@ -452,7 +452,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForTestGenerateSqlWithGroup()
+    public function dpForTestGenerateSqlWithGroup(): array
     {
         return [
             'one field' => [
@@ -485,10 +485,10 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dpForJoinConditions
      *
-     * @param array $conditions
+     * @param string|string[] $conditions
      * @param string $expectedSqlPart
      */
-    public function testGenerateSqlForJoinConditions($conditions, $expectedSqlPart)
+    public function testGenerateSqlForJoinConditions($conditions, string $expectedSqlPart)
     {
         $this->out->from(['a' => 'Test']);
         $this->out->join(['b' => 'Table2'], $conditions);
@@ -502,7 +502,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForJoinConditions()
+    public function dpForJoinConditions(): array
     {
         return [
             'single field comparison' => [

--- a/tests/libraries/ilch/Database/Mysql/UpdateTest.php
+++ b/tests/libraries/ilch/Database/Mysql/UpdateTest.php
@@ -21,7 +21,7 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
 
         $db = $this->getMockBuilder('\Ilch\Database\Mysql')
             ->disableOriginalConstructor()
-            ->setMethods(['escape'])
+            ->onlyMethods(['escape'])
             ->getMockForAbstractClass();
         $db->method('escape')
             ->willReturnCallback(function ($value, $addQuotes = false) {


### PR DESCRIPTION
# Description
- Support functions in group by
- Remove support for a sortorder in a group by. This is deprecated since MySQL 5.7 and removed with MySQL 8.0.13
- Remove usage of deprecated setMethods() of PHPUnit.
- Further some code style fixes.

Fixes #534 
Fixes #536

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update