### PR TITLE
Gallery: Fix errors in Settings.php

### DIFF
--- a/application/modules/gallery/controllers/admin/Settings.php
+++ b/application/modules/gallery/controllers/admin/Settings.php
@@ -52,7 +52,7 @@ class Settings extends \Ilch\Controller\Admin
 
             if ($validation->isValid()) {
                 $this->getConfig()->set('gallery_picturesPerPage', $this->getRequest()->getPost('picturesPerPage'));
-                $pictureOfXSource = is_array($data = $this->getRequest()->getPost('pictureOfXSource')) ? implode(",", $data) : '';
+                $pictureOfXSource = is_array($this->getRequest()->getPost('pictureOfXSource')) ? implode(",", $this->getRequest()->getPost('pictureOfXSource')) : '';
                 $this->getConfig()->set('gallery_pictureOfXSource', (empty($pictureOfXSource)) ? '' : $pictureOfXSource);
                 $this->getConfig()->set('gallery_pictureOfXInterval', $this->getRequest()->getPost('pictureOfXInterval'));
                 $this->getConfig()->set('gallery_pictureOfXRandom', $this->getRequest()->getPost('pictureOfXRandom'));
@@ -67,7 +67,7 @@ class Settings extends \Ilch\Controller\Admin
         }
 
         $this->getView()->set('picturesPerPage', $this->getConfig()->get('gallery_picturesPerPage'));
-        $this->getView()->set('pictureOfXSource', explode(',', $this->getConfig()->get('gallery_pictureOfXSource')));
+        $this->getView()->set('pictureOfXSource', explode(',', $this->getConfig()->get('gallery_pictureOfXSource') ?? ''));
         $this->getView()->set('pictureOfXInterval', $this->getConfig()->get('gallery_pictureOfXInterval'));
         $this->getView()->set('pictureOfXRandom', $this->getConfig()->get('gallery_pictureOfXRandom'));
         $this->getView()->set('galleries', $galleryMapper->getGalleryCatItem(1));

--- a/application/modules/gallery/controllers/admin/Settings.php
+++ b/application/modules/gallery/controllers/admin/Settings.php
@@ -52,7 +52,7 @@ class Settings extends \Ilch\Controller\Admin
 
             if ($validation->isValid()) {
                 $this->getConfig()->set('gallery_picturesPerPage', $this->getRequest()->getPost('picturesPerPage'));
-                $pictureOfXSource = implode(',', $this->getRequest()->getPost('pictureOfXSource'));
+                $pictureOfXSource = is_array($data = $this->getRequest()->getPost('pictureOfXSource')) ? implode(",", $data) : '';
                 $this->getConfig()->set('gallery_pictureOfXSource', (empty($pictureOfXSource)) ? '' : $pictureOfXSource);
                 $this->getConfig()->set('gallery_pictureOfXInterval', $this->getRequest()->getPost('pictureOfXInterval'));
                 $this->getConfig()->set('gallery_pictureOfXRandom', $this->getRequest()->getPost('pictureOfXRandom'));


### PR DESCRIPTION
# Description
- Fix "implode(): Argument must be of type array, string given"
- Fix "explode(): Passing null to parameter of type string is deprecated"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
