### PR TITLE
Remove jquery.bxslider on update

### DIFF
--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -888,6 +888,11 @@ class Config extends \Ilch\Config\Install
                 $databaseConfig->set('comment_excludeFloodProtection', '1');
                 $this->db()->query("UPDATE `[prefix]_modules` SET `icon_small` = 'fa-regular fa-comments' WHERE `key` = 'comment';");
                 break;
+            case "2.1.50":
+                // Remove jquery.bxslider. The only known usage is the partner module. With the last version of that module bxslider got
+                // integrated into the module.
+                removeDir(ROOT_PATH . '/static/js/jquery.bxslider');
+                break;
         }
 
         return 'Update function executed.';


### PR DESCRIPTION
# Description
Remove jquery.bxslider on update. The only known usage is the partner module. With the last version of that module bxslider got integrated into the module.

The removal of jquery.bxslider was announced in the news of ilch 2.1.50.
https://github.com/IlchCMS/Ilch-2.0/releases/tag/v2.1.50

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)