### PR TITLE
Shop module: Fix error on empty shop

### DIFF
--- a/application/modules/shop/config/config.php
+++ b/application/modules/shop/config/config.php
@@ -14,7 +14,7 @@ class Config extends Install
 {
     public $config = [
         'key' => 'shop',
-        'version' => '1.1.0',
+        'version' => '1.1.1',
         'icon_small' => 'fa-solid fa-cart-shopping',
         'author' => 'blackcoder & LordSchirmer',
         'link' => 'https://ilch.de',

--- a/application/modules/shop/mappers/Items.php
+++ b/application/modules/shop/mappers/Items.php
@@ -83,20 +83,17 @@ class Items extends Mapper
      */
     public function getCountOfItemsPerCategory(array $catIds = [], int $status = 1): array
     {
+        if (empty($catIds)){
+            return [];
+        }
         $itemsArray = $this->db()->select(['cat_id', 'count' => 'COUNT(id)'])
             ->from('shop_items')
             ->where(['cat_id' => $catIds, 'status' => $status])
             ->group(['cat_id'])
             ->execute()
             ->fetchRows();
-
-        $itemCounts = [];
-
-        foreach ($itemsArray as $item) {
-            $itemCounts[$item['cat_id']] = $item['count'];
-        }
-
-        return $itemCounts;
+        
+        return array_column($itemsArray, 'count', 'cat_id');
     }
 
     /**


### PR DESCRIPTION
Fehler: An unexpected error occurred:
You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ') AND `status` = "1") GROUP BY `cat_id`' at line 1

Dieser trat auf, wenn der Shop ohne Kategorie und Produkte im Frontend aufgerufen wurde.

