### PR TITLE
User: Fix errors in the dialog

### DIFF
--- a/application/modules/user/models/Dialog.php
+++ b/application/modules/user/models/Dialog.php
@@ -104,9 +104,9 @@ class Dialog extends \Ilch\Model
     /**
      * Get the ID of the message
      *
-     * @return int
+     * @return int|null
      */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -127,9 +127,9 @@ class Dialog extends \Ilch\Model
     /**
      * Get the CONVERSATION_ID of the dialog
      *
-     * @return int
+     * @return int|null
      */
-    public function getCId(): int
+    public function getCId(): ?int
     {
         return $this->c_id;
     }
@@ -265,9 +265,9 @@ class Dialog extends \Ilch\Model
     /**
      * Get the text of the dialog
      *
-     * @return string
+     * @return string|null
      */
-    public function getText(): string
+    public function getText(): ?string
     {
         return $this->text;
     }


### PR DESCRIPTION
# Description
- Fix errors in the dialog

> Uncaught TypeError: Modules\User\Models\Dialog::getId(): Return value must be of type int, null returned
> ...

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
