### PR TITLE
Auth providers: Fix "Creation of dynamic property module_name is deprecated" and more

### DIFF
--- a/application/modules/user/controllers/admin/Providers.php
+++ b/application/modules/user/controllers/admin/Providers.php
@@ -1,14 +1,15 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
 namespace Modules\User\Controllers\Admin;
 
+use Ilch\Controller\Admin;
 use Modules\User\Mappers\AuthProvider;
 
-class Providers extends \Ilch\Controller\Admin
+class Providers extends Admin
 {
     public function init()
     {

--- a/application/modules/user/mappers/AuthProvider.php
+++ b/application/modules/user/mappers/AuthProvider.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
 namespace Modules\User\Mappers;
 
+use Ilch\Database\Mysql\Result;
 use Modules\User\Models\AuthProviderUser;
 use Modules\User\Models\Provider;
 use Modules\User\Models\AuthProviderModule;
@@ -183,7 +184,7 @@ class AuthProvider extends \Ilch\Mapper
      * the links to the auth providers of that deleted user are of no use anymore.
      *
      * @param $user_id
-     * @return \Ilch\Database\Mysql\Result|int
+     * @return Result|int
      */
     public function deleteUser($user_id)
     {
@@ -210,7 +211,7 @@ class AuthProvider extends \Ilch\Mapper
     public function deleteProvider($key)
     {
         $provider = $this->db()->delete('auth_providers', ['key' => $key])->execute();
-        $provider_users = $this->db()->delete('users_auth_providers', ['provider' => $key])->execute();
+        $this->db()->delete('users_auth_providers', ['provider' => $key])->execute();
 
         return $provider === 1;
     }

--- a/application/modules/user/models/AuthProviderModule.php
+++ b/application/modules/user/models/AuthProviderModule.php
@@ -8,11 +8,39 @@ namespace Modules\User\Models;
 
 class AuthProviderModule extends \Ilch\Model
 {
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
     protected $provider;
+
+    /**
+     * @var string
+     */
     protected $module;
+
+    /**
+     * @var string
+     */
     protected $auth_controller;
+
+    /**
+     * @var string
+     */
     protected $auth_action;
+
+    /**
+     * @var string
+     */
     protected $unlink_controller;
+
+    /**
+     * @var string
+     */
     protected $unlink_action;
 
     public function __construct()
@@ -20,11 +48,29 @@ class AuthProviderModule extends \Ilch\Model
     }
 
     /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return AuthProviderModule
+     */
+    public function setName(string $name): AuthProviderModule
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
      * Gets the value of provider.
      *
-     * @return mixed
+     * @return string
      */
-    public function getProvider()
+    public function getProvider(): string
     {
         return $this->provider;
     }
@@ -32,11 +78,11 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Sets the value of provider.
      *
-     * @param mixed $provider the provider
+     * @param string $provider the provider
      *
      * @return self
      */
-    public function setProvider($provider)
+    public function setProvider(string $provider): AuthProviderModule
     {
         $this->provider = $provider;
 
@@ -46,9 +92,9 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Gets the value of module.
      *
-     * @return mixed
+     * @return string
      */
-    public function getModule()
+    public function getModule(): string
     {
         return $this->module;
     }
@@ -60,7 +106,7 @@ class AuthProviderModule extends \Ilch\Model
      *
      * @return self
      */
-    public function setModule($module)
+    public function setModule($module): AuthProviderModule
     {
         $this->module = $module;
 
@@ -70,9 +116,9 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Gets the value of auth_controller.
      *
-     * @return mixed
+     * @return string
      */
-    public function getAuthController()
+    public function getAuthController(): string
     {
         return $this->auth_controller;
     }
@@ -80,11 +126,11 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Sets the value of auth_controller.
      *
-     * @param mixed $auth_controller the auth controller
+     * @param string $auth_controller the auth controller
      *
      * @return self
      */
-    public function setAuthController($auth_controller)
+    public function setAuthController(string $auth_controller): AuthProviderModule
     {
         $this->auth_controller = $auth_controller;
 
@@ -94,9 +140,9 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Gets the value of auth_action.
      *
-     * @return mixed
+     * @return string
      */
-    public function getAuthAction()
+    public function getAuthAction(): string
     {
         return $this->auth_action;
     }
@@ -104,11 +150,11 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Sets the value of auth_action.
      *
-     * @param mixed $auth_action the auth action
+     * @param string $auth_action the auth action
      *
      * @return self
      */
-    public function setAuthAction($auth_action)
+    public function setAuthAction(string $auth_action): AuthProviderModule
     {
         $this->auth_action = $auth_action;
 
@@ -118,9 +164,9 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Gets the value of unlink_controller.
      *
-     * @return mixed
+     * @return string
      */
-    public function getUnlinkController()
+    public function getUnlinkController(): string
     {
         return $this->unlink_controller;
     }
@@ -128,11 +174,11 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Sets the value of unlink_controller.
      *
-     * @param mixed $unlink_controller the unlink controller
+     * @param string $unlink_controller the unlink controller
      *
      * @return self
      */
-    public function setUnlinkController($unlink_controller)
+    public function setUnlinkController(string $unlink_controller): AuthProviderModule
     {
         $this->unlink_controller = $unlink_controller;
 
@@ -142,9 +188,9 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Gets the value of unlink_action.
      *
-     * @return mixed
+     * @return string
      */
-    public function getUnlinkAction()
+    public function getUnlinkAction(): string
     {
         return $this->unlink_action;
     }
@@ -152,11 +198,11 @@ class AuthProviderModule extends \Ilch\Model
     /**
      * Sets the value of unlink_action.
      *
-     * @param mixed $unlink_action the unlink action
+     * @param string $unlink_action the unlink action
      *
      * @return self
      */
-    public function setUnlinkAction($unlink_action)
+    public function setUnlinkAction(string $unlink_action): AuthProviderModule
     {
         $this->unlink_action = $unlink_action;
 

--- a/application/modules/user/models/Provider.php
+++ b/application/modules/user/models/Provider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -10,43 +10,57 @@ class Provider extends \Ilch\Model
 {
     /**
      * Unique key
+     * @var string
      */
     protected $key;
 
     /**
      * Human readable name
+     * @var string
      */
     protected $name;
 
     /**
      * Font-awesome icon
+     * @var string
      */
     protected $icon;
 
     /**
      * Module providing the auth functionality of this provider
+     * @var string
     */
     protected $module;
 
     /**
      * Controller that performs the authentication
+     * @var string
      */
     protected $auth_controller;
 
     /**
      * Action that performs the authentication
+     * @var string
      */
     protected $auth_action;
 
     /**
      * Controller that performs the unlink
+     * @var string
      */
     protected $unlink_controller;
 
     /**
      * Action that performs the unlink
+     * @var string
      */
     protected $unlink_action;
+
+    /**
+     * The localised module name.
+     * @var string
+     */
+    protected $module_name;
 
     /**
      * Constructor
@@ -59,9 +73,9 @@ class Provider extends \Ilch\Model
     /**
      * Gets the Unique key.
      *
-     * @return mixed
+     * @return string
      */
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -73,7 +87,7 @@ class Provider extends \Ilch\Model
      *
      * @return self
      */
-    protected function setKey($key)
+    protected function setKey($key): Provider
     {
         $this->key = $key;
 
@@ -83,9 +97,9 @@ class Provider extends \Ilch\Model
     /**
      * Gets the Human readable name.
      *
-     * @return mixed
+     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -93,11 +107,11 @@ class Provider extends \Ilch\Model
     /**
      * Sets the Human readable name.
      *
-     * @param mixed $name the name
+     * @param string $name the name
      *
      * @return self
      */
-    protected function setName($name)
+    protected function setName(string $name): Provider
     {
         $this->name = $name;
 
@@ -107,9 +121,9 @@ class Provider extends \Ilch\Model
     /**
      * Gets the Font-awesome icon.
      *
-     * @return mixed
+     * @return string
      */
-    public function getIcon()
+    public function getIcon(): string
     {
         return $this->icon;
     }
@@ -117,11 +131,11 @@ class Provider extends \Ilch\Model
     /**
      * Sets the Font-awesome icon.
      *
-     * @param mixed $icon the icon
+     * @param string $icon the icon
      *
      * @return self
      */
-    protected function setIcon($icon)
+    protected function setIcon(string $icon): Provider
     {
         $this->icon = $icon;
 
@@ -131,9 +145,9 @@ class Provider extends \Ilch\Model
     /**
      * Gets the Module providing the auth functionality of this provider.
      *
-     * @return mixed
+     * @return string|null
      */
-    public function getModule()
+    public function getModule(): ?string
     {
         return $this->module;
     }
@@ -141,11 +155,11 @@ class Provider extends \Ilch\Model
     /**
      * Sets the Module providing the auth functionality of this provider.
      *
-     * @param mixed $module the module
+     * @param string $module the module
      *
      * @return self
      */
-    protected function setModule($module)
+    protected function setModule(string $module): Provider
     {
         $this->module = $module;
 
@@ -155,9 +169,9 @@ class Provider extends \Ilch\Model
     /**
      * Gets the value of auth_controller.
      *
-     * @return mixed
+     * @return string|null
      */
-    public function getAuthController()
+    public function getAuthController(): ?string
     {
         return $this->auth_controller;
     }
@@ -165,11 +179,11 @@ class Provider extends \Ilch\Model
     /**
      * Sets the value of auth_controller.
      *
-     * @param mixed $auth_controller the auth controller
+     * @param string $auth_controller the auth controller
      *
      * @return self
      */
-    protected function setAuthController($auth_controller)
+    protected function setAuthController(string $auth_controller): Provider
     {
         $this->auth_controller = $auth_controller;
 
@@ -179,9 +193,9 @@ class Provider extends \Ilch\Model
     /**
      * Gets the value of auth_action.
      *
-     * @return mixed
+     * @return string|null
      */
-    public function getAuthAction()
+    public function getAuthAction(): ?string
     {
         return $this->auth_action;
     }
@@ -189,11 +203,11 @@ class Provider extends \Ilch\Model
     /**
      * Sets the value of auth_action.
      *
-     * @param mixed $auth_action the auth action
+     * @param string $auth_action the auth action
      *
      * @return self
      */
-    protected function setAuthAction($auth_action)
+    protected function setAuthAction(string $auth_action): Provider
     {
         $this->auth_action = $auth_action;
 
@@ -203,9 +217,9 @@ class Provider extends \Ilch\Model
     /**
      * Gets the value of unlink_controller.
      *
-     * @return mixed
+     * @return string|null
      */
-    public function getUnlinkController()
+    public function getUnlinkController(): ?string
     {
         return $this->unlink_controller;
     }
@@ -213,11 +227,11 @@ class Provider extends \Ilch\Model
     /**
      * Sets the value of unlink_controller.
      *
-     * @param mixed $unlink_controller the unlink controller
+     * @param string $unlink_controller the unlink controller
      *
      * @return self
      */
-    protected function setUnlinkController($unlink_controller)
+    protected function setUnlinkController(string $unlink_controller): Provider
     {
         $this->unlink_controller = $unlink_controller;
 
@@ -227,9 +241,9 @@ class Provider extends \Ilch\Model
     /**
      * Gets the value of unlink_action.
      *
-     * @return mixed
+     * @return string|null
      */
-    public function getUnlinkAction()
+    public function getUnlinkAction(): ?string
     {
         return $this->unlink_action;
     }
@@ -237,14 +251,36 @@ class Provider extends \Ilch\Model
     /**
      * Sets the value of unlink_action.
      *
-     * @param mixed $unlink_action the unlink action
+     * @param string $unlink_action the unlink action
      *
      * @return self
      */
-    protected function setUnlinkAction($unlink_action)
+    protected function setUnlinkAction(string $unlink_action): Provider
     {
         $this->unlink_action = $unlink_action;
 
+        return $this;
+    }
+
+    /**
+     * Get the localised module name.
+     *
+     * @return string|null
+     */
+    public function getModuleName(): ?string
+    {
+        return $this->module_name;
+    }
+
+    /**
+     * Set the localised module name.
+     *
+     * @param string $module_name
+     * @return Provider
+     */
+    protected function setModuleName(string $module_name): Provider
+    {
+        $this->module_name = $module_name;
         return $this;
     }
 }

--- a/application/modules/user/views/admin/providers/index.php
+++ b/application/modules/user/views/admin/providers/index.php
@@ -29,7 +29,7 @@
                                 </span>
                             <?php else: ?>
                                 <span class="text-success">
-                                    <i class="fa-solid fa-check fa-fw"></i> <b><?=$this->escape($provider->module_name) ?></b> (<?= $provider->getModule() ?>)
+                                    <i class="fa-solid fa-check fa-fw"></i> <b><?=$this->escape($provider->getModuleName()) ?></b> (<?= $provider->getModule() ?>)
                                 </span>
                             <?php endif; ?>
                         </td>


### PR DESCRIPTION
# Description
- Fix "Creation of dynamic property module_name is deprecated" and more

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
