### PR TITLE
Awards: Support multiple recipients

### DIFF
--- a/application/modules/awards/controllers/Index.php
+++ b/application/modules/awards/controllers/Index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -16,17 +16,87 @@ class Index extends \Ilch\Controller\Frontend
     {
         $awardsMapper = new AwardsMapper();
         $userMapper = new UserMapper();
-        $teamsMapper = new TeamsMapper();
+
+        $userIds = [];
+        $users = [];
+        $teams = [];
+        $teamIds = [];
 
         $this->getLayout()->getHmenu()
             ->add($this->getTranslator()->trans('menuAwards'), ['action' => 'index']);
 
         $awards = $awardsMapper->getAwards();
-        $this->getView()->set('userMapper', $userMapper)
-            ->set('teamsMapper', $teamsMapper)
-            ->set('awards', $awards)
-            ->set('awardsCount', count($awards));
+        foreach ($awards as $award) {
+            foreach($award->getRecipients() as $recipient) {
+                if ($recipient->getTyp() == 1) {
+                    $userIds[] = $recipient->getUtId();
+                } else {
+                    $teamIds[] = $recipient->getUtId();
+                }
+            }
+
+            if (!empty($userIds)) {
+                $users[$award->getId()] = $userMapper->getUserList(['id' => $userIds]);
+            }
+
+            if ($awardsMapper->existsTable('teams') && !empty($teamIds)) {
+                $teamsMapper = new TeamsMapper();
+                $teams[$award->getId()] = $teamsMapper->getTeams(['id' => $teamIds]);
+            }
+        }
+        $this->getView()->set('awards', $awards)
+            ->set('awardsCount', count($awards))
+            ->set('users', $users)
+            ->set('teams', $teams);
+    }
+
+    public function showAction()
+    {
+        $awardsMapper = new AwardsMapper();
+        $userMapper = new UserMapper();
+
+        $userIds = [];
+        $users = [];
+        $teams = [];
+        $teamIds = [];
+        $award = null;
+
+        $this->getLayout()->getHmenu()
+            ->add($this->getTranslator()->trans('menuAwards'), ['action' => 'show', 'id' => $this->getRequest()->getParam('id')]);
+
+        if ($this->getRequest()->getParam('id') && is_numeric($this->getRequest()->getParam('id'))) {
+            $award = $awardsMapper->getAwardsById($this->getRequest()->getParam('id'));
+
+            if ($award) {
+                foreach($award->getRecipients() as $recipient) {
+                    if ($recipient->getTyp() == 1) {
+                        $userIds[] = $recipient->getUtId();
+                    } else {
+                        $teamIds[] = $recipient->getUtId();
+                    }
+                }
+
+                if (!empty($userIds)) {
+                    $users = $userMapper->getUserList(['id' => $userIds]);
+                }
+
+                if ($awardsMapper->existsTable('teams') && !empty($teamIds)) {
+                    $teamsMapper = new TeamsMapper();
+                    $teams = $teamsMapper->getTeams(['id' => $teamIds]);
+                }
+            } else {
+                $this->redirect()
+                    ->withMessage('awardNotFound', 'danger')
+                    ->to(['action' => 'index']);
+            }
+        } else {
+            $this->redirect()
+                ->withMessage('awardNotFound', 'danger')
+                ->to(['action' => 'index']);
+        }
+
+        $this->getView()->set('users', $users)
+            ->set('teams', $teams)
+            ->set('award', $award);
     }
 }
-
-

--- a/application/modules/awards/controllers/admin/Index.php
+++ b/application/modules/awards/controllers/admin/Index.php
@@ -167,7 +167,6 @@ class Index extends \Ilch\Controller\Admin
                     $recipientModel->setAwardId((!$this->getRequest()->getParam('id')) ? $idOrAffectedRows : $awardsModel->getId())
                         ->setUtId(substr($value, 2))
                         ->setTyp(substr($value, 0, 1));
-//                    $recipientMapper->save($recipientModel);
                     $recipientModels[] = $recipientModel;
                 }
                 $recipientMapper->saveMulti($recipientModels);

--- a/application/modules/awards/controllers/admin/Index.php
+++ b/application/modules/awards/controllers/admin/Index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -8,6 +8,8 @@ namespace Modules\Awards\Controllers\Admin;
 
 use Modules\Awards\Mappers\Awards as AwardsMapper;
 use Modules\Awards\Models\Awards as AwardsModel;
+use Modules\Awards\Mappers\Recipients as RecipientsMapper;
+use Modules\Awards\Models\Recipient as RecipientModel;
 use Modules\User\Mappers\User as UserMapper;
 use Modules\Teams\Mappers\Teams as TeamsMapper;
 use Ilch\Validation;
@@ -49,9 +51,10 @@ class Index extends \Ilch\Controller\Admin
         $awardsMapper = new AwardsMapper();
         $userMapper = new UserMapper();
 
-        if ($awardsMapper->existsTable('teams') == true) {
-            $teamsMapper = new TeamsMapper();
-        }
+        $userIds = [];
+        $users = [];
+        $teams = [];
+        $teamIds = [];
 
         $this->getLayout()->getAdminHmenu()
             ->add($this->getTranslator()->trans('menuAwards'), ['action' => 'index'])
@@ -63,12 +66,29 @@ class Index extends \Ilch\Controller\Admin
             }
         }
 
-        if ($awardsMapper->existsTable('teams') == true) {
-            $this->getView()->set('teamsMapper', $teamsMapper);
+        $awards = $awardsMapper->getAwards();
+        foreach ($awards as $award) {
+            foreach($award->getRecipients() as $recipient) {
+                if ($recipient->getTyp() == 1) {
+                    $userIds[] = $recipient->getUtId();
+                } else {
+                    $teamIds[] = $recipient->getUtId();
+                }
+            }
+
+            if (!empty($userIds)) {
+                $users[$award->getId()] = $userMapper->getUserList(['id' => $userIds]);
+            }
+
+            if ($awardsMapper->existsTable('teams') && !empty($teamIds)) {
+                $teamsMapper = new TeamsMapper();
+                $teams[$award->getId()] = $teamsMapper->getTeams(['id' => $teamIds]);
+            }
         }
 
-        $this->getView()->set('userMapper', $userMapper)
-            ->set('awards', $awardsMapper->getAwards());
+        $this->getView()->set('awards', $awards)
+            ->set('users', $users)
+            ->set('teams', $teams);
     }
 
     public function treatAction()
@@ -76,16 +96,20 @@ class Index extends \Ilch\Controller\Admin
         $awardsMapper = new AwardsMapper();
         $userMapper = new UserMapper();
 
-        if ($awardsMapper->existsTable('teams') == true) {
-            $teamsMapper = new TeamsMapper();
-        }
-
         if ($this->getRequest()->getParam('id')) {
             $this->getLayout()->getAdminHmenu()
                 ->add($this->getTranslator()->trans('menuAwards'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('edit'), ['action' => 'treat']);
 
-            $this->getView()->set('awards', $awardsMapper->getAwardsById($this->getRequest()->getParam('id')));
+            $awards = $awardsMapper->getAwardsById($this->getRequest()->getParam('id'));
+
+            if (!$awards) {
+                $this->redirect()
+                    ->withMessage('awardNotFound', 'danger')
+                    ->to(['action' => 'index']);
+            }
+
+            $this->getView()->set('awards', $awards);
         } else {
             $this->getLayout()->getAdminHmenu()
                 ->add($this->getTranslator()->trans('menuAwards'), ['action' => 'index'])
@@ -103,7 +127,7 @@ class Index extends \Ilch\Controller\Admin
                 'date' => trim($this->getRequest()->getPost('date')),
                 'rank' => trim($this->getRequest()->getPost('rank')),
                 'image' => $image,
-                'utId' => trim($this->getRequest()->getPost('utId')),
+                'utId' => $this->getRequest()->getPost('utId'),
                 'event' => trim($this->getRequest()->getPost('event')),
                 'page' => trim($this->getRequest()->getPost('page'))
             ];
@@ -124,21 +148,29 @@ class Index extends \Ilch\Controller\Admin
             $post['image'] = trim($this->getRequest()->getPost('image'));
 
             if ($validation->isValid()) {
-                $typ = substr($post['utId'], 0, 1);
-                $userTeamId = substr($post['utId'], 2);
+                $recipientMapper = new RecipientsMapper();
 
-                $model = new AwardsModel();
+                $awardsModel = new AwardsModel();
                 if ($this->getRequest()->getParam('id')) {
-                    $model->setId($this->getRequest()->getParam('id'));
+                    $awardsModel->setId($this->getRequest()->getParam('id'));
                 }
-                $model->setDate(new \Ilch\Date($post['date']))
+                $awardsModel->setDate(new \Ilch\Date($post['date']))
                     ->setRank($post['rank'])
-                    ->setTyp($typ)
                     ->setImage($post['image'])
-                    ->setUTId($userTeamId)
                     ->setEvent($post['event'])
                     ->setURL($post['page']);
-                $awardsMapper->save($model);
+                $idOrAffectedRows = $awardsMapper->save($awardsModel);
+
+                $recipientModels = [];
+                foreach($post['utId'] as $value) {
+                    $recipientModel = new RecipientModel();
+                    $recipientModel->setAwardId((!$this->getRequest()->getParam('id')) ? $idOrAffectedRows : $awardsModel->getId())
+                        ->setUtId(substr($value, 2))
+                        ->setTyp(substr($value, 0, 1));
+//                    $recipientMapper->save($recipientModel);
+                    $recipientModels[] = $recipientModel;
+                }
+                $recipientMapper->saveMulti($recipientModels);
 
                 $this->redirect()
                     ->withMessage('saveSuccess')
@@ -149,10 +181,11 @@ class Index extends \Ilch\Controller\Admin
             $this->redirect()
                 ->withInput()
                 ->withErrors($validation->getErrorBag())
-                ->to(['action' => 'treat']);
+                ->to(['action' => 'treat', 'id' => $this->getRequest()->getParam('id')]);
         }
 
-        if ($awardsMapper->existsTable('teams') == true) {
+        if ($awardsMapper->existsTable('teams')) {
+            $teamsMapper = new TeamsMapper();
             $this->getView()->set('teams', $teamsMapper->getTeams());
         }
 

--- a/application/modules/awards/mappers/Recipients.php
+++ b/application/modules/awards/mappers/Recipients.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Awards\Mappers;
+
+use http\Exception\InvalidArgumentException;
+use Ilch\Mapper;
+use Modules\Awards\Models\Recipient as RecipientModel;
+
+/**
+ * The recipient mapper.
+ */
+class Recipients extends Mapper
+{
+    /**
+     * Get recipients.
+     *
+     * @param array $where
+     * @return array
+     */
+    public function getRecipients(array $where = []): array
+    {
+        $recipientsArray = $this->db()->select('*')
+            ->from('awards_recipients')
+            ->where($where)
+            ->execute()
+            ->fetchRows();
+
+        if (empty($recipientsArray)) {
+            return [];
+        }
+
+        $recipients = [];
+        foreach ($recipientsArray as $recipient) {
+            $recipientModel = new RecipientModel();
+            $recipientModel->setAwardId($recipient['id'])
+                ->setUtId($recipient['ut_id'])
+                ->setTyp($recipient['typ']);
+            $recipients[] = $recipientModel;
+        }
+
+        return $recipients;
+    }
+
+    /**
+     * Saves a single or multiple recipients of an award at once.
+     * Don't supply more than 1000 at a time.
+     *
+     * @param RecipientModel[] $recipients
+     * @return int number of affected rows.
+     */
+    public function saveMulti(array $recipients): int
+    {
+        if (count($recipients) > 1000) {
+            throw new InvalidArgumentException('Too many recipients. There is a limit of 1000.');
+        }
+
+        $fields = [];
+        foreach($recipients as $recipient) {
+            $fields[] = [$recipient->getAwardId(), $recipient->getUtId(), $recipient->getTyp()];
+        }
+
+        $this->db()->delete()->from('awards_recipients')
+            ->where(['award_id' => $recipients[0]->getAwardId()])
+            ->execute();
+
+        return $this->db()->insert('awards_recipients')
+            ->columns(['award_id', 'ut_id', 'typ'])
+            ->values($fields)
+            ->execute();
+    }
+}

--- a/application/modules/awards/mappers/Recipients.php
+++ b/application/modules/awards/mappers/Recipients.php
@@ -6,8 +6,8 @@
 
 namespace Modules\Awards\Mappers;
 
-use http\Exception\InvalidArgumentException;
 use Ilch\Mapper;
+use InvalidArgumentException;
 use Modules\Awards\Models\Recipient as RecipientModel;
 
 /**

--- a/application/modules/awards/models/Awards.php
+++ b/application/modules/awards/models/Awards.php
@@ -1,11 +1,14 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
 namespace Modules\Awards\Models;
 
+/**
+ * Awards model
+ */
 class Awards extends \Ilch\Model
 {
     /**
@@ -51,25 +54,16 @@ class Awards extends \Ilch\Model
     protected $url;
 
     /**
-     * The utId of the awards.
-     *
-     * @var int
+     * @var array
      */
-    protected $utId;
-
-    /**
-     * The typ of the awards.
-     *
-     * @var int
-     */
-    protected $typ;
+    protected $recipients;
 
     /**
      * Gets the id of the awards.
      *
      * @return int
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -80,9 +74,9 @@ class Awards extends \Ilch\Model
      * @param int $id
      * @return $this
      */
-    public function setId($id)
+    public function setId(int $id): Awards
     {
-        $this->id = (int)$id;
+        $this->id = $id;
 
         return $this;
     }
@@ -92,7 +86,7 @@ class Awards extends \Ilch\Model
      *
      * @return string
      */
-    public function getDate()
+    public function getDate(): string
     {
         return $this->date;
     }
@@ -103,9 +97,9 @@ class Awards extends \Ilch\Model
      * @param string $date
      * @return $this
      */
-    public function setDate($date)
+    public function setDate(string $date): Awards
     {
-        $this->date = (string)$date;
+        $this->date = $date;
 
         return $this;
     }
@@ -115,7 +109,7 @@ class Awards extends \Ilch\Model
      *
      * @return int
      */
-    public function getRank()
+    public function getRank(): int
     {
         return $this->rank;
     }
@@ -126,9 +120,9 @@ class Awards extends \Ilch\Model
      * @param int $rank
      * @return $this
      */
-    public function setRank($rank)
+    public function setRank(int $rank): Awards
     {
-        $this->rank = (int)$rank;
+        $this->rank = $rank;
 
         return $this;
     }
@@ -138,7 +132,7 @@ class Awards extends \Ilch\Model
      *
      * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return $this->image;
     }
@@ -149,7 +143,7 @@ class Awards extends \Ilch\Model
      * @param string $image
      * @return $this
      */
-    public function setImage($image)
+    public function setImage(string $image): Awards
     {
         $this->image = $image;
 
@@ -161,7 +155,7 @@ class Awards extends \Ilch\Model
      *
      * @return string
      */
-    public function getEvent()
+    public function getEvent(): string
     {
         return $this->event;
     }
@@ -172,9 +166,9 @@ class Awards extends \Ilch\Model
      * @param string $event
      * @return $this
      */
-    public function setEvent($event)
+    public function setEvent(string $event): Awards
     {
-        $this->event = (string)$event;
+        $this->event = $event;
 
         return $this;
     }
@@ -184,7 +178,7 @@ class Awards extends \Ilch\Model
      *
      * @return string
      */
-    public function getURL()
+    public function getURL(): string
     {
         return $this->url;
     }
@@ -195,55 +189,32 @@ class Awards extends \Ilch\Model
      * @param string $url
      * @return $this
      */
-    public function setURL($url)
+    public function setURL(string $url): Awards
     {
-        $this->url = (string)$url;
+        $this->url = $url;
 
         return $this;
     }
 
     /**
-     * Gets the utId of the awards.
+     * Get the recipients of this award.
      *
-     * @return int
+     * @return array
      */
-    public function getUTid()
+    public function getRecipients(): array
     {
-        return $this->utId;
+        return $this->recipients;
     }
 
     /**
-     * Sets the utId of the awards.
+     * Sets the recipients of this award.
      *
-     * @param int $utId
+     * @param array $recipients
      * @return $this
      */
-    public function setUTId($utId)
+    public function setRecipients(array $recipients): Awards
     {
-        $this->utId = (int)$utId;
-
-        return $this;
-    }
-
-    /**
-     * Gets the typ of the awards.
-     *
-     * @return int
-     */
-    public function getTyp()
-    {
-        return $this->typ;
-    }
-
-    /**
-     * Sets the typ of the awards.
-     *
-     * @param int $typ
-     * @return $this
-     */
-    public function setTyp($typ)
-    {
-        $this->typ = (int)$typ;
+        $this->recipients = $recipients;
 
         return $this;
     }

--- a/application/modules/awards/models/Recipient.php
+++ b/application/modules/awards/models/Recipient.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Awards\Models;
+
+use Ilch\Model;
+
+/**
+ * The model for a award recipient.
+ */
+class Recipient extends Model
+{
+    /**
+     * The id of the awards.
+     *
+     * @var int
+     */
+    protected $award_id;
+
+    /**
+     * The utId of the awards.
+     *
+     * @var int
+     */
+    protected $utId;
+
+    /**
+     * The type of the awards.
+     *
+     * @var int
+     */
+    protected $typ;
+
+    /**
+     * Get the award id.
+     *
+     * @return int
+     */
+    public function getAwardId(): int
+    {
+        return $this->award_id;
+    }
+
+    /**
+     * Set the award id.
+     *
+     * @param int $award_id
+     * @return Recipient
+     */
+    public function setAwardId(int $award_id): Recipient
+    {
+        $this->award_id = $award_id;
+        return $this;
+    }
+
+    /**
+     * Get the user or team id.
+     *
+     * @return int
+     */
+    public function getUtId(): int
+    {
+        return $this->utId;
+    }
+
+    /**
+     * Set the user or team id.
+     *
+     * @param int $utId
+     * @return Recipient
+     */
+    public function setUtId(int $utId): Recipient
+    {
+        $this->utId = $utId;
+        return $this;
+    }
+
+    /**
+     * Get the type.
+     *
+     * @return int
+     */
+    public function getTyp(): int
+    {
+        return $this->typ;
+    }
+
+    /**
+     * Set the type.
+     *
+     * @param int $typ
+     * @return Recipient
+     */
+    public function setTyp(int $typ): Recipient
+    {
+        $this->typ = $typ;
+        return $this;
+    }
+}

--- a/application/modules/awards/static/css/awards.css
+++ b/application/modules/awards/static/css/awards.css
@@ -13,7 +13,13 @@
     font-size: 32px;
     font-weight: bold;
 }
-.rank_info {
+.rank_show {
+    float: left;
+    padding: 15px;
+    font-size: 32px;
+    font-weight: bold;
+}
+.rank_info .rank_info_show {
     padding: 5px;
 }
 .rank_image {

--- a/application/modules/awards/translations/de.php
+++ b/application/modules/awards/translations/de.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -22,6 +22,6 @@ return [
     'awards' => 'Auszeichnungen',
     'currentlyThereAre' => 'Derzeit gibt es',
     'invalidUserTeam' => 'Benutzer oder Team',
-    'formerTeam' => 'Ehemaliges Team',
-    'formerUser' => 'Ehemaliger Benutzer',
+    'awardNotFound' => 'Auszeichnung nicht gefunden',
+    'recipientsOfAward' => 'Auszeichnung haben erhalten',
 ];

--- a/application/modules/awards/translations/en.php
+++ b/application/modules/awards/translations/en.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -22,6 +22,6 @@ return [
     'awards' => 'Awards',
     'currentlyThereAre' => 'Currently, there are',
     'invalidUserTeam' => 'User or team',
-    'formerTeam' => 'former team',
-    'formerUser' => 'former user',
+    'awardNotFound' => 'Award not found',
+    'recipientsOfAward' => 'Recipients of this award',
 ];

--- a/application/modules/awards/views/admin/index/index.php
+++ b/application/modules/awards/views/admin/index/index.php
@@ -1,6 +1,7 @@
 <?php
-$userMapper = $this->get('userMapper');
-$teamsMapper = $this->get('teamsMapper');
+$teams = $this->get('teams');
+$users = $this->get('users');
+$recipientToDisplayLimit = 6;
 ?>
 
 <h1><?=$this->getTrans('manage') ?></h1>
@@ -30,35 +31,44 @@ $teamsMapper = $this->get('teamsMapper');
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($this->get('awards') as $awards) : ?>
-                    <?php $getDate = new \Ilch\Date($awards->getDate()); ?>
+                    <?php foreach ($this->get('awards') as $award) : ?>
+                    <?php $getDate = new \Ilch\Date($award->getDate()); ?>
                         <tr>
-                            <td><?=$this->getDeleteCheckbox('check_entries', $awards->getId()) ?></td>
-                            <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $awards->getId()]) ?></td>
-                            <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $awards->getId()]) ?></td>
+                            <td><?=$this->getDeleteCheckbox('check_entries', $award->getId()) ?></td>
+                            <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $award->getId()]) ?></td>
+                            <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $award->getId()]) ?></td>
                             <td><?=$getDate->format('d.m.Y', true) ?></td>
-                            <td><?=$this->escape($awards->getRank()) ?></td>
-                            <?php if ($awards->getTyp() == 2): ?>
-                                <?php $team = $teamsMapper->getTeamById($awards->getUTId()); ?>
-                                <?php if ($team) : ?>
-                                    <td><a href="<?=$this->getUrl('teams/index/index') ?>" target="_blank"><?=$this->escape($team->getName()) ?></a></td>
-                                <?php else: ?>
-                                    <td><?=$this->getTrans('formerTeam') ?></td>
+                            <td><?=$this->escape($award->getRank()) ?></td>
+                            <td>
+                            <?php $recipientsDisplayed = 0 ?>
+                            <?php foreach($award->getRecipients() as $recipient) : ?>
+                                <?php if ($recipientsDisplayed >= $recipientToDisplayLimit): ?>
+                                    <a href="<?=$this->getUrl(['action' => 'show', 'id' => $award->getId()]) ?>">...</a>
+                                    <?php break; ?>
                                 <?php endif; ?>
-                            <?php else: ?>
-                                <?php $user = $userMapper->getUserById($awards->getUTId()); ?>
-                                <?php if ($user) : ?>
-                                    <td><a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>" target="_blank"><?=$this->escape($user->getName()) ?></a></td>
+                                <?php if ($recipient->getTyp() == 2): ?>
+                                    <?php foreach($teams[$award->getId()] as $team) : ?>
+                                        <?php if ($team->getId() === $recipient->getUtId()) : ?>
+                                            <a href="<?=$this->getUrl('teams/index/index') ?>" target="_blank"><?=$this->escape($team->getName()) ?></a>
+                                            <?php break; ?>
+                                        <?php endif; ?>
+                                    <?php endforeach; ?>
                                 <?php else: ?>
-                                    <td><?=$this->getTrans('formerUser') ?></td>
+                                    <?php foreach($users[$award->getId()] as $user) : ?>
+                                        <?php if ($user->getId() === $recipient->getUtId()) : ?>
+                                            <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><?=$this->escape($user->getName()) ?></a>
+                                            <?php break; ?>
+                                        <?php endif; ?>
+                                    <?php endforeach; ?>
                                 <?php endif; ?>
-                            <?php endif; ?>
-
-                            <?php if ($awards->getEvent() != ''): ?>
-                                <?php if ($awards->getURL() != ''): ?>
-                                    <td><a href="<?=$this->escape($awards->getURL()) ?>" title="<?=$this->escape($awards->getEvent()) ?>" target="_blank" rel="noopener"><?=$this->escape($awards->getEvent()) ?></a></td>
+                                <?php $recipientsDisplayed++ ?>
+                            <?php endforeach; ?>
+                            </td>
+                            <?php if ($award->getEvent() != ''): ?>
+                                <?php if ($award->getURL() != ''): ?>
+                                    <td><a href="<?=$this->escape($award->getURL()) ?>" title="<?=$this->escape($award->getEvent()) ?>" target="_blank" rel="noopener"><?=$this->escape($award->getEvent()) ?></a></td>
                                 <?php else: ?>
-                                    <td><?=$this->escape($awards->getEvent()) ?></td>
+                                    <td><?=$this->escape($award->getEvent()) ?></td>
                                 <?php endif; ?>
                             <?php endif; ?>
                         </tr>

--- a/application/modules/awards/views/admin/index/treat.php
+++ b/application/modules/awards/views/admin/index/treat.php
@@ -57,7 +57,7 @@ if ($awards != '') {
                        placeholder="<?=$this->getTrans('httpOrMedia') ?>"
                        value="<?=($this->get('awards') != '') ? $this->escape($this->get('awards')->getImage()) : $this->escape($this->originalInput('image')) ?>" />
                 <span class="input-group-addon">
-                    <span class="fa-solid fa-xmark"></span>
+                    <span id="clearImage" class="fa-solid fa-xmark"></span>
                 </span>
                 <span class="input-group-addon">
                     <a id="media" href="javascript:media()"><i class="fa-regular fa-image"></i></a>
@@ -65,29 +65,45 @@ if ($awards != '') {
             </div>
         </div>
     </div>
-    <div class="form-group <?=($this->validation()->hasError('typ') or $this->validation()->hasError('utId')) ? 'has-error' : '' ?>">
+    <div class="form-group <?=($this->validation()->hasError('typ') || $this->validation()->hasError('utId')) ? 'has-error' : '' ?>">
         <label for="user" class="col-lg-2 control-label">
             <?=$this->getTrans('userTeam') ?>:
         </label>
         <div class="col-lg-2">
-            <select class="form-control" id="user" name="utId">
+            <select class="form-control" id="user" name="utId[]" multiple>
                 <optgroup label="<?=$this->getTrans('user') ?>">
                     <?php foreach ($this->get('users') as $user) {
                             $selected = '';
-                            if (($this->get('awards') != '' && $this->get('awards')->getUTId() == $user->getId() && $this->get('awards')->getTyp() == 1) || $this->originalInput('utId') == '1_'.$user->getId()) {
+                            if ($this->validation()->hasErrors() && in_array('1_'.$user->getId(), $this->originalInput('utId'))) {
                                 $selected = 'selected="selected"';
+                            } elseif (!$this->validation()->hasErrors() && $awards) {
+                                foreach($awards->getRecipients() as $recipient) {
+                                    if ($recipient->getUtId() === $user->getId() && $recipient->getTyp() === 1) {
+                                        $selected = 'selected="selected"';
+                                        break;
+                                    }
+                                }
                             }
+
                             echo '<option '.$selected.' value="1_'.$user->getId().'">'.$this->escape($user->getName()).'</option>';
                         }
                     ?>
                 </optgroup>
-                <?php if ($awardsMapper->existsTable('teams') == true && $this->get('teams') != ''): ?>
+                <?php if ($awardsMapper->existsTable('teams') && $this->get('teams') != ''): ?>
                     <optgroup label="<?=$this->getTrans('team') ?>">
                         <?php foreach ($this->get('teams') as $team) {
                             $selected = '';
-                            if (($this->get('awards') != '' && $this->get('awards')->getUTId() == $team->getId() && $this->get('awards')->getTyp() == 2) || $this->originalInput('utId') == '2_'.$team->getId()) {
+                            if ($this->validation()->hasErrors() && in_array('2_'.$team->getId(), $this->originalInput('utId'))) {
                                 $selected = 'selected="selected"';
+                            } elseif (!$this->validation()->hasErrors() && $awards) {
+                                foreach($awards->getRecipients() as $recipient) {
+                                    if ($recipient->getUtId() === $team->getId() && $recipient->getTyp() === 2) {
+                                        $selected = 'selected="selected"';
+                                        break;
+                                    }
+                                }
                             }
+
                             echo '<option '.$selected.' value="2_'.$team->getId().'">'.$this->escape($team->getName()).'</option>';
                         }
                         ?>
@@ -117,7 +133,7 @@ if ($awards != '') {
                    class="form-control"
                    name="page"
                    id="page"
-                   placeholder="http://"
+                   placeholder="https://"
                    value="<?=($this->get('awards') != '') ? $this->escape($this->get('awards')->getURL()) : $this->escape($this->originalInput('page')) ?>" />
         </div>
     </div>
@@ -141,6 +157,10 @@ $(document).ready(function() {
         language: '<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>',
         minView: 2,
         todayHighlight: true
+    });
+
+    $("#clearImage").click(function(){
+            $("#selectedImage").val('');
     });
 });
 

--- a/application/modules/awards/views/index/index.php
+++ b/application/modules/awards/views/index/index.php
@@ -1,6 +1,7 @@
 <?php
-$userMapper = $this->get('userMapper');
-$teamsMapper = $this->get('teamsMapper');
+$teams = $this->get('teams');
+$users = $this->get('users');
+$recipientToDisplayLimit = 6;
 ?>
 
 <link href="<?=$this->getModuleUrl('static/css/awards.css') ?>" rel="stylesheet">
@@ -15,52 +16,63 @@ $teamsMapper = $this->get('teamsMapper');
                 </div>
             </div>
         </div>
-        <?php foreach ($this->get('awards') as $awards): ?>
+        <?php foreach ($this->get('awards') as $award): ?>
             <div class="col-lg-6">
                 <div class="award">
                     <div class="rank" align="center">
-                        <?php if ($awards->getRank() == 1): ?>
-                            <i class="fa-solid fa-trophy img_gold" title="<?=$this->getTrans('rank') ?> <?=$awards->getRank() ?>"></i>
-                        <?php elseif ($awards->getRank() == 2): ?>
-                            <i class="fa-solid fa-trophy img_silver" title="<?=$this->getTrans('rank') ?> <?=$awards->getRank() ?>"></i>
-                        <?php elseif ($awards->getRank() == 3): ?>
-                            <i class="fa-solid fa-trophy img_bronze" title="<?=$this->getTrans('rank') ?> <?=$awards->getRank() ?>"></i>
+                        <a href="<?=$this->getUrl(['action' => 'show', 'id' => $award->getId()]) ?>">
+                        <?php if ($award->getRank() == 1): ?>
+                            <i class="fa-solid fa-trophy img_gold" title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>"></i>
+                        <?php elseif ($award->getRank() == 2): ?>
+                            <i class="fa-solid fa-trophy img_silver" title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>"></i>
+                        <?php elseif ($award->getRank() == 3): ?>
+                            <i class="fa-solid fa-trophy img_bronze" title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>"></i>
                         <?php else: ?>
-                            <span title="<?=$this->getTrans('rank') ?> <?=$awards->getRank() ?>"><?=$awards->getRank() ?></span>
+                            <span title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>"><?=$award->getRank() ?></span>
                         <?php endif; ?>
+                        </a>
                     </div>
                     <div class="rank_info">
-                        <?php if ($awards->getTyp() == 2): ?>
-                            <?php $team = $teamsMapper->getTeamById($awards->getUTId()); ?>
-                            <?php if ($team) : ?>
-                                <a href="<?=$this->getUrl('teams/index/index') ?>" target="_blank"><?=$this->escape($team->getName()) ?></a>
-                            <?php else: ?>
-                                <?=$this->getTrans('formerTeam') ?>
+                        <?php $recipientsDisplayed = 0 ?>
+                        <?php foreach($award->getRecipients() as $recipient) : ?>
+                            <?php if ($recipientsDisplayed >= $recipientToDisplayLimit): ?>
+                                <a href="<?=$this->getUrl(['action' => 'show', 'id' => $award->getId()]) ?>">...</a>
+                                <?php break; ?>
                             <?php endif; ?>
-                        <?php else: ?>
-                            <?php $user = $userMapper->getUserById($awards->getUTId()); ?>
-                            <?php if ($user) : ?>
-                                <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><?=$this->escape($user->getName()) ?></a>
+                            <?php if ($recipient->getTyp() == 2): ?>
+                                <?php foreach($teams[$award->getId()] as $team) : ?>
+                                    <?php if ($team->getId() === $recipient->getUtId()) : ?>
+                                        <a href="<?=$this->getUrl('teams/index/index') ?>" target="_blank"><?=$this->escape($team->getName()) ?></a>
+                                        <?php break; ?>
+                                    <?php endif; ?>
+                                <?php endforeach; ?>
                             <?php else: ?>
-                                <?=$this->getTrans('formerUser') ?>
+                                <?php foreach($users[$award->getId()] as $user) : ?>
+                                    <?php if ($user->getId() === $recipient->getUtId()) : ?>
+                                        <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><?=$this->escape($user->getName()) ?></a>
+                                        <?php break; ?>
+                                    <?php endif; ?>
+                                <?php endforeach; ?>
                             <?php endif; ?>
-                        <?php endif; ?>
-                        <br />
-                        <?=date('d.m.Y', strtotime($awards->getDate())) ?><br />
+                            <?php $recipientsDisplayed++ ?>
+                        <?php endforeach; ?>
 
-                        <?php if ($awards->getEvent() != ''): ?>
-                            <?php if ($awards->getURL() != ''): ?>
-                                <a href="<?=$this->escape($awards->getURL()) ?>" title="<?=$this->escape($awards->getEvent()) ?>" target="_blank" rel="noopener"><?=$this->escape($awards->getEvent()) ?></a>
+                        <br />
+                        <?=date('d.m.Y', strtotime($award->getDate())) ?><br />
+
+                        <?php if ($award->getEvent() != ''): ?>
+                            <?php if ($award->getURL() != ''): ?>
+                                <a href="<?=$this->escape($award->getURL()) ?>" title="<?=$this->escape($award->getEvent()) ?>" target="_blank" rel="noopener"><?=$this->escape($award->getEvent()) ?></a>
                             <?php else: ?>
-                                <?=$this->escape($awards->getEvent()) ?>
+                                <?=$this->escape($award->getEvent()) ?>
                             <?php endif; ?>
                         <?php else: ?>
                             <br />
                         <?php endif; ?>
                     </div>
-                    <?php if ($awards->getImage() != ''): ?>
+                    <?php if ($award->getImage() != ''): ?>
                         <div class="rank_image">
-                            <img src="<?=(strncmp($awards->getImage(), 'application', 11) === 0) ? $this->getBaseUrl($awards->getImage()) : $this->escape($awards->getImage()) ?>" alt="<?=$this->getTrans('rank') ?> <?=$awards->getRank() ?>" title="<?=$this->getTrans('rank') ?> <?=$awards->getRank() ?>" />
+                            <img src="<?=(strncmp($award->getImage(), 'application', 11) === 0) ? $this->getBaseUrl($award->getImage()) : $this->escape($award->getImage()) ?>" alt="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>" title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>" />
                         </div>
                     <?php endif; ?>
                 </div>

--- a/application/modules/awards/views/index/show.php
+++ b/application/modules/awards/views/index/show.php
@@ -1,0 +1,63 @@
+<?php
+$award = $this->get('award');
+$teams = $this->get('teams');
+$users = $this->get('users');
+?>
+<link href="<?=$this->getModuleUrl('static/css/awards.css') ?>" rel="stylesheet">
+
+<h1><?=$this->getTrans('menuAwards') ?></h1>
+<?php if ($this->get('award')): ?>
+    <div class="row">
+            <div class="rank_show">
+                <?php if ($award->getRank() == 1): ?>
+                    <i class="fa-solid fa-trophy img_gold fa-4x" title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>"></i>
+                <?php elseif ($award->getRank() == 2): ?>
+                    <i class="fa-solid fa-trophy img_silver fa-4x" title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>"></i>
+                <?php elseif ($award->getRank() == 3): ?>
+                    <i class="fa-solid fa-trophy img_bronze fa-4x" title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>"></i>
+                <?php else: ?>
+                    <span title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>"><?=$award->getRank() ?></span>
+                <?php endif; ?>
+            </div>
+            <div class="rank_info_show">
+                <?=date('d.m.Y', strtotime($award->getDate())) ?><br />
+                <?php if ($award->getEvent() != ''): ?>
+                    <?php if ($award->getURL() != ''): ?>
+                        <a href="<?=$this->escape($award->getURL()) ?>" title="<?=$this->escape($award->getEvent()) ?>" target="_blank" rel="noopener"><?=$this->escape($award->getEvent()) ?></a>
+                    <?php else: ?>
+                        <?=$this->escape($award->getEvent()) ?>
+                    <?php endif; ?>
+                <?php else: ?>
+                    <br />
+                <?php endif; ?>
+            </div>
+            <?php if ($award->getImage() != ''): ?>
+            <div class="rank_image">
+                <img src="<?=(strncmp($award->getImage(), 'application', 11) === 0) ? $this->getBaseUrl($award->getImage()) : $this->escape($award->getImage()) ?>" alt="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>" title="<?=$this->getTrans('rank') ?> <?=$award->getRank() ?>" />
+            </div>
+            <?php endif; ?>
+    </div>
+    <br>
+    <p><?=$this->getTrans('recipientsOfAward') ?>:</p>
+    <div class="award_recipients_show">
+    <?php foreach($award->getRecipients() as $recipient) : ?>
+        <?php if ($recipient->getTyp() == 2): ?>
+            <?php foreach($teams as $team) : ?>
+                <?php if ($team->getId() === $recipient->getUtId()) : ?>
+                    <a href="<?=$this->getUrl('teams/index/index') ?>" target="_blank"><?=$this->escape($team->getName()) ?></a>
+                    <?php break; ?>
+                <?php endif; ?>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <?php foreach($users as $user) : ?>
+                <?php if ($user->getId() === $recipient->getUtId()) : ?>
+                    <a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>"><?=$this->escape($user->getName()) ?></a>
+                    <?php break; ?>
+                <?php endif; ?>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    <?php endforeach; ?>
+    </div>
+<?php else: ?>
+    <?=$this->getTrans('awardNotFound') ?>
+<?php endif; ?>


### PR DESCRIPTION
# Description
- Support multiple recipients
-- Added a new view (frontend, show action) for an award to see all recipients (in case there are a lot of recipients). Limited the amount of recipients to display on the overviews (frontend, index action and admincenter, index action) to 6.
-- Created a new table to hold all recipients of the awards.
- Fixed "clear" button on image selection
- Code style fixes

Fixes #441

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
- [ ] IE
