### PR TITLE
Add bbcodeconvert module

### DIFF
--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -6,6 +6,8 @@
 
 namespace Modules\Admin\Config;
 
+use Ilch\View;
+
 class Config extends \Ilch\Config\Install
 {
     public $config = [
@@ -892,6 +894,23 @@ class Config extends \Ilch\Config\Install
                 // Remove jquery.bxslider. The only known usage is the partner module. With the last version of that module bxslider got
                 // integrated into the module.
                 removeDir(ROOT_PATH . '/static/js/jquery.bxslider');
+                break;
+            case "2.1.51":
+                // Add notification in the admincenter regarding the available bbcodeconvert module.
+                $notificationsMapper = new \Modules\Admin\Mappers\Notifications();
+                $notificationModel = new \Modules\Admin\Models\Notification();
+
+                $message = [
+                    'de' => 'Das Modul "BBCode-Konvertierung" steht zur Installation zur Verfügung.',
+                    'en' => 'The module "BBCode Conversion" is available for installation.'
+                ];
+
+                $notificationModel->setModule('bbcodeconvert');
+                $notificationModel->setMessage($message[$this->getTranslator()->shortenLocale($this->getTranslator()->getLocale())]);
+                $notificationModel->setURL(BASE_URL . '/' . 'admin/admin/modules/notinstalled');
+                $notificationModel->setType('bbcodeconvertAvailableForInstallation');
+
+                $notificationsMapper->addNotification($notificationModel);
                 break;
         }
 

--- a/application/modules/bbcodeconvert/config/config.php
+++ b/application/modules/bbcodeconvert/config/config.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Bbcodeconvert\Config;
+
+use Ilch\Config\Install;
+
+class Config extends Install
+{
+    public $config = [
+        'key' => 'bbcodeconvert',
+        'version' => '1.0.0',
+        'icon_small' => 'fa-solid fa-arrow-right-arrow-left',
+        'author' => 'ilch.de',
+        'link' => 'https://www.ilch.de',
+        'official' => true,
+        'languages' => [
+            'de_DE' => [
+                'name' => 'BBCode-Konvertierung',
+                'description' => 'Modul zum Konvertierung von BBCode zu HTML.',
+            ],
+            'en_EN' => [
+                'name' => 'BBCode Conversion',
+                'description' => 'Module to convert BBCode to HTML.',
+            ],
+        ],
+        'ilchCore' => '2.1.51',
+        'phpVersion' => '7.3'
+    ];
+
+    public function install()
+    {
+    }
+
+    public function uninstall()
+    {
+        $this->db()->queryMulti("DELETE FROM `[prefix]_config` WHERE `key` = 'bbcodeconvert_converted';");
+    }
+
+    public function getUpdate(string $installedVersion)
+    {
+    }
+}

--- a/application/modules/bbcodeconvert/controllers/admin/Index.php
+++ b/application/modules/bbcodeconvert/controllers/admin/Index.php
@@ -1,0 +1,409 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Bbcodeconvert\Controllers\Admin;
+
+use Ilch\Controller\Admin;
+use Modules\Admin\Mappers\Module as ModuleMapper;
+use Modules\Bbcodeconvert\Mappers\Texts as TextsMapper;
+use Modules\Bbcodeconvert\Mappers\User as UserMapper;
+use Modules\Admin\Mappers\Backup as BackupMapper;
+use Modules\Admin\Models\Layout as LayoutModel;
+use Modules\Admin\Mappers\LayoutAdvSettings;
+
+class Index extends Admin
+{
+    private const supportedModules = [
+        'contact' => ['2.1.50'],
+        'events' => ['1.21.2', '1.22.0'],
+        'forum' => ['1.31.0', '1.32.0'],
+        'guestbook' => ['1.12.0', '1.13.0'],
+        'jobs' => ['1.5.0', '1.6.0'],
+        'teams' => ['1.22.0', '1.23.0'],
+        'user' => ['2.1.50']
+    ];
+
+    private const supportedLayouts = [
+        'privatlayout' => ['1.1.0']
+    ];
+
+    // Number of items per batch (work is splitted up).
+    private const batch = 100;
+
+    public function init()
+    {
+        $items = [
+            [
+                'name' => 'menuOverview',
+                'active' => false,
+                'icon' => 'fa-solid fa-arrow-right-arrow-left',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+            ],
+            [
+                'name' => 'menuNote',
+                'active' => false,
+                'icon' => 'fa-solid fa-circle-info',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'note'])
+            ]
+        ];
+
+        if ($this->getRequest()->getActionName() === 'note') {
+            $items[1]['active'] = true;
+        } else {
+            $items[0]['active'] = true;
+        }
+
+        $this->getLayout()->addMenu(
+            'menuConvert',
+            $items
+        );
+    }
+
+    public function indexAction()
+    {
+        $moduleMapper = new ModuleMapper();
+        $backupMapper = new BackupMapper();
+
+        $this->getLayout()->getAdminHmenu()
+            ->add($this->getTranslator()->trans('menuConvert'), ['action' => 'index'])
+            ->add($this->getTranslator()->trans('menuOverview'), ['action' => 'index']);
+
+        $installedSupportedModules = [];
+        $installedSupportedLayouts = [];
+        $_SESSION['bbcodeconvert_toConvert'] = [];
+        $modules = $moduleMapper->getModules();
+        $getHtmlFromBBCodeExists = method_exists('\Ilch\View', 'getHtmlFromBBCode');
+
+        foreach ($modules as $module) {
+            // Check if the version of the module is supported. For system modules this is the ilch version.
+            if (array_key_exists($module->getKey(), self::supportedModules) && (in_array($module->getVersion(), self::supportedModules[$module->getKey()]) || ($module->getSystemModule() && in_array(VERSION, self::supportedModules[$module->getKey()])))) {
+                if ($module->getSystemModule() && empty($module->getVersion())) {
+                    $module->setVersion(VERSION);
+                }
+
+                $installedSupportedModules[] = $module;
+            }
+        }
+
+        foreach (glob(APPLICATION_PATH.'/layouts/*') as $layoutPath) {
+            file_put_contents('php://stderr', print_r($layoutPath.PHP_EOL, TRUE));
+            if (is_dir($layoutPath)) {
+                file_put_contents('php://stderr', print_r('is_dir true'.PHP_EOL, TRUE));
+                $configClass = '\\Layouts\\' . ucfirst(basename($layoutPath)) . '\\Config\\Config';
+                $config = new $configClass($this->getTranslator());
+                $model = new LayoutModel();
+                $model->setKey(basename($layoutPath));
+                $model->setName($config->config['name']);
+                $model->setVersion($config->config['version']);
+
+                // Check if the version of the layout is supported.
+                if (array_key_exists($model->getKey(), self::supportedLayouts) && (in_array($model->getVersion(), self::supportedLayouts[$model->getKey()]))) {
+                    $installedSupportedLayouts[] = $model;
+                }
+            }
+        }
+
+        if ($getHtmlFromBBCodeExists && $this->getRequest()->getPost('action') === 'convert' && ($this->getRequest()->getPost('check_modules') || $this->getRequest()->getPost('check_layouts'))) {
+            if ($this->getRequest()->getPost('check_modules')) {
+                foreach ($this->getRequest()->getPost('check_modules') as $moduleKey) {
+                    $_SESSION['bbcodeconvert_toConvert'][] = ['key' => $moduleKey, 'currentTask' => '', 'completed' => false, 'index' => 0, 'progress' => 0, 'count' => $this->getCount($moduleKey)];
+                }
+            }
+
+            if ($this->getRequest()->getPost('check_layouts')) {
+                foreach ($this->getRequest()->getPost('check_layouts') as $layoutKey) {
+                    $_SESSION['bbcodeconvert_toConvert'][] = ['key' => $layoutKey, 'currentTask' => '', 'completed' => false, 'index' => 0, 'progress' => 0, 'count' => $this->getCount($layoutKey)];
+                }
+            }
+
+            $this->redirect($this->getView()->getUrl(['action' => 'convert'], null, true));
+        }
+
+        $this->getView()->set('installedSupportedModules', $installedSupportedModules)
+            ->set('installedSupportedLayouts', $installedSupportedLayouts)
+            ->set('maintenanceModeEnabled', $this->getConfig()->get('maintenance_mode'))
+            ->set('lastBackup', $backupMapper->getLastBackup())
+            ->set('converted', (json_decode($this->getConfig()->get('bbcodeconvert_converted'), true)) ?? [])
+            ->set('getHtmlFromBBCodeExists', $getHtmlFromBBCodeExists);
+    }
+
+    public function convertAction()
+    {
+        if (!$this->getRequest()->isSecure() || !method_exists('\Ilch\View', 'getHtmlFromBBCode')) {
+            $this->redirect(['action' => 'index']);
+            return;
+        }
+
+        @set_time_limit(300);
+        $workDone = true;
+
+        foreach ($_SESSION['bbcodeconvert_toConvert'] as $key => $moduleOrLayout) {
+            if (!$moduleOrLayout['completed']) {
+                $workDone = false;
+                $result = $this->convert($moduleOrLayout['key'], $moduleOrLayout['index'], $moduleOrLayout['progress']);
+
+                if (!empty($result)) {
+                    $_SESSION['bbcodeconvert_toConvert'][$key] = array_merge($_SESSION['bbcodeconvert_toConvert'][$key], $this->convert($moduleOrLayout['key'], $moduleOrLayout['index'], $moduleOrLayout['progress'], $moduleOrLayout['currentTask']));
+
+                    // Exit this loop to not reach max_execution_time inside this function. This function gets called again by a javascript redirect.
+                    $this->getView()->set('redirectAfterPause', true);
+                    break;
+                }
+            }
+        }
+
+        $converted = [];
+        foreach($_SESSION['bbcodeconvert_toConvert'] as $value) {
+            $converted[$value['key']] = $value['completed'];
+        }
+
+        $knownConverted = (json_decode($this->getConfig()->get('bbcodeconvert_converted'), true)) ?? [];
+        $knownConverted = array_merge($knownConverted, $converted);
+        $this->getConfig()->set('bbcodeconvert_converted', json_encode($knownConverted));
+
+        $this->getView()->set('workDone', $workDone);
+    }
+
+    public function noteAction()
+    {
+        $this->getLayout()->getAdminHmenu()
+            ->add($this->getTranslator()->trans('menuConvert'), ['action' => 'index'])
+            ->add($this->getTranslator()->trans('menuNote'), ['action' => 'note']);
+
+        $this->getView()->set('supportedModules', self::supportedModules)
+            ->set('supportedLayouts', self::supportedLayouts);
+    }
+
+    /**
+     * Get number of items to convert.
+     *
+     * @param string $key
+     * @return int
+     */
+    public function getCount(string $key): int
+    {
+        $textsMapper = new TextsMapper();
+
+        switch ($key) {
+            case 'contact':
+                // table: config, column: value, datatype: VARCHAR(191)
+                return 1;
+            case 'events':
+                // table: events, column: text, datatype: LONGTEXT
+                $textsMapper->table = 'events';
+                break;
+            case 'forum':
+                // table: forum_posts, column: text, datatype: TEXT
+                $textsMapper->table = 'forum_posts';
+                break;
+            case 'guestbook':
+                // table: gbook, column: text, datatype: MEDIUMTEXT
+                $textsMapper->table = 'gbook';
+                break;
+            case 'jobs':
+                // table: jobs, column: text, datatype: MEDIUMTEXT
+                $textsMapper->table = 'jobs';
+                break;
+            case 'teams':
+                // table: teams_joins, column: text, datatype: LONGTEXT
+                $textsMapper->table = 'teams_joins';
+                break;
+            case 'user':
+                // table: users, column: signature, datatype: VARCHAR
+                // table: users_dialog_reply, column: reply, datatype: TEXT
+                $userMapper = new UserMapper();
+
+                return $userMapper->getCount();
+            case 'privatlayout':
+                // Layout
+                // table: admin_layoutadvsettings, column: value, datatype: TEXT
+                return 1;
+        }
+
+        return $textsMapper->getCount();
+    }
+
+    /**
+     * Convert from bbcode to html.
+     *
+     * @param string $key
+     * @param int $index
+     * @param int $progress
+     * @param string $currentTask
+     * @return array
+     * @see https://dev.mysql.com/doc/refman/8.0/en/storage-requirements.html#data-types-storage-reqs-strings
+     */
+    public function convert(string $key, int $index, int $progress, string $currentTask = ''): array
+    {
+        switch ($key) {
+            case 'contact':
+                // table: config, column: value, datatype: VARCHAR(191)
+                $convertedText = $this->getView()->getHtmlFromBBCode($this->getConfig()->get('contact_welcomeMessage'));
+
+                if (strlen($convertedText) <= 191) {
+                    $this->getConfig()->set('contact_welcomeMessage', $convertedText);
+                }
+                return ['completed' => true, 'index' => 0, 'progress' => 1];
+            case 'events':
+                // table: events, column: text, datatype: LONGTEXT
+                $textsMapper = new TextsMapper();
+                $textsMapper->table = 'events';
+                $texts = $textsMapper->getTexts($index, self::batch);
+
+                foreach($texts as $text) {
+                    $convertedText = $this->getView()->getHtmlFromBBCode($text['text']);
+                    // L + 4 bytes, where L < 2^32
+                    if (strlen($convertedText) <= ((4294967295 / 5) - 4)) {
+                        $textsMapper->updateText($text['id'], $convertedText);
+                    }
+                }
+
+                if (empty($texts)) {
+                    return ['completed' => true, 'index' => $index];
+                }
+
+                return ['completed' => false, 'index' => $index + count($texts), 'progress' => $index + count($texts)];
+            case 'forum':
+                // table: forum_posts, column: text, datatype: TEXT
+                $textsMapper = new TextsMapper();
+                $textsMapper->table = 'forum_posts';
+                $texts = $textsMapper->getTexts($index, self::batch);
+
+                foreach($texts as $text) {
+                    $convertedText = $this->getView()->getHtmlFromBBCode($text['text']);
+
+                    // L + 2 bytes, where L < 2^16
+                    if (strlen($convertedText) <= ((65535 / 5) - 2)) {
+                        $textsMapper->updateText($text['id'], $convertedText);
+                    }
+                }
+
+                if (empty($texts)) {
+                    return ['completed' => true, 'index' => $index];
+                }
+
+                return ['completed' => false, 'index' => $index + count($texts), 'progress' => $index + count($texts)];
+            case 'guestbook':
+                // table: gbook, column: text, datatype: MEDIUMTEXT
+                $textsMapper = new TextsMapper();
+                $textsMapper->table = 'gbook';
+                $texts = $textsMapper->getTexts($index, self::batch);
+
+                foreach($texts as $text) {
+                    $convertedText = $this->getView()->getHtmlFromBBCode($text['text']);
+
+                    // L + 3 bytes, where L < 2^24
+                    if (strlen($convertedText) <= ((16777215 / 5) - 3)) {
+                        $textsMapper->updateText($text['id'], $convertedText);
+                    }
+                }
+
+                if (empty($texts)) {
+                    return ['completed' => true, 'index' => $index];
+                }
+
+                return ['completed' => false, 'index' => $index + count($texts), 'progress' => $index + count($texts)];
+            case 'jobs':
+                // table: jobs, column: text, datatype: MEDIUMTEXT
+                $textsMapper = new TextsMapper();
+                $textsMapper->table = 'jobs';
+                $texts = $textsMapper->getTexts($index, self::batch);
+
+                foreach($texts as $text) {
+                    $convertedText = $this->getView()->getHtmlFromBBCode($text['text']);
+
+                    // L + 3 bytes, where L < 2^24
+                    if (strlen($convertedText) <= ((16777215 / 5) - 3)) {
+                        $textsMapper->updateText($text['id'], $convertedText);
+                    }
+                }
+
+                if (empty($texts)) {
+                    return ['completed' => true, 'index' => $index];
+                }
+
+                return ['completed' => false, 'index' => $index + count($texts), 'progress' => $index + count($texts)];
+            case 'teams':
+                // table: teams_joins, column: text, datatype: LONGTEXT
+                $textsMapper = new TextsMapper();
+                $textsMapper->table = 'teams_joins';
+                $texts = $textsMapper->getTexts($index, self::batch);
+
+                foreach($texts as $text) {
+                    $convertedText = $this->getView()->getHtmlFromBBCode($text['text']);
+
+                    // L + 3 bytes, where L < 2^24
+                    if (strlen($convertedText) <= ((16777215 / 5) - 3)) {
+                        $textsMapper->updateText($text['id'], $convertedText);
+                    }
+                }
+
+                if (empty($texts)) {
+                    return ['completed' => true, 'index' => $index];
+                }
+
+                return ['completed' => false, 'index' => $index + count($texts), 'progress' => $index + count($texts)];
+            case 'user':
+                $userMapper = new UserMapper();
+
+                if ($currentTask === '' || $currentTask === 'signature') {
+                    // table: users, column: signature, datatype: VARCHAR(255)
+                    $signatures = $userMapper->getSignatures($index, self::batch);
+
+                    foreach($signatures as $signature) {
+                        $convertedSignature = $this->getView()->getHtmlFromBBCode($signature['signature']);
+
+                        if (strlen($convertedSignature) <= 255) {
+                            $userMapper->updateSignature($signature['id'], $convertedSignature);
+                        }
+                    }
+
+                    if (!empty($signatures) && $currentTask === 'signature') {
+                        return ['currentTask' => 'signature', 'completed' => false, 'index' => $index + count($signatures), 'progress' => $index + count($signatures)];
+                    }
+
+                    if (empty($signatures)) {
+                        // Reset index to 0 for next task.
+                        $index = 0;
+                    }
+                }
+
+                // table: users_dialog_reply, column: reply, datatype: TEXT
+                $replies = $userMapper->getReplies($index, self::batch);
+
+                foreach($replies as $reply) {
+                    $convertedReply = $this->getView()->getHtmlFromBBCode($reply['reply']);
+
+                    // L + 2 bytes, where L < 2^16
+                    if (strlen($convertedReply) <= ((65535 / 5) - 2)) {
+                        $userMapper->updateReply($reply['id'], $convertedReply);
+                    }
+                }
+
+                if (empty($replies)) {
+                    return ['currentTask' => 'reply', 'completed' => true, 'index' => $index];
+                }
+
+                return ['currentTask' => 'reply', 'completed' => false, 'index' => $index + count($replies), 'progress' => $progress + count($replies)];
+            case 'privatlayout':
+                // Layout
+                // table: admin_layoutadvsettings, column: value, datatype: TEXT
+                $layoutAdvSettingsMapper = new LayoutAdvSettings();
+
+                $model[] = $layoutAdvSettingsMapper->getSetting('privatlayout', 'siteInfo');
+                $model[0]->setValue(nl2br($this->getView()->getHtmlFromBBCode($model[0]->getValue())));
+
+                // L + 2 bytes, where L < 2^16
+                if (strlen($model[0]->getValue()) <= ((65535 / 5) - 2)) {
+                    $layoutAdvSettingsMapper->save($model);
+                }
+
+                return ['completed' => true, 'index' => 0, 'progress' => 1];
+        }
+
+        return [];
+    }
+}

--- a/application/modules/bbcodeconvert/controllers/admin/Index.php
+++ b/application/modules/bbcodeconvert/controllers/admin/Index.php
@@ -17,13 +17,13 @@ use Modules\Admin\Mappers\LayoutAdvSettings;
 class Index extends Admin
 {
     private const supportedModules = [
-        'contact' => ['2.1.50'],
-        'events' => ['1.21.2', '1.22.0'],
-        'forum' => ['1.31.0', '1.32.0'],
-        'guestbook' => ['1.12.0', '1.13.0'],
-        'jobs' => ['1.5.0', '1.6.0'],
-        'teams' => ['1.22.0', '1.23.0'],
-        'user' => ['2.1.50']
+        'contact' => ['2.1.51'],
+        'events' => ['1.22.0'],
+        'forum' => ['1.33.0'],
+        'guestbook' => ['1.13.0'],
+        'jobs' => ['1.6.0'],
+        'teams' => ['1.23.0'],
+        'user' => ['2.1.51']
     ];
 
     private const supportedLayouts = [

--- a/application/modules/bbcodeconvert/mappers/Texts.php
+++ b/application/modules/bbcodeconvert/mappers/Texts.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Bbcodeconvert\Mappers;
+
+use Ilch\Database\Mysql\Result;
+use Ilch\Mapper;
+
+/**
+ * Get and update the texts. This mapper is used for the following modules: contact, events, forum, guestbook, jobs and teams.
+ */
+class Texts extends Mapper
+{
+    public $table = '';
+
+    /**
+     * Get the texts.
+     *
+     * @param int $offset
+     * @param int $limit
+     * @return array
+     */
+    public function getTexts(int $offset, int $limit): array
+    {
+        $texts = $this->db()->select(['id', 'text'])
+            ->from($this->table)
+            ->limit([$offset, $limit])
+            ->execute()
+            ->fetchRows('id');
+
+        if (empty($texts)) {
+            return [];
+        }
+
+        return $texts;
+    }
+
+    /**
+     * Returns the count of texts.
+     *
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return (int)$this->db()->select('COUNT(*)')
+            ->from($this->table)
+            ->execute()
+            ->fetchCell();
+    }
+
+    /**
+     * Update the text.
+     *
+     * @param int $id
+     * @param string $text
+     * @return Result|int
+     */
+    public function updateText(int $id, string $text): int
+    {
+        return $this->db()->update()->table($this->table)
+            ->values(['text' => $text])
+            ->where(['id' => $id])
+            ->execute();
+    }
+}

--- a/application/modules/bbcodeconvert/mappers/User.php
+++ b/application/modules/bbcodeconvert/mappers/User.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Bbcodeconvert\Mappers;
+
+use Ilch\Database\Mysql\Result;
+use Ilch\Mapper;
+
+/**
+ * Get and update the signatures and replies in the database.
+ */
+class User extends Mapper
+{
+    /**
+     * Get the signatures.
+     *
+     * @param int $offset
+     * @param int $limit
+     * @return array
+     */
+    public function getSignatures(int $offset, int $limit): array
+    {
+        $signatures = $this->db()->select(['id', 'signature'])
+            ->from('users')
+            ->limit([$offset, $limit])
+            ->execute()
+            ->fetchRows('id');
+
+        if (empty($signatures)) {
+            return [];
+        }
+
+        return $signatures;
+    }
+
+    /**
+     * Get the replies.
+     *
+     * @param int $offset
+     * @param int $limit
+     * @return array
+     */
+    public function getReplies(int $offset, int $limit): array
+    {
+        $replies = $this->db()->select(['id', 'reply'])
+            ->from('users_dialog_reply')
+            ->limit([$offset, $limit])
+            ->execute()
+            ->fetchRows('id');
+
+        if (empty($replies)) {
+            return [];
+        }
+
+        return $replies;
+    }
+
+    /**
+     * Returns the count of all items (signatures and dialog replys) to convert.
+     *
+     * @return int
+     */
+    public function getCount(): int
+    {
+        $count = (int)$this->db()->select('COUNT(*)')
+            ->from('users')
+            ->execute()
+            ->fetchCell();
+
+        $count += (int)$this->db()->select('COUNT(*)')
+            ->from('users_dialog_reply')
+            ->execute()
+            ->fetchCell();
+
+        return $count;
+    }
+
+    /**
+     * Update the signature.
+     *
+     * @param int $id
+     * @param string $signature
+     * @return Result|int
+     */
+    public function updateSignature(int $id, string $signature): int
+    {
+        return $this->db()->update()->table('users')
+            ->values(['signature' => $signature])
+            ->where(['id' => $id])
+            ->execute();
+    }
+
+    /**
+     * Update the reply.
+     *
+     * @param int $id
+     * @param string $reply
+     * @return int
+     */
+    public function updateReply(int $id, string $reply): int
+    {
+        return $this->db()->update()->table('users_dialog_reply')
+            ->values(['reply' => $reply])
+            ->where(['id' => $id])
+            ->execute();
+    }
+}

--- a/application/modules/bbcodeconvert/static/css/bbcodeconvert_styles.css
+++ b/application/modules/bbcodeconvert/static/css/bbcodeconvert_styles.css
@@ -1,0 +1,63 @@
+#sortable td:hover {
+    cursor:move;
+}
+#sortable .placeholder {
+    outline: 0;
+    border: 0;
+    background-image: linear-gradient(135deg, #eeeeee 8.33%, #ffffff 8.33%, #ffffff 50%, #eeeeee 50%, #eeeeee 58.33%, #ffffff 58.33%, #ffffff 100%);
+    background-size: 12px 12px;
+}
+#sortTable th.sort {
+    cursor: pointer;
+}
+#sortTable th.sort:after {
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    display: inline;
+    content: ' \f0dc';
+    color: #ccc;
+}
+#sortTable th.sort:hover::after,
+#sortTable th.sort.asc:hover::after,
+#sortTable th.sort.desc:hover::after {
+    color: #f00;
+}
+#sortTable th.sort.asc:after {
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    display: inline;
+    content: ' \f0dd';
+    color: #000;
+}
+#sortTable th.sort.desc:after {
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    display: inline;
+    content: ' \f0de';
+    color: #000;
+}
+div.input-group.filter {
+    top: -3px;
+    width: 300px;
+    float: right;
+}
+div.input-group.filter input:not(:placeholder-shown) {
+    font-weight: bold;
+    color: #a94442;
+    background: #f2dede;
+}
+.order .table td {
+    border-bottom: 1px solid #F0F0F0;
+    padding: 10px;
+}
+.order .table td.finish {
+    background: #fff;
+    border-top: none !important;
+    border-bottom: none !important;
+    padding: 3px 10px;
+}
+.order .table td.finished {
+    background: #fff;
+    border-top: 2px solid #ddd !important;
+    border-bottom: none !important;
+}

--- a/application/modules/bbcodeconvert/translations/de.php
+++ b/application/modules/bbcodeconvert/translations/de.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+return [
+    'contact' => 'Kontakt',
+    'events' => 'Veranstaltungen',
+    'forum' => 'Forum',
+    'guestbook' => 'Gästebuch',
+    'jobs' => 'Jobs',
+    'teams' => 'Teams',
+    'user' => 'Benutzer',
+    'menuConvert' => 'BBCode-Konvertierung',
+    'menuOverview' => 'Übersicht',
+    'menuNote' => 'Hinweis',
+    'noteDescription' => 'Modul zum Konvertierung von BBCode zu HTML für explizit unterstütze Module und Layouts.<br>Der BBCode wird nur konvertiert, wenn der resultierende HTML-Code weiterhin in die entsprechende Spalte der Tabelle in der Datenbank passt, da dies andernfalls zu Datenverlust oder Fehlern führen würde.',
+    'module' => 'Modul',
+    'layout' => 'Layout',
+    'supportedVersions' => 'Unterstütze Versionen',
+    'converted' => 'konvertiert',
+    'notConverted' => 'nicht konvertiert',
+    'filterModules' => 'Module filtern',
+    'progress' => 'Fortschritt',
+    'warningMaintenanceMode' => 'Es wird empfohlen die Seite vor der Konvertierung von Inhalten in den Wartungsmodus zu versetzen.',
+    'warningBackup' => 'Es wird dringend empfohlen vor der Konvertierung eine Sicherheitskopie der Datenbank zu erstellen. Letzte Sicherheitskopie vom: %s',
+    'noBackup' => 'Keine Sicherheitskopie gefunden!',
+    'infoMessage' => 'Die folgenden unterstützten Module und Layouts wurden gefunden und können konvertiert werden, indem Sie ausgewählt werden und die Konvertierung gestartet wird:',
+    'convert' => 'konvertieren',
+    'confirmConvert' => 'Wollen Sie die Konvertierung für die ausgewählten Module und Layouts starten?',
+    'redirectAfterPause' => 'Diese Seite leitet nach 3 Sekunden weiter um die Arbeit fortzusetzen.',
+    'workDone' => 'Konvertierung abgeschlossen.',
+    'moduleNoLongerSupported' => 'Dieses Modul wird leider nicht mehr unterstützt. Eine Konvertierung ist mit dieser Version von Ilch nicht mehr möglich. Möglicherweise ist eine neuere Version dieses Moduls verfügbar.',
+    'cancelled' => 'abgebrochen',
+];

--- a/application/modules/bbcodeconvert/translations/en.php
+++ b/application/modules/bbcodeconvert/translations/en.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+return [
+    'contact' => 'Contact',
+    'events' => 'Events',
+    'forum' => 'Forum',
+    'guestbook' => 'Guestbook',
+    'jobs' => 'Jobs',
+    'teams' => 'Teams',
+    'user' => 'User',
+    'menuConvert' => 'BBCode conversion',
+    'menuOverview' => 'Overview',
+    'menuNote' => 'About',
+    'noteDescription' => 'Module to convert BBCode to HTML for explicitly supported modules and layouts.<br>The BBCode only gets converted if the resulting HTML code still fits the column of the table in the database. Otherwhise this would lead to data loss or errors.',
+    'module' => 'Module',
+    'layout' => 'Layouts',
+    'supportedVersions' => 'Supported versions',
+    'converted' => 'converted',
+    'notConverted' => 'not converted',
+    'filterModules' => 'Filter modules',
+    'progress' => 'Progress',
+    'warningMaintenanceMode' => 'It is recommended to set the site to maintenance mode before converting content.',
+    'warningBackup' => 'It is strongly recommended to create a backup before converting content. Last backup created on: %s',
+    'noBackup' => 'No backup found!',
+    'infoMessage' => 'The following supported modules and layouts where found an can be converted by selecting them and starting the conversion:',
+    'convert' => 'convert',
+    'confirmConvert' => 'Do you want to start the convertion for the selected modules and layouts?',
+    'redirectAfterPause' => 'The page will redirect after a delay of 3 seconds to continue the work.',
+    'workDone' => 'Conversion done.',
+    'moduleNoLongerSupported' => 'This module is no longer supported. A conversion is not supported with this version of Ilch. There might be a newer version of this module.',
+    'cancelled' => 'cancelled',
+];

--- a/application/modules/bbcodeconvert/views/admin/index/convert.php
+++ b/application/modules/bbcodeconvert/views/admin/index/convert.php
@@ -1,0 +1,58 @@
+<h1><?=$this->getTrans('menuConvert') ?></h1>
+
+<div class="table-responsive">
+    <table id="sortTable" class="table table-hover table-striped">
+        <colgroup>
+            <col>
+            <col>
+        </colgroup>
+        <thead>
+        <tr>
+            <th class="sort"><?=$this->getTrans('module') ?>/<?=$this->getTrans('layout') ?></th>
+            <th><?=$this->getTrans('progress') ?></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($_SESSION['bbcodeconvert_toConvert'] as $moduleOrLayout) : ?>
+            <tr class="filter">
+                <td><?=$this->getTrans($moduleOrLayout['key']) ?></td>
+                <td>
+                    <div class="progress">
+                        <div class="progress-bar" role="progressbar" style="width: <?=($moduleOrLayout['progress']/$moduleOrLayout['count']) * 100 ?>%" aria-valuenow="<?=$moduleOrLayout['progress'] ?>" aria-valuemin="0" aria-valuemax="<?=$moduleOrLayout['count'] ?>"></div>
+                    </div>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+
+<p id="result"><?=($this->get('workDone')) ? $this->getTrans('workDone') : '' ?></p>
+<?php if (!$this->get('workDone')) : ?>
+    <button id="cancelConversion" class="btn btn-default" onclick="cancel(this)"><?=$this->getTrans('cancel') ?></button>
+<?php endif; ?>
+
+<script>
+    let interval;
+
+    function redirect () {
+        interval = setInterval(myURL, 3000);
+        let result = document.getElementById("result");
+        result.innerHTML = "<?=$this->getTrans('redirectAfterPause') ?>";
+    }
+
+    function myURL() {
+        document.location.href = '<?=$this->getUrl(['action' => 'convert'], null, true) ?>';
+        clearInterval(interval);
+    }
+
+    if (<?=($this->get('redirectAfterPause')) ?? 0 ?>) {
+        redirect();
+    }
+
+    function cancel(event) {
+        clearInterval(interval);
+        result.innerHTML = "<?=$this->getTrans('cancelled') ?>";
+        event.remove();
+    }
+</script>

--- a/application/modules/bbcodeconvert/views/admin/index/index.php
+++ b/application/modules/bbcodeconvert/views/admin/index/index.php
@@ -1,0 +1,148 @@
+<link href="<?=$this->getModuleUrl('static/css/bbcodeconvert_styles.css') ?>" rel="stylesheet">
+
+<h1><?=$this->getTrans('menuOverview') ?>
+    <div class="input-group input-group-sm filter">
+        <span class="input-group-addon">
+            <i class="fa-solid fa-filter"></i>
+        </span>
+        <input type="text" id="filterInput" class="form-control" placeholder="<?=$this->getTrans('filterModules') ?>">
+        <span class="input-group-addon">
+            <span id="filterClear" class="fa-solid fa-xmark"></span>
+        </span>
+    </div>
+</h1>
+
+<?php if (!$this->get('getHtmlFromBBCodeExists')) : ?>
+    <div class="alert alert-danger">
+        <strong><?=$this->getTrans('moduleNoLongerSupported') ?></strong>
+    </div>
+<?php endif; ?>
+
+<?php if (!$this->get('maintenanceModeEnabled')) : ?>
+    <div class="alert alert-danger">
+        <strong><?=$this->getTrans('warningMaintenanceMode') ?></strong>
+    </div>
+<?php endif; ?>
+
+<div class="alert alert-danger">
+    <strong><?=$this->getTrans('warningBackup', ($this->get('lastBackup')) ? $this->get('lastBackup')->getDate() : $this->getTrans('noBackup')) ?></strong>
+</div>
+
+<p><strong><?=$this->getTrans('infoMessage') ?></strong></p>
+
+<form class="form-horizontal" method="POST" action="">
+    <?=$this->getTokenField() ?>
+    <div class="table-responsive">
+        <table id="sortTable" class="table table-hover table-striped">
+            <colgroup>
+                <col class="icon_width">
+                <col>
+                <col>
+                <col>
+            </colgroup>
+            <thead>
+            <tr>
+                <th><?=$this->getCheckAllCheckbox('check_modules') ?></th>
+                <th class="sort"><?= $this->getTrans('module') ?></th>
+                <th><?=$this->getTrans('version') ?></th>
+                <th class="sort"><?= $this->getTrans('converted') ?></th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($this->get('installedSupportedModules') as $module) : ?>
+                <tr class="filter">
+                    <td><?=$this->getDeleteCheckbox('check_modules', $module->getKey()) ?></td>
+                    <td><?=$this->getTrans($module->getKey()) ?></td>
+                    <td><?=$module->getVersion() ?></td>
+                    <td><?=(key_exists($module->getKey(), $this->get('converted'))) ? $this->getTrans('converted') : $this->getTrans('notConverted') ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="table-responsive">
+        <table id="sortTable" class="table table-hover table-striped">
+            <colgroup>
+                <col class="icon_width">
+                <col>
+                <col>
+                <col>
+            </colgroup>
+            <thead>
+            <tr>
+                <th><?=$this->getCheckAllCheckbox('check_layouts') ?></th>
+                <th class="sort"><?= $this->getTrans('layout') ?></th>
+                <th><?=$this->getTrans('version') ?></th>
+                <th class="sort"><?= $this->getTrans('converted') ?></th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($this->get('installedSupportedLayouts') as $layout) : ?>
+                <tr class="filter">
+                    <td><?=$this->getDeleteCheckbox('check_layouts', $layout->getKey()) ?></td>
+                    <td><?=$this->getTrans($layout->getKey()) ?></td>
+                    <td><?=$layout->getVersion() ?></td>
+                    <td><?=(key_exists($layout->getKey(), $this->get('converted'))) ? $this->getTrans('converted') : $this->getTrans('notConverted') ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="content_savebox">
+        <input type="hidden" class="content_savebox_hidden" name="action" value="convert" />
+        <div class="btn-group dropup">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"<?=($this->get('getHtmlFromBBCodeExists')) ? '' : ' disabled' ?>>
+                <?=$this->getTrans('selected') ?> <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu listConvert" role="menu">
+                <li><a href="#" data-hiddenkey="convert" id="convert"><?=$this->getTrans('convert') ?></a></li>
+            </ul>
+        </div>
+    </div>
+</form>
+
+<script>
+    $("table").on("click", "th.sort", function () {
+        const index = $(this).index(),
+            rows = [],
+            thClass = $(this).hasClass("asc") ? "desc" : "asc";
+        $(this).removeClass("asc desc");
+        $(this).addClass(thClass);
+        $(this).closest('.table').find('tbody tr').each(function (index, row) {
+            rows.push($(row).detach());
+        });
+        rows.sort(function (a, b) {
+            const aValue = $(a).find("td").eq(index).text(),
+                bValue = $(b).find("td").eq(index).text();
+            return aValue > bValue ? 1 : (aValue < bValue ? -1 : 0);
+        });
+        if ($(this).hasClass("desc")) {
+            rows.reverse();
+        }
+        let tableBody = $(this).closest('.table').find('tbody');
+        $.each(rows, function (index, row) {
+            tableBody.append(row);
+        });
+    });
+
+    $("#filterInput").on("keyup", function() {
+        const value = $(this).val().toLowerCase();
+        $("#sortTable tr.filter").filter(function() {
+            $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+        });
+    });
+
+    $("#filterClear").click(function(){
+        $("#sortTable tr.filter").show(function() {
+            $("#filterInput").val('');
+        });
+    });
+
+    $('.listConvert a').click(function(){
+        if (confirm(<?=json_encode($this->getTrans('confirmConvert')) ?>)) {
+            $(this).closest('form').submit();
+        }
+    });
+</script>

--- a/application/modules/bbcodeconvert/views/admin/index/note.php
+++ b/application/modules/bbcodeconvert/views/admin/index/note.php
@@ -1,0 +1,99 @@
+<link href="<?=$this->getModuleUrl('static/css/bbcodeconvert_styles.css') ?>" rel="stylesheet">
+
+<h1><?=$this->getTrans('menuNote') ?>
+    <div class="input-group input-group-sm filter">
+        <span class="input-group-addon">
+            <i class="fa-solid fa-filter"></i>
+        </span>
+        <input type="text" id="filterInput" class="form-control" placeholder="<?=$this->getTrans('filterModules') ?>">
+        <span class="input-group-addon">
+            <span id="filterClear" class="fa-solid fa-xmark"></span>
+        </span>
+    </div>
+</h1>
+
+<p><?=$this->getTrans('noteDescription') ?></p>
+
+<div class="table-responsive">
+    <table id="sortTable" class="table table-hover table-striped">
+        <colgroup>
+            <col>
+            <col>
+        </colgroup>
+        <thead>
+        <tr>
+            <th class="sort"><?=$this->getTrans('module') ?></th>
+            <th><?=$this->getTrans('supportedVersions') ?></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($this->get('supportedModules') as $supportedModuleKey => $supportedModuleVersions) : ?>
+            <tr class="filter">
+                <td><?=$this->getTrans($supportedModuleKey) ?></td>
+                <td><?=implode(', ', $supportedModuleVersions) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+
+<div class="table-responsive">
+    <table id="sortTable" class="table table-hover table-striped">
+        <colgroup>
+            <col>
+            <col>
+        </colgroup>
+        <thead>
+        <tr>
+            <th class="sort"><?=$this->getTrans('layout') ?></th>
+            <th><?=$this->getTrans('supportedVersions') ?></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($this->get('supportedLayouts') as $supportedLayoutKey => $supportedLayoutVersions) : ?>
+            <tr class="filter">
+                <td><?=$this->getTrans($supportedLayoutKey) ?></td>
+                <td><?=implode(', ', $supportedLayoutVersions) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+
+<script>
+    $("table").on("click", "th.sort", function () {
+        const index = $(this).index(),
+            rows = [],
+            thClass = $(this).hasClass("asc") ? "desc" : "asc";
+        $(this).removeClass("asc desc");
+        $(this).addClass(thClass);
+        $(this).closest('.table').find('tbody tr').each(function (index, row) {
+            rows.push($(row).detach());
+        });
+        rows.sort(function (a, b) {
+            const aValue = $(a).find("td").eq(index).text(),
+                bValue = $(b).find("td").eq(index).text();
+            return aValue > bValue ? 1 : (aValue < bValue ? -1 : 0);
+        });
+        if ($(this).hasClass("desc")) {
+            rows.reverse();
+        }
+        let tableBody = $(this).closest('.table').find('tbody');
+        $.each(rows, function (index, row) {
+            tableBody.append(row);
+        });
+    });
+
+    $("#filterInput").on("keyup", function() {
+        const value = $(this).val().toLowerCase();
+        $("#sortTable tr.filter").filter(function() {
+            $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+        });
+    });
+
+    $("#filterClear").click(function(){
+        $("#sortTable tr.filter").show(function() {
+            $("#filterInput").val('');
+        });
+    });
+</script>


### PR DESCRIPTION
# Description
Add bbcodeconvert module. This module is used to convert items (guestbook messages, posts in the forum, ...) from BBCode to HTML. This is needed as in preparation for a move to CKEditor 5, which doesn't support BBCode, we migrate the modules and layouts to use the CKEditor 4 in HTML mode. This module should be supported for some time after the move to HTML mode and CKEditor 5 to allow everyone to convert the items. After that it can be removed from the repo.

- https://github.com/IlchCMS/Ilch-2.0/pull/701

ToDo:
- Add this module to the next ilch update. It should not be part of a new install of ilch.
- ~~Adjust version numbers of supported ilch versions and module/layout versions.~~

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [X] Edge
