### PR TITLE
User: Fix errors in dialog when other user got deleted

### DIFF
--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -452,8 +452,6 @@ class Panel extends BaseController
                 } else {
                     $dialogMapper->markAllAsRead($c_id, $this->getUser()->getId());
                 }
-
-                $this->getView()->set('inbox', $dialogMapper->getDialogMessage($c_id));
             } else {
                 $this->redirect(['action' => 'dialog']);
             }

--- a/application/modules/user/mappers/Dialog.php
+++ b/application/modules/user/mappers/Dialog.php
@@ -105,7 +105,11 @@ class Dialog extends \Ilch\Mapper
 
         $dialogModel = new DialogModel();
         $dialogModel->setId($dialogRow['id']);
-        $dialogModel->setName($dialogRow['name']);
+        if (!empty($dialog['name'])) {
+            $dialogModel->setName($dialog['name']);
+        } else {
+            $dialogModel->setName('No longer exists');
+        }
         if (file_exists($dialogRow['avatar'])) {
             $dialogModel->setAvatar($dialogRow['avatar']);
         } else {

--- a/application/modules/user/models/Dialog.php
+++ b/application/modules/user/models/Dialog.php
@@ -91,10 +91,10 @@ class Dialog extends \Ilch\Model
     /**
      * Set the ID of the message
      *
-     * @param int $id
+     * @param int|null $id
      * @return $this
      */
-    public function setId(int $id): Dialog
+    public function setId(?int $id): Dialog
     {
         $this->id = $id;
 


### PR DESCRIPTION
# Description
- Fix errors in dialog when other user got deleted
- Remove call of getDialogMessage in the dialog action as it seems to be not used in the view.

Fixes #813

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
