### PR TITLE
Fix errors when trying to delete a category.

### DIFF
--- a/application/modules/gallery/controllers/admin/Index.php
+++ b/application/modules/gallery/controllers/admin/Index.php
@@ -42,13 +42,11 @@ class Index extends \Ilch\Controller\Admin
         $galleryMapper = new GalleryMapper();
         $imageMapper = new ImageMapper();
 
-        /*
-         * Saves the item tree to database.
-         */
+        // Saves the item tree to database.
         if ($this->getRequest()->isPost()) {
             if ($this->getRequest()->getPost('save')) {
                 $sortItems = json_decode($this->getRequest()->getPost('hiddenMenu'));
-                $items = $this->getRequest()->getPost('items');
+                $items = $this->getRequest()->getPost('items') ?? [];
 
                 foreach ($items as $item) {
                     $validation = Validation::create($item, [


### PR DESCRIPTION
# Description
- Fix errors when trying to delete a category.
-- Fix "key_exists(): Argument ($array) must be of type array, null given"
-- Fix "foreach() argument must be of type array|object, null given"

```
Warning: foreach() argument must be of type array|object, null given in application\modules\gallery\controllers\admin\Index.php on line 53

Fatal error: Uncaught TypeError: key_exists(): Argument #2 ($array) must be of type array, null given in application\modules\gallery\controllers\admin\Index.php:70
Stack trace:
#0 application\modules\gallery\controllers\admin\Index.php(70): key_exists(1, NULL)
#1 application\libraries\Ilch\Page.php(241): Modules\Gallery\Controllers\Admin\Index->indexAction()
#2 application\libraries\Ilch\Page.php(135): Ilch\Page->loadController()
#3 index.php(66): Ilch\Page->loadPage()
#4 {main} thrown in application\modules\gallery\controllers\admin\Index.php on line 70
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
