### PR TITLE
Gallery: Fix "Argument must be of type string, null given"

### DIFF
--- a/application/modules/gallery/mappers/Image.php
+++ b/application/modules/gallery/mappers/Image.php
@@ -35,8 +35,8 @@ class Image extends \Ilch\Mapper
         $imageModel = new ImageModel();
         $imageModel->setId($imageRow['imgid']);
         $imageModel->setImageId($imageRow['image_id']);
-        $imageModel->setImageUrl($imageRow['url']);
-        $imageModel->setImageThumb($imageRow['url_thumb']);
+        $imageModel->setImageUrl((string)$imageRow['url']);
+        $imageModel->setImageThumb((string)$imageRow['url_thumb']);
         $imageModel->setImageTitle($imageRow['image_title']);
         $imageModel->setImageDesc($imageRow['image_description']);
         $imageModel->setGalleryId($imageRow['gallery_id']);
@@ -69,7 +69,7 @@ class Image extends \Ilch\Mapper
 
         $imageModel = new ImageModel();
         $imageModel->setImageId($imageRow['image_id']);
-        $imageModel->setImageThumb($imageRow['url_thumb']);
+        $imageModel->setImageThumb((string)$imageRow['url_thumb']);
         $imageModel->setImageTitle($imageRow['image_title']);
         $imageModel->setImageDesc($imageRow['image_description']);
         $imageModel->setVisits($imageRow['visits']);
@@ -141,8 +141,8 @@ class Image extends \Ilch\Mapper
 
         foreach ($imageArray as $entries) {
             $entryModel = new ImageModel();
-            $entryModel->setImageUrl($entries['url']);
-            $entryModel->setImageThumb($entries['url_thumb']);
+            $entryModel->setImageUrl((string)$entries['url']);
+            $entryModel->setImageThumb((string)$entries['url_thumb']);
             $entryModel->setId($entries['imgid']);
             $entryModel->setImageTitle($entries['image_title']);
             $entryModel->setImageDesc($entries['image_description']);

--- a/application/modules/gallery/views/index/show.php
+++ b/application/modules/gallery/views/index/show.php
@@ -43,25 +43,30 @@
 
 <div id="gallery">
     <?php foreach ($this->get('image') as $image): ?>
- 
         <?php $commentsCount = $commentMapper->getCountComments ('gallery/index/showimage/id/'.$image->getId()); ?>
  
         <div class="col-xs-6 col-md-4 col-lg-3 col-sm-4">
             <div class="panel panel-default">
- 
-                <a class="venobox" data-gall="gallery01" href="<?=$this->getUrl().'/' .$image->getImageUrl() ?>"title="<?=$image->getImageTitle() ?> ">
- 
-                <div class="panel-image thumbnail">
-                        <img src="<?=$this->getUrl().'/'.$image->getImageThumb() ?>" class="panel-image-preview" alt="<?=$image->getImageTitle()?>" />
-                </div>
- 
+            <?php if (file_exists($image->getImageThumb())): ?>
+                <a class="venobox" data-gall="gallery01" href="<?= $this->getUrl() . '/' . $image->getImageUrl() ?>" title="<?= $image->getImageTitle() ?> ">
+                    <div class="panel-image thumbnail">
+                        <img src="<?= $this->getUrl() . '/' . $image->getImageThumb() ?>" class="panel-image-preview" alt="<?= $this->escape($image->getImageTitle()) ?>" />
+                    </div>
+                </a>
+            <?php else: ?>
+                <a class="venobox" data-gall="gallery01" href="<?= $this->getUrl() . '/' . $image->getImageUrl() ?>" title="<?= $image->getImageTitle() ?> ">
+                    <div class="panel-image thumbnail">
+                        <img src="<?=$this->getBaseUrl('application/modules/media/static/img/nomedia.png') ?>" class="panel-image-preview" alt="<?=$this->getTrans('noMediaAlt') ?>" />
+                    </div>
+                </a>
+            <?php endif; ?>
+
                 <a href="<?=$this->getUrl(['action' => 'showimage', 'id' => $image->getId()]) ?>" title="<?=$this->getTrans('description')?>">
- 
- 
-                <div class="panel-footer text-center">
-                    <i class="fa-regular fa-comment"></i> <?=$commentsCount ?>
-                    <i class="fa-solid fa-eye"> <?=$image->getVisits() ?></i>
-                </div>
+                    <div class="panel-footer text-center">
+                        <i class="fa-regular fa-comment"></i> <?=$commentsCount ?>
+                        <i class="fa-solid fa-eye"></i> <?=$image->getVisits() ?>
+                    </div>
+                </a>
             </div>
         </div>
     <?php endforeach; ?>
@@ -77,4 +82,4 @@
         navTouch: true,
         spinner: 'pulse',
     })
-    </script>
+</script>

--- a/application/modules/gallery/views/index/showimage.php
+++ b/application/modules/gallery/views/index/showimage.php
@@ -9,9 +9,15 @@ $commentsClass = new Ilch\Comments();
 <div id="gallery">
     <div class="row">
         <div class="col-md-6">
-            <a class="venobox" href="<?=$this->getUrl().'/'.$image->getImageUrl() ?>">
-                <img src="<?=$this->getUrl().'/'.$image->getImageUrl() ?>" alt="<?=$this->escape($image->getImageTitle()) ?>"/>
+        <?php if ($image->getImageUrl()): ?>
+            <a class="venobox" href="<?= $this->getUrl() . '/' . $image->getImageUrl() ?>">
+                <img src="<?= $this->getUrl() . '/' . $image->getImageUrl() ?>" alt="<?= $this->escape($image->getImageTitle()) ?>" />
             </a>
+        <?php else: ?>
+            <a class="venobox" href="<?= $this->getUrl() . '/' . $image->getImageUrl() ?>">
+                <img src="<?=$this->getBaseUrl('application/modules/media/static/img/nomedia.png') ?>" alt="<?=$this->getTrans('noMediaAlt') ?>" />
+            </a>
+        <?php endif; ?>
         </div>
     </div>
 </div>


### PR DESCRIPTION
# Description
Deleting an image in the media module, which is used in a gallery of the gallery module caused an exception.

- Fix "setImageUrl(): Argument must be of type string, null given"
- Further improved the views for handling a missing image.

```
Fatal error: Uncaught TypeError: Modules\Gallery\Models\Image::setImageUrl(): Argument #1 ($imageUrl) must be of type string, null given, called in application\modules\gallery\mappers\Image.php on line 144 and defined in application\modules\gallery\models\Image.php:225
Stack trace:
#0 application\modules\gallery\mappers\Image.php(144): Modules\Gallery\Models\Image->setImageUrl(NULL)
#1 application\modules\gallery\controllers\admin\Gallery.php(81): Modules\Gallery\Mappers\Image->getImageByGalleryId(2, Object(Ilch\Pagination))
#2 application\libraries\Ilch\Page.php(241): Modules\Gallery\Controllers\Admin\Gallery->treatGalleryAction()
#3 application\libraries\Ilch\Page.php(135): Ilch\Page->loadController()
#4 index.php(66): Ilch\Page->loadPage()
#5 {main} thrown in application\modules\gallery\models\Image.php on line 225


Fatal error: Uncaught TypeError: Modules\Gallery\Models\Image::setImageThumb(): Argument #1 ($imagethumb) must be of type string, null given, called in application\modules\gallery\mappers\Image.php on line 72 and defined in application\modules\gallery\models\Image.php:175
Stack trace:
#0 application\modules\gallery\mappers\Image.php(72): Modules\Gallery\Models\Image->setImageThumb(NULL)
#1 application\modules\gallery\views\index\index.php(35): Modules\Gallery\Mappers\Image->getLastImageByGalleryId(2)
#2 application\modules\gallery\views\index\index.php(70): recGallery(Object(Modules\Gallery\Models\GalleryItem), Object(Modules\Gallery\Mappers\Gallery), Object(Ilch\View), Object(Modules\Gallery\Mappers\Image), '1', 'cat')
#3 application\modules\gallery\views\index\index.php(115): recGallery(Object(Modules\Gallery\Models\GalleryItem), Object(Modules\Gallery\Mappers\Gallery), Object(Ilch\View), Object(Modules\Gallery\Mappers\Image), '1', 'cat')
#4 application\libraries\Ilch\View.php(22): include('...')
#5 application\libraries\Ilch\Page.php(159): Ilch\View->loadScript('...')
#6 index.php(66): Ilch\Page->loadPage()
#7 {main} thrown in application\modules\gallery\models\Image.php on line 175


Fatal error: Uncaught TypeError: Modules\Gallery\Models\Image::setImageUrl(): Argument #1 ($imageUrl) must be of type string, null given, called in application\modules\gallery\mappers\Image.php on line 38 and defined in application\modules\gallery\models\Image.php:225
Stack trace:
#0 application\modules\gallery\mappers\Image.php(38): Modules\Gallery\Models\Image->setImageUrl(NULL)
#1 application\modules\gallery\controllers\Index.php(82): Modules\Gallery\Mappers\Image->getImageById(5)
#2 application\libraries\Ilch\Page.php(241): Modules\Gallery\Controllers\Index->showImageAction()
#3 application\libraries\Ilch\Page.php(135): Ilch\Page->loadController()
#4 index.php(66): Ilch\Page->loadPage()
#5 {main} thrown in application\modules\gallery\models\Image.php on line 225
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
- [ ] IE
