### PR TITLE
Shop: Fix errors when the shopping cart is empty

### DIFF
--- a/application/modules/shop/config/config.php
+++ b/application/modules/shop/config/config.php
@@ -14,7 +14,7 @@ class Config extends Install
 {
     public $config = [
         'key' => 'shop',
-        'version' => '1.1.1',
+        'version' => '1.1.2',
         'icon_small' => 'fa-solid fa-cart-shopping',
         'author' => 'blackcoder & LordSchirmer',
         'link' => 'https://ilch.de',

--- a/application/modules/shop/views/index/cart.php
+++ b/application/modules/shop/views/index/cart.php
@@ -212,6 +212,8 @@ if (!empty($_SESSION['shopping_cart'])) {
     </a>
     <?php } ?>
 </div>
+
+<?php if (isset($_SESSION['shopping_cart'])) : ?>
 <script>
 let willCollect = $('#willCollect');
 
@@ -281,3 +283,4 @@ $('.plus-btn').on('click', function(e) {
     $('#reload').css('display','inline-block');
 });
 </script>
+<?php endif; ?>


### PR DESCRIPTION
# Description
- Fix errors when the shopping cart is empty
- Update version number to 1.1.2

> Undefined variable: total_price in application/modules/shop/views/index/cart.php
Undefined variable: shipping_costs in application/modules/shop/views/index/cart.php
Undefined variable: arrayShippingCosts in application/modules/shop/views/index/cart.php
max(): When only one parameter is given, it must be an array in application/modules/shop/views/index/cart.php
Undefined variable: total_price in application/modules/shop/views/index/cart.php

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
