### PR TITLE
FAQ: Fix "Argument must be of type Countable|array, null given"

### DIFF
--- a/application/modules/faq/config/config.php
+++ b/application/modules/faq/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'faq',
-        'version' => '1.9.0',
+        'version' => '1.9.1',
         'icon_small' => 'fa-regular fa-circle-question',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/faq/views/admin/cats/index.php
+++ b/application/modules/faq/views/admin/cats/index.php
@@ -33,8 +33,7 @@ $cats = $this->get('cats');
                 </thead>
                 <tbody>
                     <?php foreach ($cats as $cat) : ?>
-                        <?php $faqs = $faqMapper->getFaqsByCatId($cat->getId()); ?>
-                        <?php $countFaqs = is_array($faqs) ? count($faqs) : 0; ?>
+                        <?php $countFaqs = count($faqMapper->getFaqsByCatId($cat->getId()) ?? []); ?>
                         <tr>
                             <td><?=$this->getDeleteCheckbox('check_cats', $cat->getId()) ?></td>
                             <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $cat->getId()]) ?></td>

--- a/application/modules/faq/views/admin/cats/index.php
+++ b/application/modules/faq/views/admin/cats/index.php
@@ -33,7 +33,8 @@ $cats = $this->get('cats');
                 </thead>
                 <tbody>
                     <?php foreach ($cats as $cat) : ?>
-                        <?php $countFaqs = count($faqMapper->getFaqsByCatId($cat->getId())); ?>
+                        <?php $faqs = $faqMapper->getFaqsByCatId($cat->getId()); ?>
+                        <?php $countFaqs = is_array($faqs) ? count($faqs) : 0; ?>
                         <tr>
                             <td><?=$this->getDeleteCheckbox('check_cats', $cat->getId()) ?></td>
                             <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $cat->getId()]) ?></td>


### PR DESCRIPTION
Dieser Fehler trat auf, wenn man eine neue Kategorie anlegen wollte.

```
Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in ilch_normal\application\modules\faq\views\admin\cats\index.php:36
Stack trace:
#0 ilch_normal\application\libraries\Ilch\View.php(22): include()
#1 ilch_normal\application\libraries\Ilch\Page.php(151): Ilch\View->loadScript('')
#2 ilch_normal\index.php(67): Ilch\Page->loadPage()
#3 {main} thrown in ilch_normal\application\modules\faq\views\admin\cats\index.php on line 36
```


