### PR TITLE
Fix line-breaks in shoutbox

### DIFF
--- a/application/modules/shoutbox/boxes/views/shoutbox.php
+++ b/application/modules/shoutbox/boxes/views/shoutbox.php
@@ -7,6 +7,11 @@ $userMapper = new \Modules\User\Mappers\User();
 
 $config = \Ilch\Registry::get('config');
 ?>
+<style>
+.shoutbox-text {
+    line-break: anywhere;
+}
+</style>
 <script>
     $(function() {
         let $shoutboxContainer = $('#shoutbox-container<?=$this->get('uniqid') ?>'),
@@ -188,12 +193,7 @@ $config = \Ilch\Registry::get('config');
                         <?php endif; ?>
                     </tr>
                     <tr>
-                        <?php
-                        /*
-                         * @todo should fix this regex.
-                         */
-                        ?>
-                        <td><?=preg_replace('/([^\s]{' . $this->get('maxwordlength') . '})(?=[^\s])/', "$1\n", $this->escape($shoutbox->getTextarea())) ?></td>
+                        <td class="shoutbox-text"><?=$this->escape($shoutbox->getTextarea()) ?></td>
                     </tr>
                 <?php endforeach; ?>
             <?php else : ?>

--- a/application/modules/shoutbox/config/config.php
+++ b/application/modules/shoutbox/config/config.php
@@ -45,7 +45,6 @@ class Config extends \Ilch\Config\Install
 
         $databaseConfig = new \Ilch\Config\Database($this->db());
         $databaseConfig->set('shoutbox_limit', '5')
-            ->set('shoutbox_maxwordlength', '10')
             ->set('shoutbox_maxtextlength', '50')
             ->set('shoutbox_writeaccess', '1,2');
     }
@@ -57,7 +56,6 @@ class Config extends \Ilch\Config\Install
         $databaseConfig = new \Ilch\Config\Database($this->db());
         $databaseConfig->delete('shoutbox_limit')
             ->delete('shoutbox_maxtextlength')
-            ->delete('shoutbox_maxwordlength')
             ->delete('shoutbox_writeaccess');
     }
 
@@ -99,6 +97,9 @@ class Config extends \Ilch\Config\Install
                 // no break
             case "1.5.0":
                 // no break
+                $databaseConfig = new \Ilch\Config\Database($this->db());
+                $databaseConfig->delete('shoutbox_limit')
+                    ->delete('shoutbox_maxwordlength');
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';

--- a/application/modules/shoutbox/controllers/admin/Settings.php
+++ b/application/modules/shoutbox/controllers/admin/Settings.php
@@ -52,7 +52,6 @@ class Settings extends \Ilch\Controller\Admin
         if ($this->getRequest()->isPost()) {
             $validation = Validation::create($this->getRequest()->getPost(), [
                 'limit'         => 'required|min:1',
-                'maxwordlength' => 'required|min:10',
                 'maxtextlength' => 'required|min:20'
             ]);
 
@@ -64,7 +63,6 @@ class Settings extends \Ilch\Controller\Admin
                 }
 
                 $this->getConfig()->set('shoutbox_limit', $this->getRequest()->getPost('limit'))
-                    ->set('shoutbox_maxwordlength', $this->getRequest()->getPost('maxwordlength'))
                     ->set('shoutbox_maxtextlength', $this->getRequest()->getPost('maxtextlength'))
                     ->set('shoutbox_writeaccess', $writeAccess);
 
@@ -80,7 +78,6 @@ class Settings extends \Ilch\Controller\Admin
         }
 
         $this->getView()->set('limit', $this->getConfig()->get('shoutbox_limit'))
-            ->set('maxwordlength', $this->getConfig()->get('shoutbox_maxwordlength'))
             ->set('maxtextlength', $this->getConfig()->get('shoutbox_maxtextlength'))
             ->set('userGroupList', $userGroupMapper->getGroupList())
             ->set('writeAccess', $this->getConfig()->get('shoutbox_writeaccess'));

--- a/application/modules/shoutbox/translations/de.php
+++ b/application/modules/shoutbox/translations/de.php
@@ -14,7 +14,6 @@ return [
     'message' => 'Nachricht',
     'noEntrys' => 'Keine Einträge vorhanden',
     'numberOfMessagesDisplayed' => 'Anzahl angezeigter Nachrichten',
-    'maximumWordLength' => 'Maximale Wortlänge',
     'maximumTextLength' => 'Maximale Textlänge',
     'settings' => 'Einstellungen',
     'answer' => 'Antworten',

--- a/application/modules/shoutbox/translations/en.php
+++ b/application/modules/shoutbox/translations/en.php
@@ -14,7 +14,6 @@ return [
     'message' => 'Message',
     'noEntrys' => 'No entries exist',
     'numberOfMessagesDisplayed' => 'Number of messages displayed',
-    'maximumWordLength' => 'Maximum word length',
     'maximumTextLength' => 'Maximum text length',
     'settings' => 'Settings',
     'answer' => 'Answer',

--- a/application/modules/shoutbox/views/admin/settings/index.php
+++ b/application/modules/shoutbox/views/admin/settings/index.php
@@ -18,19 +18,6 @@
                    value="<?=$this->originalInput('limit', $this->get('limit')) ?>">
         </div>
     </div>
-    <div class="form-group <?=$this->validation()->hasError('maxwordlength') ? 'has-error' : '' ?>">
-        <label for="maxwordlength" class="col-lg-2 control-label">
-            <?=$this->getTrans('maximumWordLength') ?>
-        </label>
-        <div class="col-lg-1">
-            <input type="number"
-                   class="form-control"
-                   id="maxwordlength"
-                   name="maxwordlength"
-                   min="1"
-                   value="<?=$this->originalInput('maxwordlength', $this->get('maxwordlength')) ?>">
-        </div>
-    </div>
     <div class="form-group <?=$this->validation()->hasError('maxtextlength') ? 'has-error' : '' ?>">
         <label for="maxtextlength" class="col-lg-2 control-label">
             <?=$this->getTrans('maximumTextLength') ?>


### PR DESCRIPTION
# Description
- Fix line-breaks in shoutbox (replace regexp with css line-break anywhere).
- Remove setting for maxwordlength.

See https://developer.mozilla.org/en-US/docs/Web/CSS/line-break
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
