### PR TITLE
Reduce db queries caused by the config

### DIFF
--- a/application/libraries/Ilch/Config/Database.php
+++ b/application/libraries/Ilch/Config/Database.php
@@ -31,8 +31,8 @@ class Database
     /**
      * Gets the config for given key.
      *
-     * @param  string     $key
-     * @param  boolean    $alwaysLoad
+     * @param string $key
+     * @param bool $alwaysLoad
      * @return mixed|null
      */
     public function get(string $key, bool $alwaysLoad = false)
@@ -60,9 +60,9 @@ class Database
     /**
      * Sets the config for given key/vale.
      *
-     * @param string         $key
-     * @param string|integer $value
-     * @param integer        $autoload
+     * @param string $key
+     * @param string|int $value
+     * @param int $autoload
      *
      * @return $this
      */
@@ -118,9 +118,9 @@ class Database
     /**
      * delete the config for given key.
      *
-     * @param   string|array    $keys
-     * @return  $this
-     * @since   2.1.43
+     * @param string|array $keys
+     * @return $this
+     * @since 2.1.43
      */
     public function delete($keys)
     {
@@ -138,9 +138,9 @@ class Database
     /**
      * delete the config for given key.
      *
-     * @param   string  $key
-     * @return  boolean
-     * @since   2.1.43
+     * @param string $key
+     * @return bool
+     * @since 2.1.43
      */
     protected function deleteKey(string $key)
     {

--- a/application/libraries/Ilch/Config/File.php
+++ b/application/libraries/Ilch/Config/File.php
@@ -28,7 +28,7 @@ class File
      * Sets the config for given key/vale.
      *
      * @param string         $key
-     * @param string|integer $value
+     * @param string|int $value
      */
     public function set($key, $value)
     {

--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -55,6 +55,8 @@ class Config extends \Ilch\Config\Install
             ->set('maintenance_status', '0')
             ->set('maintenance_date', $date->format('Y-m-d H:i:s'))
             ->set('maintenance_text', '<p>Die Seite befindet sich im Wartungsmodus</p>')
+            ->set('mod_rewrite', '0')
+            ->set('multilingual_acp', '0')
             ->set('custom_css', '')
             ->set('emailBlacklist', '')
             ->set('disable_purifier', '0');
@@ -892,6 +894,13 @@ class Config extends \Ilch\Config\Install
                 // Remove jquery.bxslider. The only known usage is the partner module. With the last version of that module bxslider got
                 // integrated into the module.
                 removeDir(ROOT_PATH . '/static/js/jquery.bxslider');
+                break;
+            case "2.1.51":
+                // Set a default value if it hasn't a value for 'mod_rewrite' and 'multilingual_acp' as it is causing a lot of database queries if not set and therefore not gets cached.
+                // Example: Reduction of db queries from 218 to 124 ('multilingual_acp' set) and further down to 115 ('mod_rewrite' set) for the forum module index action in this dev environment.
+                $databaseConfig = new \Ilch\Config\Database($this->db());
+                $databaseConfig->get('mod_rewrite') ?? $databaseConfig->set('mod_rewrite', '0');
+                $databaseConfig->get('multilingual_acp') ?? $databaseConfig->set('multilingual_acp', '0');
                 break;
         }
 


### PR DESCRIPTION
# Description
Reduce db queries caused by the config.
Set a default value if it hasn't a value for 'mod_rewrite' and 'multilingual_acp' as it is causing a lot of database queries if not set and therefore not gets cached.

Example: Reduction of db queries from 218 to 124 ('multilingual_acp' set) and further down to 115 ('mod_rewrite' set) for the forum module index action in this dev environment.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
