### PR TITLE
bbcodeconvert: fix wrong version number

### DIFF
--- a/application/modules/bbcodeconvert/controllers/admin/Index.php
+++ b/application/modules/bbcodeconvert/controllers/admin/Index.php
@@ -17,13 +17,13 @@ use Modules\Admin\Mappers\LayoutAdvSettings;
 class Index extends Admin
 {
     private const supportedModules = [
-        'contact' => ['2.1.51'],
+        'contact' => ['2.1.52'],
         'events' => ['1.22.0'],
         'forum' => ['1.33.0'],
         'guestbook' => ['1.13.0'],
         'jobs' => ['1.6.0'],
         'teams' => ['1.23.0'],
-        'user' => ['2.1.51']
+        'user' => ['2.1.52']
     ];
 
     private const supportedLayouts = [


### PR DESCRIPTION
# Description
bbcodeconvert: fix wrong version number

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
