### PR TITLE
Statistic: reduce db queries

### DIFF
--- a/application/modules/statistic/boxes/Online.php
+++ b/application/modules/statistic/boxes/Online.php
@@ -15,7 +15,9 @@ class Online extends \Ilch\Box
     {
         $statisticMapper = new StatisticMapper();
 
-        $this->getView()->set('usersOnline', $statisticMapper->getVisitsOnlineUser());
-        $this->getView()->set('guestOnline', $statisticMapper->getVisitsCountOnline() - count($statisticMapper->getVisitsOnlineUser()));
+        $usersOnline = $statisticMapper->getVisitsOnlineUser();
+
+        $this->getView()->set('usersOnline', $usersOnline);
+        $this->getView()->set('guestOnline', $statisticMapper->getVisitsCountOnline() - count($usersOnline));
     }
 }

--- a/application/modules/statistic/mappers/Statistic.php
+++ b/application/modules/statistic/mappers/Statistic.php
@@ -10,13 +10,16 @@ namespace Modules\Statistic\Mappers;
 use Modules\Statistic\Models\Statistic as StatisticModel;
 use Modules\User\Mappers\User as UserMapper;
 use Modules\Article\Mappers\Article as ArticleMapper;
+use Modules\User\Models\User;
+use Ilch\Database\Exception;
 
 class Statistic extends \Ilch\Mapper
 {
     /**
      * Returns all online users.
      *
-     * @return \Modules\User\Models\User[]
+     * @return array []|User[]
+     * @throws Exception
      */
     public function getVisitsOnlineUser(): array
     {
@@ -24,15 +27,14 @@ class Statistic extends \Ilch\Mapper
         $date = new \Ilch\Date();
         $date->modify('-5 minutes');
 
-        $select = $this->db()->select(['*'])
+        $select = $this->db()->select(['date_last_activity', 'user_id'])
             ->from('visits_online')
             ->where(['date_last_activity >' => $date->format('Y-m-d H:i:s', true), 'user_id >' => 0]);
-
         $rows = $select->execute()->fetchRows();
 
         $users = [];
         foreach ($rows as $row) {
-            if ($userMapper->getUserById($row['user_id'])) {
+            if ($row['user_id']) {
                 $users[] = $userMapper->getUserById($row['user_id']);
             }
         }
@@ -75,7 +77,7 @@ class Statistic extends \Ilch\Mapper
     /**
      * Returns all users who were online.
      *
-     * @return \Modules\User\Models\User[]
+     * @return User[]
      * @since 2.1.20
      */
     public function getWhoWasOnline(): array


### PR DESCRIPTION
# Description
- Reduce db queries of getVisitsOnlineUser
- Remove second call of getVisitsOnlineUser in the "Online" box.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
