### PR TITLE
Kleine Spielerei...checkt mal ob man das so machen kann?

### DIFF
--- a/application/layouts/clan3columns/index.php
+++ b/application/layouts/clan3columns/index.php
@@ -3,10 +3,9 @@
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
         <?=$this->getHeader() ?>
-        <link href="<?=$this->getVendorUrl('twbs/bootstrap/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
+        <?=$this->getBootstrap() ?>
         <link href="<?=$this->getLayoutUrl('style.css') ?>" rel="stylesheet">
         <?=$this->getCustomCSS() ?>
-        <script src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
     </head>
     <body>
         <header>

--- a/application/layouts/clan3columns/index_full.php
+++ b/application/layouts/clan3columns/index_full.php
@@ -3,10 +3,10 @@
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
         <?=$this->getHeader() ?>
-        <link href="<?=$this->getVendorUrl('twbs/bootstrap/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
+        <link href="<?=$this->getVendorUrl('twbs/bootstrap3/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getLayoutUrl('style.css') ?>" rel="stylesheet">
         <?=$this->getCustomCSS() ?>
-        <script src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
+        <script src="<?=$this->getVendorUrl('twbs/bootstrap3/dist/js/bootstrap.min.js') ?>"></script>
     </head>
     <body>
         <header>

--- a/application/libraries/Ilch/Layout/Frontend.php
+++ b/application/libraries/Ilch/Layout/Frontend.php
@@ -596,6 +596,17 @@ class Frontend extends Base
         return $html;
     }
 
+    public function getBootstrap()
+    {
+        if ($this->getConfigKey('bootstrapVersion') == '3') {
+            return '<link rel="stylesheet" type="text/css" href="' . $this->getVendorUrl('twbs/bootstrap3/dist/css/bootstrap.css') . '"></style>
+                    <script src="' . $this->getVendorUrl('twbs/bootstrap3/dist/js/bootstrap.js') . '"></script>';
+        }return '<link rel="stylesheet" type="text/css" href="' . $this->getVendorUrl('twbs/bootstrap5/dist/css/bootstrap.css') . '"></style>
+                 <script src="' . $this->getVendorUrl('twbs/bootstrap5/dist/js/bootstrap.bundle.js') . '"></script>';
+
+    }
+
+
     /**
      * Gets the custom css.
      *

--- a/application/modules/admin/layouts/iframe.php
+++ b/application/modules/admin/layouts/iframe.php
@@ -12,7 +12,7 @@
         <link rel="shortcut icon" type="image/x-icon" href="<?=$this->getStaticUrl('img/favicon.ico') ?>">
 
         <!-- STYLES -->
-        <link href="<?=$this->getVendorUrl('twbs/bootstrap/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
+        <link href="<?=$this->getVendorUrl('twbs/bootstrap3/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/all.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/v4-shims.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getStaticUrl('css/ilch.css') ?>" rel="stylesheet">
@@ -26,7 +26,7 @@
         <script src="<?=$this->getVendorUrl('npm-asset/jquery/dist/jquery.min.js') ?>"></script>
         <script src="<?=$this->getVendorUrl('npm-asset/jquery-ui/dist/jquery-ui.min.js') ?>"></script>
         <script src="<?=$this->getStaticUrl('js/jquery.mjs.nestedSortable.js') ?>"></script>
-        <script src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
+        <script src="<?=$this->getVendorUrl('twbs/bootstrap3/dist/js/bootstrap.min.js') ?>"></script>
         <script src="<?=$this->getVendorUrl('harvesthq/chosen/chosen.jquery.min.js') ?>"></script>
         <script src="<?=$this->getStaticUrl('js/validate/jquery.validate.min.js') ?>"></script>
         <script src="<?=$this->getStaticUrl('js/validate/additional-methods.min.js') ?>"></script>

--- a/application/modules/admin/layouts/index.php
+++ b/application/modules/admin/layouts/index.php
@@ -21,7 +21,7 @@ $accesses = $this->get('accesses');
     <link rel="shortcut icon" type="image/x-icon" href="<?=$this->getStaticUrl('img/favicon.ico') ?>">
 
     <!-- STYLES -->
-    <link href="<?=$this->getVendorUrl('twbs/bootstrap/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
+    <link href="<?=$this->getVendorUrl('twbs/bootstrap3/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
     <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/all.min.css') ?>" rel="stylesheet">
     <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/v4-shims.min.css') ?>" rel="stylesheet">
     <link href="<?=$this->getStaticUrl('css/ilch.css') ?>" rel="stylesheet">
@@ -43,7 +43,7 @@ $accesses = $this->get('accesses');
     <script src="<?=$this->getVendorUrl('npm-asset/jquery/dist/jquery.min.js') ?>"></script>
     <script src="<?=$this->getVendorUrl('npm-asset/jquery-ui/dist/jquery-ui.min.js') ?>"></script>
     <script src="<?=$this->getStaticUrl('js/jquery.mjs.nestedSortable.js') ?>"></script>
-    <script src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
+    <script src="<?=$this->getVendorUrl('twbs/bootstrap3/dist/js/bootstrap.min.js') ?>"></script>
     <script src="<?=$this->getStaticUrl('../application/modules/admin/static/js/functions.js') ?>"></script>
     <script src="<?=$this->getVendorUrl('harvesthq/chosen/chosen.jquery.min.js') ?>"></script>
     <script src="<?=$this->getStaticUrl('js/tokenfield/bootstrap-tokenfield.min.js') ?>"></script>

--- a/application/modules/admin/layouts/login.php
+++ b/application/modules/admin/layouts/login.php
@@ -18,7 +18,7 @@ $languages = (!empty($this->get('languages'))) ? $this->get('languages') : [];
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
         <link rel="shortcut icon" type="image/x-icon" href="<?=$this->getStaticUrl('img/favicon.ico') ?>">
-        <link href="<?=$this->getVendorUrl('twbs/bootstrap/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
+        <link href="<?=$this->getVendorUrl('twbs/bootstrap3/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/all.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/v4-shims.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getStaticUrl('css/ilch.css') ?>" rel="stylesheet">

--- a/application/modules/admin/layouts/maintenance.php
+++ b/application/modules/admin/layouts/maintenance.php
@@ -19,7 +19,7 @@ $date = new \Ilch\Date();
         <link rel="shortcut icon" type="image/x-icon" href="<?=$this->getStaticUrl('img/favicon.ico') ?>">
 
         <!-- STYLES -->
-        <link href="<?=$this->getVendorUrl('twbs/bootstrap/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
+        <link href="<?=$this->getVendorUrl('twbs/bootstrap3/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/all.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/v4-shims.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getStaticUrl('css/ilch.css') ?>" rel="stylesheet">
@@ -29,7 +29,7 @@ $date = new \Ilch\Date();
         <!-- SCRIPTS -->
         <script src="<?=$this->getVendorUrl('npm-asset/jquery/dist/jquery.min.js') ?>"></script>
         <script src="<?=$this->getVendorUrl('npm-asset/jquery-ui/dist/jquery-ui.min.js') ?>"></script>
-        <script src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
+        <script src="<?=$this->getVendorUrl('twbs/bootstrap3/dist/js/bootstrap.min.js') ?>"></script>
         <script src="<?=$this->getStaticUrl('js/countdown/jquery.countdown.min.js') ?>"></script>
     </head>
     <body>

--- a/application/modules/admin/views/admin/settings/bootstrap.php
+++ b/application/modules/admin/views/admin/settings/bootstrap.php
@@ -1,0 +1,22 @@
+<h1><?=$this->getTrans('bootstrap') ?></h1>
+<p><?=$this->getTrans('bootstrapText') ?></p>
+<h4 style="color: red">Bedenken Sie, dass die Version 5.x noch nicht zu 100% auf das Ilch CMS abgestimmt ist.</h4>
+
+<form class="form-horizontal" method="POST">
+    <?=$this->getTokenField() ?>
+<div id="bootstrapVersion" class="form-group">
+    <div class="col-lg-2 control-label">
+        <?=$this->getTrans('bootstrapVersion') ?>:
+    </div>
+    <div class="col-lg-4">
+            <select class="form-control" name="bootstrapVersion" id="bootstrapVersion">
+                <option <?php if ($this->get('bootstrapVersion') == '3') { echo 'selected="selected"'; } ?> value="3"><?=$this->getTrans('bootstrap3') ?></option>
+                <option <?php if ($this->get('bootstrapVersion') == '5') { echo 'selected="selected"'; } ?> value="5"><?=$this->getTrans('bootstrap5') ?></option>
+
+            </select>
+    </div>
+</div>
+
+<?=$this->getSaveBar() ?>
+</form>
+

--- a/application/modules/install/layouts/index.php
+++ b/application/modules/install/layouts/index.php
@@ -9,7 +9,7 @@
         <title>Ilch <?=VERSION ?> - Installation</title>
         <meta name="description" content="Ilch <?=VERSION ?> - Installation">
         <link rel="shortcut icon" type="image/x-icon" href="<?=$this->getStaticUrl('img/favicon.ico') ?>">
-        <link href="<?=$this->getVendorUrl('twbs/bootstrap/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
+        <link href="<?=$this->getVendorUrl('twbs/bootstrap3/dist/css/bootstrap.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/all.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getVendorUrl('fortawesome/font-awesome/css/v4-shims.min.css') ?>" rel="stylesheet">
         <link href="<?=$this->getStaticUrl('css/ilch.css') ?>" rel="stylesheet">
@@ -17,7 +17,7 @@
         <link href="<?=$this->getVendorUrl('npm-asset/jquery-ui/dist/themes/ui-lightness/jquery-ui.min.css') ?>" rel="stylesheet">
         <script src="<?=$this->getVendorUrl('npm-asset/jquery/dist/jquery.min.js') ?>"></script>
         <script src="<?=$this->getVendorUrl('npm-asset/jquery-ui/dist/jquery-ui.min.js') ?>"></script>
-        <script src="<?=$this->getVendorUrl('twbs/bootstrap/dist/js/bootstrap.min.js') ?>"></script>
+        <script src="<?=$this->getVendorUrl('twbs/bootstrap3/dist/js/bootstrap.min.js') ?>"></script>
     </head>
     <body>
         <div class="container">

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "jbbcode/jbbcode": "^1.4",
         "ifsnop/mysqldump-php": "2.*",
         "kartik-v/bootstrap-star-rating": "^4.0",
-        "twbs/bootstrap": "^3.4",
+        "twbs/bootstrap3": "3.4.1",
+        "twbs/bootstrap5": "5.3.0",
         "fortawesome/font-awesome": "^6.2.1",
         "npm-asset/jquery": "^3.5",
         "npm-asset/jquery-ui": "^1.13",
@@ -30,7 +31,7 @@
         "symfony/yaml": "^3.3.6"
     },
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "": "application/libraries/"
         },
         "files": [
@@ -46,6 +47,28 @@
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "twbs/bootstrap3",
+                "version": "3.4.1",
+                "dist": {
+                    "url": "https://github.com/twbs/bootstrap/archive/v3.4.1.zip",
+                    "type": "zip"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "twbs/bootstrap5",
+                "version": "5.3.0",
+                "dist": {
+                    "url": "https://github.com/twbs/bootstrap/archive/v5.3.0.zip",
+                    "type": "zip"
+                }
+            }
         }
     ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33231b1d580656bf1ac9eddcea65ae88",
+    "content-hash": "a8001487a27961ffca72473f6ad1d1dd",
     "packages": [
         {
             "name": "blueimp/jquery-file-upload",
@@ -550,59 +550,22 @@
             "time": "2023-03-06T14:43:22+00:00"
         },
         {
-            "name": "twbs/bootstrap",
-            "version": "v3.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/twbs/bootstrap.git",
-                "reference": "68b0d231a13201eb14acd3dc84e51543d16e5f7e"
-            },
+            "name": "twbs/bootstrap3",
+            "version": "3.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twbs/bootstrap/zipball/68b0d231a13201eb14acd3dc84e51543d16e5f7e",
-                "reference": "68b0d231a13201eb14acd3dc84e51543d16e5f7e",
-                "shasum": ""
+                "url": "https://github.com/twbs/bootstrap/archive/v3.4.1.zip"
             },
-            "replace": {
-                "twitter/bootstrap": "self.version"
+            "type": "library"
+        },
+        {
+            "name": "twbs/bootstrap5",
+            "version": "5.3.0",
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/twbs/bootstrap/archive/v5.3.0.zip"
             },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jacob Thornton",
-                    "email": "jacobthornton@gmail.com"
-                },
-                {
-                    "name": "Mark Otto",
-                    "email": "markdotto@gmail.com"
-                }
-            ],
-            "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
-            "homepage": "https://getbootstrap.com/",
-            "keywords": [
-                "JS",
-                "css",
-                "framework",
-                "front-end",
-                "less",
-                "mobile-first",
-                "responsive",
-                "web"
-            ],
-            "support": {
-                "issues": "https://github.com/twbs/bootstrap/issues",
-                "source": "https://github.com/twbs/bootstrap/tree/v3.4.1"
-            },
-            "time": "2019-02-13T15:55:38+00:00"
+            "type": "library"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Habe die composer.json und .lock geändert, sodass Bootstrap beim "composer install" jeweils in Version 3.4.1 und 5.3.0 installiert wird. Jeweils als eigenes Paket.
twbs/bootstrap3
twbs/bootstrap5

psr-0 auf psr-4 geändert....habe gelesen soll besser sein. Warum? Keine Ahnung, CMS läuft trotzdem so weiter... :)

Mittels replace hab ich alle manuellen Aufrufe von Bootstrap auf Bootstrap3 geändert, sodass vorerst alles beim alten bleibt.

Im Adminbereich kann man dann unter Einstellungen, seine Version wählen.

In der Frontend.php habe ich ne neue Funktion getBootstrap() hinzugefügt. Diese lädt dann entsprechend die css und js Dateien der jeweiligen Version.

Testweise habe ich im Standard-Layout die manuellen Aufrufe von Bootstrap .css und .js durch die getBootstrap() ersetzt.

Der Wechsel der Versionen funktioniert....

Natürlich sieht alles mit Bootstrap 5.3.0 kacke aus....soll ja auch nur ein Anfang sein....



