### PR TITLE
Fix "Trying to access array offset on value of type bool"

### DIFF
--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -414,6 +414,11 @@ function owner(string $file)
     }
 
     $ownerarray = posix_getpwuid($owneruid);
+
+    if ($ownerarray === false) {
+        return false;
+    }
+
     return $ownerarray['name'];
 }
 


### PR DESCRIPTION
# Description
Fix "Trying to access array offset on value of type bool" when posix_getpwuid returns false

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)