### PR TITLE
Forum:  Add mark topic as read conditions

### DIFF
--- a/application/libraries/Ilch/Pagination.php
+++ b/application/libraries/Ilch/Pagination.php
@@ -9,25 +9,27 @@ namespace Ilch;
 class Pagination
 {
     /**
-     * @var integer
+     * @var int
      */
     protected $page = 1;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $rowsPerPage = 20;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $rows;
 
     /**
-     * @param integer $page
+     * @param mixed $page
      */
     public function setPage($page)
     {
+        // Don't change the type to int to avoid errors as $page typically comes from an URL parameter and can be non-numeric.
+        // Changing this would require every usage of this function to be guarded against passing non-numeric values.
         if ($page == null || !is_numeric($page)) {
             $page = 1;
         }
@@ -36,29 +38,38 @@ class Pagination
     }
 
     /**
-     * @param integer $rows
+     * @param int $rows
      */
-    public function setRows($rows)
+    public function setRows(int $rows)
     {
-        $this->rows = intval($rows);
+        $this->rows = $rows;
     }
 
     /**
-     * @param $rowsPerPage
-     * @intern param int $rowsPerPage
+     * Get the number of rows.
+     *
+     * @return int
      */
-    public function setRowsPerPage($rowsPerPage)
+    public function getRows(): int
+    {
+        return $this->rows;
+    }
+
+    /**
+     * @param int|null $rowsPerPage
+     */
+    public function setRowsPerPage(?int $rowsPerPage)
     {
         if ($rowsPerPage == null) {
             $rowsPerPage = 20;
         }
-        $this->rowsPerPage = intval($rowsPerPage);
+        $this->rowsPerPage = $rowsPerPage;
     }
 
     /**
      * @return int[]
      */
-    public function getLimit()
+    public function getLimit(): array
     {
         return [($this->page - 1) * $this->rowsPerPage, $this->rowsPerPage];
     }
@@ -70,14 +81,14 @@ class Pagination
      * @param $urlArray
      * @return string
      */
-    public function getHtml($view, $urlArray)
+    public function getHtml($view, $urlArray): string
     {
         if (empty($this->rows)) {
             return '';
         }
 
         $links = 7;
-        $last = ceil($this->rows/$this->rowsPerPage);
+        $last = ceil($this->rows / $this->rowsPerPage);
 
         if ($last == 1) {
             return '';
@@ -90,30 +101,30 @@ class Pagination
 
         if ($this->page > 1) {
             $urlArray['page'] = $this->page - 1;
-            $html .= '<li><a href="'.$view->getUrl($urlArray).'">&laquo;</a></li>';
+            $html .= '<li><a href="' . $view->getUrl($urlArray) . '">&laquo;</a></li>';
         }
 
         if ($start > 1) {
             $urlArray['page'] = 1;
-            $html .= '<li><a href="'.$view->getUrl($urlArray).'">1</a></li>';
+            $html .= '<li><a href="' . $view->getUrl($urlArray) . '">1</a></li>';
             $html .= '<li class="disabled"><span>...</span></li>';
         }
 
         for ($i = $start; $i <= $end; $i++) {
-            $class  = ($this->page == $i) ? 'active' : '';
+            $class = ($this->page == $i) ? 'active' : '';
             $urlArray['page'] = $i;
-            $html .= '<li class="'.$class.'"><a href="'.$view->getUrl($urlArray).'">'.$i.'</a></li>';
+            $html .= '<li class="' . $class . '"><a href="' . $view->getUrl($urlArray) . '">' . $i . '</a></li>';
         }
 
         if ($end < $last) {
             $urlArray['page'] = $last;
             $html .= '<li class="disabled"><span>...</span></li>';
-            $html .= '<li><a href="'.$view->getUrl($urlArray).'">'.$last.'</a></li>';
+            $html .= '<li><a href="' . $view->getUrl($urlArray) . '">' . $last . '</a></li>';
         }
 
         if ($last > $this->page) {
             $urlArray['page'] = $this->page + 1;
-            $html .= '<li><a href="'.$view->getUrl($urlArray).'">&raquo;</a></li>';
+            $html .= '<li><a href="' . $view->getUrl($urlArray) . '">&raquo;</a></li>';
         }
 
         $html .= '</ul>';

--- a/application/modules/forum/boxes/views/forum.php
+++ b/application/modules/forum/boxes/views/forum.php
@@ -34,7 +34,7 @@ $postsPerPage = $this->get('postsPerPage');
                     <?php else: ?>
                         <img src="<?=$this->getStaticUrl('../application/modules/forum/static/img/topic_read.png') ?>" style="float: left; margin-top: 8px;" alt="<?=$this->getTrans('read') ?>">
                     <?php endif; ?>
-                    <a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'showposts', 'action' => 'index', 'topicid' => $topic['topic_id'], 'page' => ($DESCPostorder?1:ceil($countPosts/$postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
+                    <a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'showposts', 'action' => 'index', 'topicid' => $topic['topic_id'], 'page' => ($DESCPostorder ? 1 : ceil($countPosts / $postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
                         <?=$this->escape($topic['topic_title']) ?>
                     </a>
                     <br />

--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -35,7 +35,7 @@ class Config extends \Ilch\Config\Install
                 ]
             ]
         ],
-        'ilchCore' => '2.1.52',
+        'ilchCore' => '2.1.53',
         'phpVersion' => '7.3'
     ];
 

--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -43,7 +43,8 @@ class Showposts extends Frontend
         $reportsMapper = new ReportsMapper();
         $rememberMapper = new RememberMapper();
 
-        $pagination->setRowsPerPage(!$this->getConfig()->get('forum_postsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
+        $rowsPerPage = !$this->getConfig()->get('forum_postsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage');
+        $pagination->setRowsPerPage($rowsPerPage);
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $topicId = $this->getRequest()->getParam('topicid');
@@ -99,9 +100,13 @@ class Showposts extends Frontend
         if ($this->getUser()) {
             $userId = $this->getUser()->getId();
 
-            // Mark topic as read.
-            $trackReadMapper = new TrackReadMapper();
-            $trackReadMapper->markTopicAsRead($this->getUser()->getId(), $topicId, $forum->getId());
+            if (($this->getConfig()->get('forum_DESCPostorder') && $this->getRequest()->getParam('page') == (1 || !$this->getRequest()->getParam('page')))
+                || (!$this->getConfig()->get('forum_DESCPostorder') && ($this->getRequest()->getParam('page') == (ceil($pagination->getRows() / $rowsPerPage))))
+            ) {
+                // Mark topic as read if on the last page or on the first page with descending post order.
+                $trackReadMapper = new TrackReadMapper();
+                $trackReadMapper->markTopicAsRead($this->getUser()->getId(), $topicId, $forum->getId());
+            }
 
             if ($this->getConfig()->get('forum_topicSubscription') == 1) {
                 $topicSubscriptionMapper = new TopicSubscriptionMapper();

--- a/application/modules/forum/views/Showunansweredtopics/index.php
+++ b/application/modules/forum/views/Showunansweredtopics/index.php
@@ -114,7 +114,7 @@ $postsPerPage = $this->get('postsPerPage');
                                         <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
                                             <?=$this->escape($lastPost->getAutor()->getName()) ?>
                                         </a>
-                                        <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $lastPost->getTopicId(), 'page' => ($DESCPostorder?1:ceil($countPosts/$postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
+                                        <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $lastPost->getTopicId(), 'page' => ($DESCPostorder ? 1 : ceil($countPosts / $postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
                                             <img src="<?=$this->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$this->getTrans('viewLastPost') ?>" title="<?=$this->getTrans('viewLastPost') ?>" height="10" width="12">
                                         </a>
                                         <br>

--- a/application/modules/forum/views/showcat/index.php
+++ b/application/modules/forum/views/showcat/index.php
@@ -93,7 +93,7 @@ function rec($item, $forumMapper, $obj, $readAccess)
                                     <a href="<?=$obj->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$obj->escape($lastPost->getAutor()->getName()) ?>">
                                         <?=$obj->escape($lastPost->getAutor()->getName()) ?>
                                     </a>
-                                    <a href="<?=$obj->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $lastPost->getTopicId(), 'page' => ($DESCPostorder?1:ceil($countPosts/$postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
+                                    <a href="<?=$obj->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $lastPost->getTopicId(), 'page' => ($DESCPostorder ? 1 : ceil($countPosts / $postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
                                         <img src="<?=$obj->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$obj->getTrans('viewLastPost') ?>" title="<?=$obj->getTrans('viewLastPost') ?>" height="10" width="12">
                                     </a>
                                     <br>

--- a/application/modules/forum/views/shownewposts/index.php
+++ b/application/modules/forum/views/shownewposts/index.php
@@ -110,7 +110,7 @@ $postsPerPage = $this->get('postsPerPage');
                                         <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
                                             <?=$this->escape($lastPost->getAutor()->getName()) ?>
                                         </a>
-                                        <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $lastPost->getTopicId(), 'page' => ($DESCPostorder?1:ceil($countPosts/$postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
+                                        <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $lastPost->getTopicId(), 'page' => ($DESCPostorder ? 1 : ceil($countPosts / $postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
                                             <img src="<?=$this->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$this->getTrans('viewLastPost') ?>" title="<?=$this->getTrans('viewLastPost') ?>" height="10" width="12">
                                         </a>
                                         <br>

--- a/application/modules/forum/views/showtopics/index.php
+++ b/application/modules/forum/views/showtopics/index.php
@@ -122,7 +122,7 @@ $postsPerPage = $this->get('postsPerPage');
                                         <?=$this->getTrans('views') ?>:
                                     </div>
                                     <div class="pull-left text-justify">
-                                        <?=$countPosts -1 ?>
+                                        <?=$countPosts - 1 ?>
                                         <br />
                                         <?=$topic->getVisits() ?>
                                     </div>
@@ -138,7 +138,7 @@ $postsPerPage = $this->get('postsPerPage');
                                         <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
                                             <?=$this->escape($lastPost->getAutor()->getName()) ?>
                                         </a>
-                                        <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic->getId(), 'page' => ($DESCPostorder?1:ceil($countPosts/$postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
+                                        <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic->getId(), 'page' => ($DESCPostorder ? 1 : ceil($countPosts / $postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
                                             <img src="<?=$this->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$this->getTrans('viewLastPost') ?>" title="<?=$this->getTrans('viewLastPost') ?>" height="10" width="12">
                                         </a>
                                         <br>


### PR DESCRIPTION
# Description
- Mark topic as read if on the last page or on the first page with descending post order.
- Added a getter for rows in the pagination class to use it in the forum. Therefore the forum now requires Ilch 2.1.53.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
