### PR TITLE
Downloads: Fix comments

### DIFF
--- a/application/modules/downloads/config/config.php
+++ b/application/modules/downloads/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'downloads',
-        'version' => '1.13.3',
+        'version' => '1.13.4',
         'icon_small' => 'fa-regular fa-circle-down',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/downloads/mappers/File.php
+++ b/application/modules/downloads/mappers/File.php
@@ -33,6 +33,7 @@ class File extends Mapper
         }
 
         $entryModel = new FileModel();
+        $entryModel->setId($id);
         $entryModel->setFileId($fileRow['file_id']);
         $entryModel->setFileUrl($fileRow['url']);
         $entryModel->setFileImage($fileRow['file_image']);

--- a/application/modules/downloads/views/index/show.php
+++ b/application/modules/downloads/views/index/show.php
@@ -57,7 +57,7 @@
                 <div class="panel-footer text-center">
                     <i class="fa-solid fa-pencil"></i> <?=$this->escape($file->getFileTitle()) ?><br>
                     <i class="fa-regular fa-comment"></i> <?=$commentsCount ?>
-                    <i class="fa-solid fa-eye"> <?=$file->getVisits() ?></i>
+                    <i class="fa-solid fa-eye"></i> <?=$file->getVisits() ?>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# Description
- Fix comments by setting the id for the file in the getFileById function.
- Fix visits count being displayed in bold.

Fixes #783

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
