### PR TITLE
Remove jquery.nicescroll.js

### DIFF
--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -622,10 +622,15 @@ class Config extends \Ilch\Config\Install
                 $this->db()->query("UPDATE `[prefix]_profile_fields` SET `icon` = 'fa-brands fa-discord' WHERE `icon` = 'fa-solid fa-headphones' AND `key` = 'discord';");
 
                 $this->db()->query("UPDATE `[prefix]_modules` SET `icon_small` = 'fa-solid fa-user' WHERE `key` = 'user';");
+                break;
             case "2.1.49":
                 $databaseConfig = new \Ilch\Config\Database($this->db());
                 $databaseConfig->set('userAvatarList_allowed', '0');
                 $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `options` TEXT NOT NULL DEFAULT \'\' AFTER `addition`;');
+                break;
+            case "2.1.51":
+                unlink(ROOT_PATH . '/application/modules/user/static/js/jquery.nicescroll.js');
+                break;
         }
     }
 }


### PR DESCRIPTION
# Description
Remove jquery.nicescroll.js. Got replaced by a newer and minified version.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
