### PR TITLE
article: fix wrong url in keywords box

### DIFF
--- a/application/modules/article/boxes/views/keywords.php
+++ b/application/modules/article/boxes/views/keywords.php
@@ -14,7 +14,7 @@
         } elseif ($count == 2) {
             echo '<span style="font-size:'.$this->get('keywordsH2').'px"><a href="'.$this->getUrl(['controller' => 'keywords', 'action' => 'show', 'keyword' => $keyword]).'">'.$keyword.'</a></span> ';
         } else {
-            echo '<a href="'.$this->getUrl(['controller' => 'keywords', 'action' => 'show', 'keyword' => $keyword]).'">'.$keyword.'</a> ';
+            echo '<a href="'.$this->getUrl(['module' => 'article', 'controller' => 'keywords', 'action' => 'show', 'keyword' => $keyword]).'">'.$keyword.'</a> ';
         }
     }
     ?>


### PR DESCRIPTION
# Description
- fix wrong url in keywords box

When opening a page of another module. The URLs for the article keywords box used that module key instead of "article".

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
