### PR TITLE
Add filesize of backup and cleanup filename, add formatBytes function

### DIFF
--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -578,3 +578,25 @@ function invalidateOpcache(string $filepath, bool $force = false): bool
 
     return opcache_invalidate($filepath, $force);
 }
+
+/**
+ * Get the bytes in a human readable format like 350 KB.
+ *
+ * @since 2.1.54
+ *
+ * @param int $bytes
+ * @param int $precision
+ * @return string
+ */
+function formatBytes(int $bytes, int $precision = 0): string
+{
+    $units = array('B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB');
+
+    $bytes = max($bytes, 0);
+    $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+    $pow = min($pow, count($units) - 1);
+
+    $bytes /= pow(1024, $pow);
+
+    return round($bytes, $precision) . ' ' . $units[$pow];
+}

--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -309,7 +309,7 @@ function var_export_short_syntax($var, string $indent = ''): string
 /**
  * Checks if the current visitor is logged in.
  *
- * @return boolean
+ * @return bool
  */
 function loggedIn(): bool
 {
@@ -580,16 +580,23 @@ function invalidateOpcache(string $filepath, bool $force = false): bool
 }
 
 /**
- * Get the bytes in a human readable format like 350 KB.
+ * Get the bytes in a human readable format like 350 KB instead of 358400 bytes.
+ * Integers in PHP are limited to 32 bits, unless they are on 64 bit architecture, then they have 64 bit size.
+ * For a larger size use string. It will be converted to a double, which should always have 64 bit length.
+ * Technically the correct unit names for powers of 1024 are KiB, MiB etc.
  *
  * @since 2.1.54
  *
- * @param int $bytes
- * @param int $precision
- * @return string
+ * @param int|string $bytes
+ * @param int $decimals
+ * @return string|bool Number as string or false on failure.
  */
-function formatBytes(int $bytes, int $precision = 0): string
+function formatBytes($bytes, int $decimals = 0)
 {
+    if ($bytes === '' || $bytes < 0 || !is_numeric($bytes)) {
+        return false;
+    }
+
     $units = array('B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB');
 
     $bytes = max($bytes, 0);
@@ -598,5 +605,5 @@ function formatBytes(int $bytes, int $precision = 0): string
 
     $bytes /= pow(1024, $pow);
 
-    return round($bytes, $precision) . ' ' . $units[$pow];
+    return round($bytes, $decimals) . ' ' . $units[$pow];
 }

--- a/application/modules/admin/controllers/admin/Backup.php
+++ b/application/modules/admin/controllers/admin/Backup.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -203,11 +203,10 @@ class Backup extends \Ilch\Controller\Admin
 
                     if (strtolower($path_parts['extension']) === 'gz') {
                         header('Content-type: application/x-gzip');
-                        header('Content-Disposition: filename="' .$publicFileName. '"');
                     } else {
                         header('Content-type: application/x-sql');
-                        header('Content-Disposition: filename="' .$publicFileName. '"');
                     }
+                    header('Content-Disposition: filename="' .$publicFileName. '"');
                     header('Content-length: ' .filesize($fullPath));
                     // RFC2616 section 14.9.1: Indicates that all or part of the response message is intended for a single user and MUST NOT be cached by a shared cache, such as a proxy server.
                     header('Cache-control: private');

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -152,6 +152,7 @@ return [
     'dropTable' => 'DROP TABLE-Befehle hinzufügen',
     'noBackups' => 'Keine Backups vorhanden',
     'backupNotFound' => 'Das Backup wurde nicht gefunden oder konnte nicht geöffnet werden.',
+    'backupFilesize' => 'Dateigröße',
     'menuCustomCSS' => 'Benutzerdefinierte CSS',
     'menuHtaccess' => 'htaccess',
     'modrewriteLinesAdded' => 'Einträge für Mod-Rewrite hinzugefügt.',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -152,6 +152,7 @@ return [
     'dropTable' => 'Add DROP TABLE statements',
     'noBackups' => 'No backups available',
     'backupNotFound' => 'The backup was not found or could not be opened.',
+    'backupFilesize' => 'Filesize',
     'menuCustomCSS' => 'Custom CSS',
     'menuHtaccess' => 'htaccess',
     'modrewriteLinesAdded' => 'Added lines for mod rewrite.',

--- a/application/modules/admin/views/admin/backup/index.php
+++ b/application/modules/admin/views/admin/backup/index.php
@@ -8,6 +8,7 @@
                 <col class="icon_width">
                 <col class="icon_width">
                 <col class="col-lg-2">
+                <col class="col-lg-2">
                 <col>
             </colgroup>
             <thead>
@@ -16,6 +17,7 @@
                     <th></th>
                     <th></th>
                     <th><?=$this->getTrans('date') ?></th>
+                    <th><?=$this->getTrans('backupFilesize') ?></th>
                     <th><?=$this->getTrans('name') ?></th>
                 </tr>
             </thead>
@@ -27,7 +29,8 @@
                             <td><a href="<?=$this->getUrl(['action' => 'download', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('download') ?>"><span class="fa-solid fa-download"></span></a></td>
                             <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $backup->getId()]) ?></td>
                             <td><?=$this->escape($backup->getDate()) ?></td>
-                            <td><?=$this->escape($backup->getName()) ?></td>
+                            <td><?=formatBytes(filesize(ROOT_PATH . '/backups/' . $backup->getName())) ?></td>
+                            <td><?=$this->escape(preg_replace('/_[^_.]*\./', '.', $backup->getName())) ?></td>
                         </tr>
                     <?php endforeach; ?>
                 <?php else: ?>

--- a/application/modules/downloads/config/config.php
+++ b/application/modules/downloads/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'downloads',
-        'version' => '1.13.5',
+        'version' => '1.13.4',
         'icon_small' => 'fa-regular fa-circle-down',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -93,7 +93,9 @@ class Config extends \Ilch\Config\Install
             case "1.13.1":
                 $this->db()->query("UPDATE `[prefix]_modules` SET `icon_small` = 'fa-regular fa-circle-down' WHERE `key` = 'downloads';");
                 // no break
+            case "1.13.2":
+            case "1.13.3":
+            case "1.13.4":
         }
     }
 }
-

--- a/tests/libraries/ilch/FunctionsTest.php
+++ b/tests/libraries/ilch/FunctionsTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @package ilch_phpunit
+ */
+
+namespace Ilch;
+
+use PHPUnit\Ilch\TestCase;
+
+/**
+ * Tests the functions in the Functions class.
+ *
+ * @package ilch_phpunit
+ */
+class FunctionsTest extends TestCase
+{
+    /**
+     * Tests the formatBytes function.
+     *
+     * @dataProvider dpForTestFormatBytes
+     * @return void
+     */
+    public function testFormatBytes(array $params, $expected)
+    {
+        self::assertSame($expected, formatBytes($params['bytes'], $params['decimals']));
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestFormatBytes(): array
+    {
+        return [
+            'invalid empty string' => ['params' => ['bytes' => '', 'decimals' => 0], false],
+            'invalid negative string' => ['params' => ['bytes' => '-1', 'decimals' => 0], false],
+            'invalid negative number' => ['params' => ['bytes' => -1, 'decimals' => 0], false],
+            'invalid string not numeric' => ['params' => ['bytes' => 'a', 'decimals' => 0], false],
+            'zero bytes' => ['params' => ['bytes' => 0, 'decimals' => 0], '0 B'],
+            'bytes' => ['params' => ['bytes' => 100, 'decimals' => 0], '100 B'],
+            'one kilobyte' => ['params' => ['bytes' => 1024, 'decimals' => 0], '1 KB'],
+            'kilobytes rounded' => ['params' => ['bytes' => 1536, 'decimals' => 0], '2 KB'],
+            'kilobytes' => ['params' => ['bytes' => 2048, 'decimals' => 0], '2 KB'],
+            'kilobytes with one decimal' => ['params' => ['bytes' => 1536, 'decimals' => 1], '1.5 KB'],
+            'megabytes' => ['params' => ['bytes' => 2097152, 'decimals' => 0], '2 MB'],
+            'gigabytes' => ['params' => ['bytes' => 2147483648, 'decimals' => 0], '2 GB'],
+            'terabytes' => ['params' => ['bytes' => 2199023255552, 'decimals' => 0], '2 TB'],
+            'petabytes' => ['params' => ['bytes' => 2251799813685248, 'decimals' => 0], '2 PB'],
+            'exabytes' => ['params' => ['bytes' => 2305843009213693952, 'decimals' => 0], '2 EB'],
+            'zettabytes' => ['params' => ['bytes' => 2361183241434822606848, 'decimals' => 0], '2 ZB'],
+            'yottabytes' => ['params' => ['bytes' => 2417851639229258349412352, 'decimals' => 0], '2 YB'],
+        ];
+    }
+}


### PR DESCRIPTION
# Description
- Backup: Add filesize to the backups table
- Backup: Don't show random part of the backup filename.
- Added formatBytes function for global usage in Ilch and unit tests for it.
- Reverted change of the version number of the downloads module.

I was expecting to find a function like formatBytes in the Functions class, but looks like we always used separate solutions. So added one now, that should also support bigger numbers.

https://github.com/IlchCMS/Ilch-2.0/blob/b448585d8f5f1716699f9767e5284a5fbc097f39/application/modules/user/mappers/Setting.php#L19
https://github.com/IlchCMS/Ilch-2.0/blob/b448585d8f5f1716699f9767e5284a5fbc097f39/application/modules/media/static/js/script.js#L104
https://github.com/IlchCMS/Ilch-2.0/blob/b448585d8f5f1716699f9767e5284a5fbc097f39/build/optimize_vendor.php#L215

It is actually a bad idea to show the full filenames with the random part. These could easily be accidentally leaked with screenshots and knowing the domain or IP address would then allow someone else to download the database backups.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
