### PR TITLE
bbcodeconvert: Fix wrong type for "contact_welcomeMessage"

### DIFF
--- a/application/modules/bbcodeconvert/controllers/admin/Index.php
+++ b/application/modules/bbcodeconvert/controllers/admin/Index.php
@@ -240,10 +240,11 @@ class Index extends Admin
     {
         switch ($key) {
             case 'contact':
-                // table: config, column: value, datatype: VARCHAR(191)
+                // table: config, column: value, datatype: TEXT
                 $convertedText = $this->getView()->getHtmlFromBBCode($this->getConfig()->get('contact_welcomeMessage'));
 
-                if (strlen($convertedText) <= 191) {
+                // L + 2 bytes, where L < 2^16
+                if (strlen($convertedText) <= ((65535 / 5) - 2)) {
                     $this->getConfig()->set('contact_welcomeMessage', $convertedText);
                 }
                 return ['completed' => true, 'index' => 0, 'progress' => 1];


### PR DESCRIPTION
# Description
Fix wrong type for "contact_welcomeMessage". The value column of the config table is of type TEXT.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
