### PR TITLE
Forum: performance optimisations

### DIFF
--- a/application/modules/forum/boxes/Forum.php
+++ b/application/modules/forum/boxes/Forum.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -27,7 +28,7 @@ class Forum extends Box
 
         $topicIds = [];
         $lastActiveTopicsToShow = [];
-        foreach ($lastActiveTopics as $index => $topic) {
+        foreach ($lastActiveTopics as $topic) {
             if ($isAdmin || $forums[$topic['forum_id']]->getReadAccess()) {
                 $topicIds[] = $topic['topic_id'];
             }

--- a/application/modules/forum/boxes/views/forum.php
+++ b/application/modules/forum/boxes/views/forum.php
@@ -1,50 +1,34 @@
 <?php
 
 use Ilch\Date;
-use Modules\Forum\Mappers\Forum;
-use Modules\Forum\Mappers\Topic;
 
-/** @var Forum $forumMapper */
-$forumMapper = $this->get('forumMapper');
-/** @var Topic $topicMapper */
-$topicMapper = $this->get('topicMapper');
-$groupIdsArray = $this->get('groupIdsArray');
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
 $DESCPostorder = $this->get('DESCPostorder');
 $postsPerPage = $this->get('postsPerPage');
 ?>
 
-<?php if (!empty($this->get('topics'))): ?>
+<?php if (!empty($this->get('lastActiveTopicsToShow'))): ?>
     <ul class="list-unstyled">
-        <?php foreach ($this->get('topics') as $topic): ?>
-            <?php $forum = $forumMapper->getForumById($topic['forum_id']); ?>
-            <?php if ($adminAccess || is_in_array($groupIdsArray, explode(',', $forum->getReadAccess()))): ?>
-                <?php $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic['topic_id'], $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic['topic_id']) ?>
-                <?php $countPosts = $forumMapper->getCountPostsByTopicId($topic['topic_id']) ?>
-                <li style="line-height: 15px;">
-                    <?php if ($this->getUser()): ?>
-                        <?php if ($lastPost->getRead()): ?>
-                            <img src="<?=$this->getStaticUrl('../application/modules/forum/static/img/topic_read.png') ?>" style="float: left; margin-top: 8px;" alt="<?=$this->getTrans('read') ?>">
-                        <?php else: ?>
-                            <img src="<?=$this->getStaticUrl('../application/modules/forum/static/img/topic_unread.png') ?>" style="float: left; margin-top: 8px;" alt="<?=$this->getTrans('unread') ?>">
-                        <?php endif; ?>
-                    <?php else: ?>
+        <?php foreach ($this->get('lastActiveTopicsToShow') as $topic): ?>
+            <li style="line-height: 15px;">
+                <?php if ($this->getUser()): ?>
+                    <?php if ($topic['lastPost']->getRead()): ?>
                         <img src="<?=$this->getStaticUrl('../application/modules/forum/static/img/topic_read.png') ?>" style="float: left; margin-top: 8px;" alt="<?=$this->getTrans('read') ?>">
+                    <?php else: ?>
+                        <img src="<?=$this->getStaticUrl('../application/modules/forum/static/img/topic_unread.png') ?>" style="float: left; margin-top: 8px;" alt="<?=$this->getTrans('unread') ?>">
                     <?php endif; ?>
-                    <a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'showposts', 'action' => 'index', 'topicid' => $topic['topic_id'], 'page' => ($DESCPostorder ? 1 : ceil($countPosts / $postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
-                        <?=$this->escape($topic['topic_title']) ?>
-                    </a>
-                    <br />
-                    <small>
-                        <?php $date = new Date($lastPost->getDateCreated()); ?>
-                        <?=$this->getTrans('by') ?> <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>"><?=$this->escape($lastPost->getAutor()->getName()) ?></a><br>
-                        <?=$date->format('d.m.y - H:i', true) ?> <?=$this->getTrans('clock') ?>
-                    </small>
-                </li>
-            <?php endif; ?>
+                <?php else: ?>
+                    <img src="<?=$this->getStaticUrl('../application/modules/forum/static/img/topic_read.png') ?>" style="float: left; margin-top: 8px;" alt="<?=$this->getTrans('read') ?>">
+                <?php endif; ?>
+                <a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'showposts', 'action' => 'index', 'topicid' => $topic['topicId'], 'page' => ($DESCPostorder ? 1 : ceil($topic['countPosts'] / $postsPerPage))]) ?>#<?=$topic['lastPost']->getId() ?>">
+                    <?=$this->escape($topic['topicTitle']) ?>
+                </a>
+                <br />
+                <small>
+                    <?php $date = new Date($topic['lastPost']->getDateCreated()); ?>
+                    <?=$this->getTrans('by') ?> <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['lastPost']->getAutor()->getId()]) ?>"><?=$this->escape($topic['lastPost']->getAutor()->getName()) ?></a><br>
+                    <?=$date->format('d.m.y - H:i', true) ?> <?=$this->getTrans('clock') ?>
+                </small>
+            </li>
         <?php endforeach; ?>
     </ul>
 <?php else: ?>

--- a/application/modules/forum/boxes/views/forum.php
+++ b/application/modules/forum/boxes/views/forum.php
@@ -1,22 +1,24 @@
 <?php
 
+/** @var \Ilch\View $this */
+
 use Ilch\Date;
 
 $DESCPostorder = $this->get('DESCPostorder');
 $postsPerPage = $this->get('postsPerPage');
 ?>
 
-<?php if (!empty($this->get('lastActiveTopicsToShow'))): ?>
+<?php if (!empty($this->get('lastActiveTopicsToShow'))) : ?>
     <ul class="list-unstyled">
-        <?php foreach ($this->get('lastActiveTopicsToShow') as $topic): ?>
+        <?php foreach ($this->get('lastActiveTopicsToShow') as $topic) : ?>
             <li style="line-height: 15px;">
-                <?php if ($this->getUser()): ?>
-                    <?php if ($topic['lastPost']->getRead()): ?>
+                <?php if ($this->getUser()) : ?>
+                    <?php if ($topic['lastPost']->getRead()) : ?>
                         <img src="<?=$this->getStaticUrl('../application/modules/forum/static/img/topic_read.png') ?>" style="float: left; margin-top: 8px;" alt="<?=$this->getTrans('read') ?>">
-                    <?php else: ?>
+                    <?php else : ?>
                         <img src="<?=$this->getStaticUrl('../application/modules/forum/static/img/topic_unread.png') ?>" style="float: left; margin-top: 8px;" alt="<?=$this->getTrans('unread') ?>">
                     <?php endif; ?>
-                <?php else: ?>
+                <?php else : ?>
                     <img src="<?=$this->getStaticUrl('../application/modules/forum/static/img/topic_read.png') ?>" style="float: left; margin-top: 8px;" alt="<?=$this->getTrans('read') ?>">
                 <?php endif; ?>
                 <a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'showposts', 'action' => 'index', 'topicid' => $topic['topicId'], 'page' => ($DESCPostorder ? 1 : ceil($topic['countPosts'] / $postsPerPage))]) ?>#<?=$topic['lastPost']->getId() ?>">
@@ -31,6 +33,6 @@ $postsPerPage = $this->get('postsPerPage');
             </li>
         <?php endforeach; ?>
     </ul>
-<?php else: ?>
+<?php else : ?>
     <?=$this->getTrans('noPosts') ?>
 <?php endif; ?>

--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -59,8 +60,8 @@ class Config extends \Ilch\Config\Install
         $databaseConfig->set('forum_groupAppearance', json_encode($appearance));
 
         $defaultCss = '#forum .appearance1 {color: #000000;font-weight: bold;}';
-        $filename = uniqid().'.css';
-        file_put_contents(APPLICATION_PATH.'/modules/forum/static/css/groupappearance/'.$filename, $defaultCss);
+        $filename = uniqid() . '.css';
+        file_put_contents(APPLICATION_PATH . '/modules/forum/static/css/groupappearance/' . $filename, $defaultCss);
         $databaseConfig->set('forum_filenameGroupappearanceCSS', $filename);
 
         $this->db()->query('INSERT INTO `[prefix]_forum_groupranking` (`group_id`,`rank`) VALUES(1,0);');
@@ -284,7 +285,7 @@ class Config extends \Ilch\Config\Install
                       <p>Administrator</p>", "en_EN");';
     }
 
-    public function getUpdate($installedVersion)
+    public function getUpdate(string $installedVersion): string
     {
         //Workaround to fix 1.1 and 1.10 being considered equal.
         if ($installedVersion == "1.10") {
@@ -344,7 +345,7 @@ class Config extends \Ilch\Config\Install
                 $this->db()->query('ALTER TABLE `[prefix]_forum_ranks` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
 
                 // Delete no longer needed file.
-                unlink(ROOT_PATH.'/application/modules/forum/controllers/admin/Base.php');
+                unlink(ROOT_PATH . '/application/modules/forum/controllers/admin/Base.php');
                 // no break
             case "1.11.0":
             case "1.12.0":
@@ -361,8 +362,8 @@ class Config extends \Ilch\Config\Install
                 $databaseConfig->set('forum_groupAppearance', serialize($appearance));
 
                 $defaultCss = '#forum .appearance1 {color: #000000;font-weight: bold;}';
-                $filename = uniqid().'.css';
-                file_put_contents(APPLICATION_PATH.'/modules/forum/static/css/groupappearance/'.$filename, $defaultCss);
+                $filename = uniqid() . '.css';
+                file_put_contents(APPLICATION_PATH . '/modules/forum/static/css/groupappearance/' . $filename, $defaultCss);
                 $databaseConfig->set('forum_filenameGroupappearanceCSS', $filename);
 
                 // Add table for group ranking, which is needed when deciding which appearance needs to be applied.
@@ -442,8 +443,8 @@ class Config extends \Ilch\Config\Install
                               <p>Administrator</p>", "en_EN");');
 
                 // Create possibly missing "groupappearance"-directory and default CSS.
-                if (!file_exists(APPLICATION_PATH.'/modules/forum/static/css/groupappearance')) {
-                    mkdir(APPLICATION_PATH.'/modules/forum/static/css/groupappearance');
+                if (!file_exists(APPLICATION_PATH . '/modules/forum/static/css/groupappearance')) {
+                    mkdir(APPLICATION_PATH . '/modules/forum/static/css/groupappearance');
 
                     // Add default appearance for admin group
                     $databaseConfig = new \Ilch\Config\Database($this->db());
@@ -453,8 +454,8 @@ class Config extends \Ilch\Config\Install
                     $databaseConfig->set('forum_groupAppearance', serialize($appearance));
 
                     $defaultCss = '#forum .appearance1 {color: #000000;font-weight: bold;}';
-                    $filename = uniqid().'.css';
-                    file_put_contents(APPLICATION_PATH.'/modules/forum/static/css/groupappearance/'.$filename, $defaultCss);
+                    $filename = uniqid() . '.css';
+                    file_put_contents(APPLICATION_PATH . '/modules/forum/static/css/groupappearance/' . $filename, $defaultCss);
                     $databaseConfig->set('forum_filenameGroupappearanceCSS', $filename);
                 }
                 // no break
@@ -566,9 +567,9 @@ class Config extends \Ilch\Config\Install
                         ->execute()
                         ->fetchList();
 
-                    foreach($currentAccesses as $item_id => $accesses) {
+                    foreach ($currentAccesses as $item_id => $accesses) {
                         // Prepare rows for inserting them in chunks later. Remove potential duplicates and group ids of groups that no longer exist.
-                        foreach($columns as $column) {
+                        foreach ($columns as $column) {
                             $groupIds = array_intersect(array_unique(explode(',', $accesses[$column])), $existingGroupIds);
 
                             foreach ($groupIds as $groupId) {

--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'forum',
-        'version' => '1.34.1',
+        'version' => '1.34.2',
         'icon_small' => 'fa-solid fa-list',
         'author' => 'Stantin Thomas',
         'link' => 'https://ilch.de',
@@ -789,13 +789,17 @@ class Config extends \Ilch\Config\Install
                 }
 
                 // Change the order of column 'forum_id' of the tables 'forum_posts' and 'forum_topics'. Move them closer to the front.
-                $this->db()->query('ALTER TABLE `[prefix]_forum_posts` CHANGE COLUMN `forum_id` `forum_id` INT(11) NOT NULL DEFAULT 0 AFTER `topic_id`;');
-                $this->db()->query('ALTER TABLE `[prefix]_forum_topics` CHANGE COLUMN `forum_id` `forum_id` INT(11) NOT NULL AFTER `id`;');
+                $this->db()->query('ALTER TABLE `[prefix]_forum_posts` CHANGE COLUMN `forum_id` INT(11) NOT NULL DEFAULT 0 AFTER `topic_id`;');
+                $this->db()->query('ALTER TABLE `[prefix]_forum_topics` CHANGE COLUMN `forum_id` INT(11) NOT NULL AFTER `id`;');
 
                 $this->db()->query('ALTER TABLE `[prefix]_forum_posts` ADD CONSTRAINT `FK_[prefix]_forum_posts_[prefix]_forum_items` FOREIGN KEY (`forum_id`) REFERENCES `[prefix]_forum_items` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
                 $this->db()->query('ALTER TABLE `[prefix]_forum_topics` ADD CONSTRAINT `FK_[prefix]_forum_topics_[prefix]_forum_items` FOREIGN KEY (`forum_id`) REFERENCES `[prefix]_forum_items` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
 
                 // no break
+            case "1.34.1":
+                // no break
         }
+
+        return '"' . $this->config['key'] . '" Update function executed.';
     }
 }

--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -789,8 +789,8 @@ class Config extends \Ilch\Config\Install
                 }
 
                 // Change the order of column 'forum_id' of the tables 'forum_posts' and 'forum_topics'. Move them closer to the front.
-                $this->db()->query('ALTER TABLE `[prefix]_forum_posts` CHANGE COLUMN `forum_id` INT(11) NOT NULL DEFAULT 0 AFTER `topic_id`;');
-                $this->db()->query('ALTER TABLE `[prefix]_forum_topics` CHANGE COLUMN `forum_id` INT(11) NOT NULL AFTER `id`;');
+                $this->db()->query('ALTER TABLE `[prefix]_forum_posts` CHANGE COLUMN `forum_id` `forum_id` INT(11) NOT NULL DEFAULT 0 AFTER `topic_id`;');
+                $this->db()->query('ALTER TABLE `[prefix]_forum_topics` CHANGE COLUMN `forum_id` `forum_id` INT(11) NOT NULL AFTER `id`;');
 
                 $this->db()->query('ALTER TABLE `[prefix]_forum_posts` ADD CONSTRAINT `FK_[prefix]_forum_posts_[prefix]_forum_items` FOREIGN KEY (`forum_id`) REFERENCES `[prefix]_forum_items` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
                 $this->db()->query('ALTER TABLE `[prefix]_forum_topics` ADD CONSTRAINT `FK_[prefix]_forum_topics_[prefix]_forum_items` FOREIGN KEY (`forum_id`) REFERENCES `[prefix]_forum_items` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');

--- a/application/modules/forum/controllers/Edittopic.php
+++ b/application/modules/forum/controllers/Edittopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/controllers/Edittopic.php
+++ b/application/modules/forum/controllers/Edittopic.php
@@ -8,7 +8,6 @@ namespace Modules\Forum\Controllers;
 
 use Ilch\Controller\Frontend;
 use Modules\Forum\Mappers\Forum as ForumMapper;
-use Modules\User\Mappers\User as UserMapper;
 use Modules\Forum\Mappers\Topic as TopicMapper;
 use Modules\Forum\Models\ForumTopic as TopicModel;
 use Modules\Forum\Mappers\Post as PostMapper;
@@ -18,25 +17,12 @@ class Edittopic extends Frontend
 {
     public function indexAction()
     {
-        $userMapper = new UserMapper();
         $forumMapper = new ForumMapper();
-        $forumItems = $forumMapper->getForumItemsByParent(0);
 
+        $user = null;
         $forumId = $this->getRequest()->getParam('forumid');
-        $forum = $forumMapper->getForumById($forumId);
+        $forum = $forumMapper->getForumByIdUser($forumId, $this->getUser());
         $cat = $forumMapper->getCatByParentId($forum->getParentId());
-
-        $groupIds = [3];
-
-        if ($this->getUser()) {
-            $userId = $this->getUser()->getId();
-            $user = $userMapper->getUserById($userId);
-
-            $groupIds = [];
-            foreach ($user->getGroups() as $groups) {
-                $groupIds[] = $groups->getId();
-            }
-        }
 
         $this->getLayout()->getTitle()
             ->add($this->getTranslator()->trans('forum'))
@@ -79,8 +65,7 @@ class Edittopic extends Frontend
             }
         }
 
-        $this->getView()->set('groupIdsArray', $groupIds)
-            ->set('forumItems', $forumItems)
+        $this->getView()->set('forumItems', $forumMapper->getForumItemsByParentIdsUser([0], $user))
             ->set('editTopicItems', $this->getRequest()->getPost('check_topics'));
     }
 

--- a/application/modules/forum/controllers/Index.php
+++ b/application/modules/forum/controllers/Index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -41,7 +42,7 @@ class Index extends Frontend
         if (!empty($this->getConfig()->get('forum_filenameGroupappearanceCSS'))) {
             $linkTagModel = new LinkTagModel();
             $linkTagModel->setRel('stylesheet')
-                ->setHref($this->getLayout()->getModuleUrl('static/css/groupappearance/'.$this->getConfig()->get('forum_filenameGroupappearanceCSS')));
+                ->setHref($this->getLayout()->getModuleUrl('static/css/groupappearance/' . $this->getConfig()->get('forum_filenameGroupappearanceCSS')));
             $this->getLayout()->add('linkTags', 'groupappearance', $linkTagModel);
         }
 
@@ -60,7 +61,7 @@ class Index extends Frontend
         }
 
         $forumIds = [];
-        foreach($forumItems as $forumItem) {
+        foreach ($forumItems as $forumItem) {
             $forumIds[] = $forumItem->getId();
         }
 

--- a/application/modules/forum/controllers/Index.php
+++ b/application/modules/forum/controllers/Index.php
@@ -33,21 +33,10 @@ class Index extends Frontend
         $this->getLayout()->getHmenu()
             ->add($this->getTranslator()->trans('forum'), ['action' => 'index']);
 
-        $forumItems = $forumMapper->getForumItemsByParent(0, ($this->getUser()) ? $this->getUser()->getId() : null);
         $whoWasOnlineUsers = $visitMapper->getWhoWasOnline();
         $allOnlineUsers = $visitMapper->getVisitsCountOnline();
         $usersOnline = $visitMapper->getVisitsOnlineUser();
-
-        $groupIds = [3];
-        if ($this->getUser()) {
-            $userId = $this->getUser()->getId();
-            $user = $userMapper->getUserById($userId);
-
-            $groupIds = [];
-            foreach ($user->getGroups() as $groups) {
-                $groupIds[] = $groups->getId();
-            }
-        }
+        $forumItems = $forumMapper->getForumItemsByParentIdsUser([0], $this->getUser());
 
         if (!empty($this->getConfig()->get('forum_filenameGroupappearanceCSS'))) {
             $linkTagModel = new LinkTagModel();
@@ -75,8 +64,7 @@ class Index extends Frontend
             $forumIds[] = $forumItem->getId();
         }
 
-        $this->getView()->set('groupIdsArray', $groupIds)
-            ->set('onlineUsersHighestRankedGroup', $onlineUsersHighestRankedGroup)
+        $this->getView()->set('onlineUsersHighestRankedGroup', $onlineUsersHighestRankedGroup)
             ->set('forumItems', $forumItems)
             ->set('usersOnlineList', $usersOnline)
             ->set('usersWhoWasOnline', $whoWasOnlineUsers)
@@ -96,20 +84,13 @@ class Index extends Frontend
         if ($this->getUser() && $this->getRequest()->isSecure()) {
             $forumMapper = new ForumMapper();
             $trackRead = new TrackRead();
-            $userMapper = new UserMapper();
 
             $adminAccess = $this->getUser()->isAdmin();
             $forumIds = [];
-            $user = $userMapper->getUserById($this->getUser()->getId());
 
-            $groupIds = [];
-            foreach ($user->getGroups() as $groups) {
-                $groupIds[] = $groups->getId();
-            }
-
-            foreach ($forumMapper->getForumItems() as $forumItem) {
+            foreach ($forumMapper->getForumItemsUser($this->getUser()) as $forumItem) {
                 // If it is a forum and the user is either admin or has read access then the forum can be marked as read.
-                if ($forumItem->getType() === 1 && $adminAccess || is_in_array($groupIds, explode(',', $forumItem->getReadAccess()))) {
+                if ($forumItem->getType() === 1 && $adminAccess || $forumItem->getReadAccess()) {
                     $forumIds[] = $forumItem->getId();
                 }
             }

--- a/application/modules/forum/controllers/Newpost.php
+++ b/application/modules/forum/controllers/Newpost.php
@@ -13,7 +13,6 @@ use Modules\Forum\Mappers\Post as PostMapper;
 use Modules\Forum\Mappers\Topic as TopicMapper;
 use Modules\Forum\Mappers\Forum as ForumMapper;
 use Modules\Forum\Mappers\TrackRead as TrackReadMapper;
-use Modules\User\Mappers\User as UserMapper;
 use Modules\Forum\Mappers\TopicSubscription as TopicSubscriptionMapper;
 use Modules\Admin\Mappers\Emails as EmailsMapper;
 use Modules\Forum\Models\ForumPost as ForumPostModel;
@@ -75,17 +74,9 @@ class Newpost extends Frontend
             // If that is not the case then don't even bother checking the rights
             // as the URL is invalid anyway.
             if ($post->getForumId() == $forum->getId()) {
-                $userMapper = new UserMapper();
-
-                $userId = null;
-                if ($this->getUser()) {
-                    $userId = $this->getUser()->getId();
-                }
-                $user = $userMapper->getUserById($userId);
-
                 $readAccess = [3];
-                if ($user) {
-                    foreach ($user->getGroups() as $us) {
+                if ($this->getUser()) {
+                    foreach ($this->getUser()->getGroups() as $us) {
                         $readAccess[] = $us->getId();
                     }
                 }

--- a/application/modules/forum/controllers/Newpost.php
+++ b/application/modules/forum/controllers/Newpost.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -105,7 +106,7 @@ class Newpost extends Frontend
                 $isExcludedFromFloodProtection = is_in_array(array_keys($this->getUser()->getGroups()), explode(',', $this->getConfig()->get('forum_excludeFloodProtection')));
             }
 
-            if ($this->getUser() && !$isExcludedFromFloodProtection && ($dateCreated >= date('Y-m-d H:i:s', time()-$this->getConfig()->get('forum_floodInterval')))) {
+            if ($this->getUser() && !$isExcludedFromFloodProtection && ($dateCreated >= date('Y-m-d H:i:s', time() - $this->getConfig()->get('forum_floodInterval')))) {
                 $this->addMessage('floodError', 'danger');
                 $this->redirect()
                     ->withInput()
@@ -162,10 +163,10 @@ class Newpost extends Frontend
                         $date = new Date();
                         $mailContent = $emailsMapper->getEmail('forum', 'topic_subscription_mail', $this->getTranslator()->getLocale());
                         $layout = $_SESSION['layout'] ?? '';
-                        if ($layout == $this->getConfig()->get('default_layout') && file_exists(APPLICATION_PATH.'/layouts/'.$this->getConfig()->get('default_layout').'/views/modules/forum/layouts/mail/topicsubscription.php')) {
-                            $messageTemplate = file_get_contents(APPLICATION_PATH.'/layouts/'.$this->getConfig()->get('default_layout').'/views/modules/forum/layouts/mail/topicsubscription.php');
+                        if ($layout == $this->getConfig()->get('default_layout') && file_exists(APPLICATION_PATH . '/layouts/' . $this->getConfig()->get('default_layout') . '/views/modules/forum/layouts/mail/topicsubscription.php')) {
+                            $messageTemplate = file_get_contents(APPLICATION_PATH . '/layouts/' . $this->getConfig()->get('default_layout') . '/views/modules/forum/layouts/mail/topicsubscription.php');
                         } else {
-                            $messageTemplate = file_get_contents(APPLICATION_PATH.'/modules/forum/layouts/mail/topicsubscription.php');
+                            $messageTemplate = file_get_contents(APPLICATION_PATH . '/modules/forum/layouts/mail/topicsubscription.php');
                         }
                         $messageReplace = [
                             '{content}' => $this->getLayout()->purify($mailContent->getText()),

--- a/application/modules/forum/controllers/Newtopic.php
+++ b/application/modules/forum/controllers/Newtopic.php
@@ -13,7 +13,6 @@ use Modules\Forum\Mappers\Topic as TopicMapper;
 use Modules\Forum\Models\ForumTopic as ForumTopicModel;
 use Modules\Forum\Mappers\Post as PostMapper;
 use Modules\Forum\Models\ForumPost as ForumPostModel;
-use Modules\User\Mappers\User as UserMapper;
 use Ilch\Validation;
 
 class Newtopic extends Frontend
@@ -29,7 +28,7 @@ class Newtopic extends Frontend
                 ->to(['controller' => 'index', 'action' => 'index']);
         }
 
-        $forum = $forumMapper->getForumById($id);
+        $forum = $forumMapper->getForumByIdUser($id, $this->getUser());
 
         if (!$forum) {
             $this->redirect()
@@ -40,16 +39,16 @@ class Newtopic extends Frontend
         $cat = $forumMapper->getCatByParentId($forum->getParentId());
 
         $this->getLayout()->getTitle()
-                ->add($this->getTranslator()->trans('forum'))
-                ->add($cat->getTitle())
-                ->add($forum->getTitle())
-                ->add($this->getTranslator()->trans('newTopicTitle'));
+            ->add($this->getTranslator()->trans('forum'))
+            ->add($cat->getTitle())
+            ->add($forum->getTitle())
+            ->add($this->getTranslator()->trans('newTopicTitle'));
         $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('forum').' - '.$forum->getDesc());
         $this->getLayout()->getHmenu()
-                ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
-                ->add($cat->getTitle(), ['controller' => 'showcat','action' => 'index', 'id' => $cat->getId()])
-                ->add($forum->getTitle(), ['controller' => 'showtopics', 'action' => 'index', 'forumid' => $id])
-                ->add($this->getTranslator()->trans('newTopicTitle'), ['controller' => 'newtopic','action' => 'index', 'id' => $id]);
+            ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
+            ->add($cat->getTitle(), ['controller' => 'showcat','action' => 'index', 'id' => $cat->getId()])
+            ->add($forum->getTitle(), ['controller' => 'showtopics', 'action' => 'index', 'forumid' => $id])
+            ->add($this->getTranslator()->trans('newTopicTitle'), ['controller' => 'newtopic','action' => 'index', 'id' => $id]);
 
         if ($this->getRequest()->getPost('saveNewTopic')) {
             $postMapper = new PostMapper();
@@ -100,20 +99,6 @@ class Newtopic extends Frontend
             }
         }
 
-        $userMapper = new UserMapper();
-        $user = null;
-        if ($this->getUser()) {
-            $user = $userMapper->getUserById($this->getUser()->getId());
-        }
-
-        $readAccess = [3];
-        if ($user) {
-            foreach ($user->getGroups() as $us) {
-                $readAccess[] = $us->getId();
-            }
-        }
-
-        $this->getView()->set('readAccess', $readAccess);
         $this->getView()->set('cat', $cat);
         $this->getView()->set('forum', $forum);
     }

--- a/application/modules/forum/controllers/Newtopic.php
+++ b/application/modules/forum/controllers/Newtopic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -43,7 +44,7 @@ class Newtopic extends Frontend
             ->add($cat->getTitle())
             ->add($forum->getTitle())
             ->add($this->getTranslator()->trans('newTopicTitle'));
-        $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('forum').' - '.$forum->getDesc());
+        $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('forum') . ' - ' . $forum->getDesc());
         $this->getLayout()->getHmenu()
             ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
             ->add($cat->getTitle(), ['controller' => 'showcat','action' => 'index', 'id' => $cat->getId()])
@@ -55,7 +56,7 @@ class Newtopic extends Frontend
             $dateCreated = $postMapper->getDateOfLastPostByUserId($this->getUser()->getId());
             $isExcludedFromFloodProtection = is_in_array(array_keys($this->getUser()->getGroups()), explode(',', $this->getConfig()->get('forum_excludeFloodProtection')));
 
-            if (!$isExcludedFromFloodProtection && ($dateCreated >= date('Y-m-d H:i:s', time()-$this->getConfig()->get('forum_floodInterval')))) {
+            if (!$isExcludedFromFloodProtection && ($dateCreated >= date('Y-m-d H:i:s', time() - $this->getConfig()->get('forum_floodInterval')))) {
                 $this->addMessage('floodError', 'danger');
                 $this->redirect()
                     ->withInput()

--- a/application/modules/forum/controllers/Rememberedposts.php
+++ b/application/modules/forum/controllers/Rememberedposts.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/controllers/Showactivetopics.php
+++ b/application/modules/forum/controllers/Showactivetopics.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/controllers/Showactivetopics.php
+++ b/application/modules/forum/controllers/Showactivetopics.php
@@ -32,17 +32,23 @@ class Showactivetopics extends Frontend
         $forums = $forumMapper->getForumItemsUser($this->getUser());
         $topics = $topicMapper->getTopicsByForumIds(array_keys($forums));
 
+        $topicIds = [];
         $topicsToShow = [];
         foreach ($topics as $topic) {
             if ($isAdmin || $forums[$topic->getForumId()]->getReadAccess()) {
-                $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId());
-                if ($lastPost->getDateCreated() < $date->format('Y-m-d H:i:s', true) && $lastPost->getDateCreated() > $dateLessHours->format('Y-m-d H:i:s', true)) {
-                    $topicsToShow[] = [
-                        'topic' => $topic,
-                        'forumPrefix' => $forums[$topic->getForumId()]->getPrefix(),
-                        'lastPost' => $lastPost,
-                    ];
-                }
+                $topicIds[] = $topic->getId();
+            }
+        }
+
+        $posts = $topicMapper->getLastPostsByTopicIds($topicIds, ($this->getUser()) ? $this->getUser()->getId() : null);
+
+        foreach ($posts as $post) {
+            if ($post->getDateCreated() < $date->format('Y-m-d H:i:s', true) && $post->getDateCreated() > $dateLessHours->format('Y-m-d H:i:s', true)) {
+                $topicsToShow[] = [
+                    'topic' => $topics[$post->getTopicId()],
+                    'forumPrefix' => $forums[$topics[$post->getTopicId()]->getForumId()]->getPrefix(),
+                    'lastPost' => $post,
+                ];
             }
         }
 

--- a/application/modules/forum/controllers/Showactivetopics.php
+++ b/application/modules/forum/controllers/Showactivetopics.php
@@ -7,10 +7,9 @@
 namespace Modules\Forum\Controllers;
 
 use Ilch\Controller\Frontend;
+use Ilch\Date;
 use Modules\Forum\Mappers\Forum as ForumMapper;
 use Modules\Forum\Mappers\Topic as TopicMapper;
-use Modules\Forum\Mappers\Post as PostMapper;
-use Modules\User\Mappers\User as UserMapper;
 
 class Showactivetopics extends Frontend
 {
@@ -18,37 +17,36 @@ class Showactivetopics extends Frontend
     {
         $forumMapper = new ForumMapper();
         $topicMapper = new TopicMapper();
-        $postMapper = new PostMapper();
-        $userMapper = new UserMapper();
+        $date = new Date();
+        $dateLessHours = new Date('-1 day');
 
-        $userId = null;
-        $groupIds = [3];
+        $this->getLayout()->getTitle()
+            ->add($this->getTranslator()->trans('forum'))
+            ->add($this->getTranslator()->trans('showActiveTopics'));
+        $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('showActiveTopics'));
+        $this->getLayout()->getHmenu()
+            ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
+            ->add($this->getTranslator()->trans('showActiveTopics'), ['action' => 'index']);
 
-        if ($this->getUser()) {
-            $userId = $this->getUser()->getId();
-        }
-        $user = $userMapper->getUserById($userId);
+        $isAdmin = $this->getUser() && $this->getUser()->isAdmin();
+        $forums = $forumMapper->getForumItemsUser($this->getUser());
+        $topics = $topicMapper->getTopicsByForumIds(array_keys($forums));
 
-        if ($this->getUser()) {
-            $groupIds = [];
-            foreach ($user->getGroups() as $groups) {
-                $groupIds[] = $groups->getId();
+        $topicsToShow = [];
+        foreach ($topics as $topic) {
+            if ($isAdmin || $forums[$topic->getForumId()]->getReadAccess()) {
+                $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId());
+                if ($lastPost->getDateCreated() < $date->format('Y-m-d H:i:s', true) && $lastPost->getDateCreated() > $dateLessHours->format('Y-m-d H:i:s', true)) {
+                    $topicsToShow[] = [
+                        'topic' => $topic,
+                        'forumPrefix' => $forums[$topic->getForumId()]->getPrefix(),
+                        'lastPost' => $lastPost,
+                    ];
+                }
             }
         }
 
-        $this->getLayout()->getTitle()
-                ->add($this->getTranslator()->trans('forum'))
-                ->add($this->getTranslator()->trans('showActiveTopics'));
-        $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('showActiveTopics'));
-        $this->getLayout()->getHmenu()
-                ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
-                ->add($this->getTranslator()->trans('showActiveTopics'), ['action' => 'index']);
-
-        $this->getView()->set('forumMapper', $forumMapper);
-        $this->getView()->set('topicMapper', $topicMapper);
-        $this->getView()->set('postMapper', $postMapper);
-        $this->getView()->set('topics', $topicMapper->getTopics());
-        $this->getView()->set('groupIdsArray', $groupIds);
+        $this->getView()->set('topics', $topicsToShow);
         $this->getView()->set('DESCPostorder', $this->getConfig()->get('forum_DESCPostorder'));
         $this->getView()->set('postsPerPage', !$this->getConfig()->get('forum_postsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
     }

--- a/application/modules/forum/controllers/Showcat.php
+++ b/application/modules/forum/controllers/Showcat.php
@@ -9,14 +9,12 @@ namespace Modules\Forum\Controllers;
 use Ilch\Controller\Frontend;
 use Modules\Forum\Mappers\Forum as ForumMapper;
 use Modules\Forum\Mappers\TrackRead;
-use Modules\User\Mappers\User as UserMapper;
 
 class Showcat extends Frontend
 {
     public function indexAction()
     {
         $forumMapper = new ForumMapper();
-        $userMapper = new UserMapper();
 
         $catId = $this->getRequest()->getParam('id');
         if (empty($catId) || !is_numeric($catId)) {
@@ -30,8 +28,6 @@ class Showcat extends Frontend
             return;
         }
 
-        $forumItems = $forumMapper->getForumItemsByParent($catId, ($this->getUser()) ? $this->getUser()->getId() : null);
-
         $this->getLayout()->getTitle()
                 ->add($this->getTranslator()->trans('forum'))
                 ->add($cat->getTitle());
@@ -40,17 +36,7 @@ class Showcat extends Frontend
                 ->add($this->getTranslator()->trans('forum'), ['controller' => 'index','action' => 'index'])
                 ->add($cat->getTitle(), ['controller' => 'showcat','action' => 'index', 'id' => $cat->getId()]);
 
-        $user = null;
-        if ($this->getUser()) {
-            $user = $userMapper->getUserById($this->getUser()->getId());
-        }
-
-        $readAccess = [3];
-        if ($user) {
-            foreach ($user->getGroups() as $us) {
-                $readAccess[] = $us->getId();
-            }
-        }
+        $forumItems = $forumMapper->getForumItemsByParentIdsUser([$catId], $this->getUser());
 
         $forumIds = [];
         foreach($forumItems as $forumItem) {
@@ -61,7 +47,6 @@ class Showcat extends Frontend
         $this->getView()->set('forumMapper', $forumMapper);
         $this->getView()->set('cat', $cat);
         $this->getView()->set('containsUnreadTopics', ($this->getUser()) ? $forumMapper->getListOfForumIdsWithUnreadTopics($this->getUser()->getId(), $forumIds) : []);
-        $this->getView()->set('readAccess', $readAccess);
         $this->getView()->set('DESCPostorder', $this->getConfig()->get('forum_DESCPostorder'));
         $this->getView()->set('postsPerPage', !$this->getConfig()->get('forum_postsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
     }
@@ -71,20 +56,13 @@ class Showcat extends Frontend
         if ($this->getUser() && $this->getRequest()->isSecure()) {
             $forumMapper = new ForumMapper();
             $trackRead = new TrackRead();
-            $userMapper = new UserMapper();
 
             $adminAccess = $this->getUser()->isAdmin();
             $forumIds = [];
-            $user = $userMapper->getUserById($this->getUser()->getId());
 
-            $groupIds = [];
-            foreach ($user->getGroups() as $groups) {
-                $groupIds[] = $groups->getId();
-            }
-
-            foreach ($forumMapper->getForumItemsByParent($this->getRequest()->getParam('id') ?? 0) as $forumItem) {
+            foreach ($forumMapper->getForumItemsByParentIdsUser([$this->getRequest()->getParam('id')] ?? [0], $this->getUser()) as $forumItem) {
                 // If it is a forum and the user is either admin or has read access then the forum can be marked as read.
-                if ($forumItem->getType() === 1 && $adminAccess || is_in_array($groupIds, explode(',', $forumItem->getReadAccess()))) {
+                if ($forumItem->getType() === 1 && $adminAccess || $forumItem->getReadAccess()) {
                     $forumIds[] = $forumItem->getId();
                 }
             }

--- a/application/modules/forum/controllers/Showcat.php
+++ b/application/modules/forum/controllers/Showcat.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -39,7 +40,7 @@ class Showcat extends Frontend
         $forumItems = $forumMapper->getForumItemsByParentIdsUser([$catId], $this->getUser());
 
         $forumIds = [];
-        foreach($forumItems as $forumItem) {
+        foreach ($forumItems as $forumItem) {
             $forumIds[] = $forumItem->getId();
         }
 

--- a/application/modules/forum/controllers/Shownewposts.php
+++ b/application/modules/forum/controllers/Shownewposts.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/controllers/Shownewposts.php
+++ b/application/modules/forum/controllers/Shownewposts.php
@@ -31,18 +31,23 @@ class Shownewposts extends Frontend
             $forums = $forumMapper->getForumItemsUser($this->getUser());
             $topics = $topicMapper->getTopicsByForumIds(array_keys($forums));
 
+            $topicIds = [];
             $topicsToShow = [];
             foreach ($topics as $topic) {
                 if ($isAdmin || $forums[$topic->getForumId()]->getReadAccess()) {
-                    $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId());
+                    $topicIds[] = $topic->getId();
+                }
+            }
 
-                    if (!$lastPost->getRead()) {
-                        $topicsToShow[] = [
-                            'topic' => $topic,
-                            'forumPrefix' => $forums[$topic->getForumId()]->getPrefix(),
-                            'lastPost' => $lastPost,
-                        ];
-                    }
+            $posts = $topicMapper->getLastPostsByTopicIds($topicIds, ($this->getUser()) ? $this->getUser()->getId() : null);
+
+            foreach ($posts as $post) {
+                if (!$post->getRead()) {
+                    $topicsToShow[] = [
+                        'topic' => $topics[$post->getTopicId()],
+                        'forumPrefix' => $forums[$topics[$post->getTopicId()]->getForumId()]->getPrefix(),
+                        'lastPost' => $post,
+                    ];
                 }
             }
 

--- a/application/modules/forum/controllers/Shownewposts.php
+++ b/application/modules/forum/controllers/Shownewposts.php
@@ -9,8 +9,6 @@ namespace Modules\Forum\Controllers;
 use Ilch\Controller\Frontend;
 use Modules\Forum\Mappers\Forum as ForumMapper;
 use Modules\Forum\Mappers\Topic as TopicMapper;
-use Modules\Forum\Mappers\Post as PostMapper;
-use Modules\User\Mappers\User as UserMapper;
 
 class Shownewposts extends Frontend
 {
@@ -19,29 +17,36 @@ class Shownewposts extends Frontend
         if ($this->getUser()) {
             $forumMapper = new ForumMapper();
             $topicMapper = new TopicMapper();
-            $postMapper = new PostMapper();
-            $userMapper = new UserMapper();
-
-            $user = $userMapper->getUserById($this->getUser()->getId());
-
-            $groupIds = [];
-            foreach ($user->getGroups() as $groups) {
-                $groupIds[] = $groups->getId();
-            }
 
             $this->getLayout()->getTitle()
-                    ->add($this->getTranslator()->trans('forum'))
-                    ->add($this->getTranslator()->trans('showNewPosts'));
+                ->add($this->getTranslator()->trans('forum'))
+                ->add($this->getTranslator()->trans('showNewPosts'));
             $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('showNewPosts'));
             $this->getLayout()->getHmenu()
-                    ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
-                    ->add($this->getTranslator()->trans('showNewPosts'), ['action' => 'index']);
+                ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
+                ->add($this->getTranslator()->trans('showNewPosts'), ['action' => 'index']);
 
-            $this->getView()->set('forumMapper', $forumMapper);
-            $this->getView()->set('topicMapper', $topicMapper);
-            $this->getView()->set('postMapper', $postMapper);
-            $this->getView()->set('topics', $topicMapper->getTopics());
-            $this->getView()->set('groupIdsArray', $groupIds);
+            $isAdmin = $this->getUser() && $this->getUser()->isAdmin();
+
+            $forums = $forumMapper->getForumItemsUser($this->getUser());
+            $topics = $topicMapper->getTopicsByForumIds(array_keys($forums));
+
+            $topicsToShow = [];
+            foreach ($topics as $topic) {
+                if ($isAdmin || $forums[$topic->getForumId()]->getReadAccess()) {
+                    $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId());
+
+                    if (!$lastPost->getRead()) {
+                        $topicsToShow[] = [
+                            'topic' => $topic,
+                            'forumPrefix' => $forums[$topic->getForumId()]->getPrefix(),
+                            'lastPost' => $lastPost,
+                        ];
+                    }
+                }
+            }
+
+            $this->getView()->set('topics', $topicsToShow);
             $this->getView()->set('DESCPostorder', $this->getConfig()->get('forum_DESCPostorder'));
             $this->getView()->set('postsPerPage', !$this->getConfig()->get('forum_postsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
         } else {

--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -128,11 +128,11 @@ class Showposts extends Frontend
             $reportedPostsIds[] = $reportedPost->getPostId();
         }
 
-        $this->getView()->set('forumMapper', $forumMapper);
         $this->getView()->set('post', $post);
         $this->getView()->set('cat', $cat);
         $this->getView()->set('posts', $posts);
         $this->getView()->set('forum', $forum);
+        $this->getView()->set('prefix', $prefix);
         $this->getView()->set('pagination', $pagination);
         $this->getView()->set('userAccess', new Accesses($this->getRequest()));
         $this->getView()->set('rankMapper', $rankMapper);

--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -53,7 +53,7 @@ class Showposts extends Frontend
             return;
         }
 
-        $forum = $forumMapper->getForumByTopicId($topicId);
+        $forum = $forumMapper->getForumByTopicIdUser($topicId, $this->getUser());
         if ($forum === null) {
             $this->redirect(['module' => 'error', 'controller' => 'index', 'action' => 'index', 'error' => 'Topic', 'errorText' => 'notFound']);
             return;
@@ -92,14 +92,9 @@ class Showposts extends Frontend
         $topicModel->setVisits($post->getVisits() + 1);
         $topicMapper->saveVisits($topicModel);
 
-        $userMapper = new UserMapper();
-
         $rememberedPostIds = [];
         $isSubscribed = false;
-        $userId = null;
         if ($this->getUser()) {
-            $userId = $this->getUser()->getId();
-
             if (($this->getConfig()->get('forum_DESCPostorder') && $this->getRequest()->getParam('page') == (1 || !$this->getRequest()->getParam('page')))
                 || (!$this->getConfig()->get('forum_DESCPostorder') && ((($this->getRequest()->getParam('page')) ?? 1) == (ceil($pagination->getRows() / $rowsPerPage))))
             ) {
@@ -114,17 +109,9 @@ class Showposts extends Frontend
                 $isSubscribed = $topicSubscriptionMapper->isSubscribedToTopic($topicId, $this->getUser()->getId());
             }
 
-            $rememberedPosts = $rememberMapper->getRememberedPostsByTopicId($topicId, $userId);
+            $rememberedPosts = $rememberMapper->getRememberedPostsByTopicId($topicId, $this->getUser()->getId());
             foreach ($rememberedPosts as $rememberedPost) {
                 $rememberedPostIds[] = $rememberedPost->getPostId();
-            }
-        }
-        $user = $userMapper->getUserById($userId);
-
-        $readAccess = [3];
-        if ($user) {
-            foreach ($user->getGroups() as $us) {
-                $readAccess[] = $us->getId();
             }
         }
 
@@ -146,7 +133,6 @@ class Showposts extends Frontend
         $this->getView()->set('cat', $cat);
         $this->getView()->set('posts', $posts);
         $this->getView()->set('forum', $forum);
-        $this->getView()->set('readAccess', $readAccess);
         $this->getView()->set('pagination', $pagination);
         $this->getView()->set('userAccess', new Accesses($this->getRequest()));
         $this->getView()->set('rankMapper', $rankMapper);

--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -65,10 +65,10 @@ class Showposts extends Frontend
 
         $prefix = '';
         if ($forum->getPrefix() != '' && $post->getTopicPrefix() > 0) {
-            $prefix = explode(',', $forum->getPrefix());
-            array_unshift($prefix, '');
+            $prefixes = explode(',', $forum->getPrefix());
+            array_unshift($prefixes, '');
 
-            foreach ($prefix as $key => $value) {
+            foreach ($prefixes as $key => $value) {
                 if ($post->getTopicPrefix() == $key) {
                     $value = trim($value);
                     $prefix = '[' . $value . '] ';

--- a/application/modules/forum/controllers/Showposts.php
+++ b/application/modules/forum/controllers/Showposts.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -80,13 +81,13 @@ class Showposts extends Frontend
                 ->add($this->getTranslator()->trans('forum'))
                 ->add($cat->getTitle())
                 ->add($forum->getTitle())
-                ->add($prefix.$post->getTopicTitle());
-        $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('forum').' - '.$forum->getDesc());
+                ->add($prefix . $post->getTopicTitle());
+        $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('forum') . ' - ' . $forum->getDesc());
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
                 ->add($cat->getTitle(), ['controller' => 'showcat', 'action' => 'index', 'id' => $cat->getId()])
                 ->add($forum->getTitle(), ['controller' => 'showtopics', 'action' => 'index', 'forumid' => $forum->getId()])
-                ->add($prefix.$post->getTopicTitle(), ['controller' => 'showposts', 'action' => 'index', 'topicid' => $topicId]);
+                ->add($prefix . $post->getTopicTitle(), ['controller' => 'showposts', 'action' => 'index', 'topicid' => $topicId]);
 
         $topicModel->setId($topicId);
         $topicModel->setVisits($post->getVisits() + 1);
@@ -95,7 +96,8 @@ class Showposts extends Frontend
         $rememberedPostIds = [];
         $isSubscribed = false;
         if ($this->getUser()) {
-            if (($this->getConfig()->get('forum_DESCPostorder') && $this->getRequest()->getParam('page') == (1 || !$this->getRequest()->getParam('page')))
+            if (
+                ($this->getConfig()->get('forum_DESCPostorder') && $this->getRequest()->getParam('page') == (1 || !$this->getRequest()->getParam('page')))
                 || (!$this->getConfig()->get('forum_DESCPostorder') && ((($this->getRequest()->getParam('page')) ?? 1) == (ceil($pagination->getRows() / $rowsPerPage))))
             ) {
                 // Mark topic as read if on the last page or on the first page with descending post order.
@@ -118,7 +120,7 @@ class Showposts extends Frontend
         if (!empty($this->getConfig()->get('forum_filenameGroupappearanceCSS'))) {
             $linkTagModel = new LinkTagModel();
             $linkTagModel->setRel('stylesheet')
-                ->setHref($this->getLayout()->getModuleUrl('static/css/groupappearance/'.$this->getConfig()->get('forum_filenameGroupappearanceCSS')));
+                ->setHref($this->getLayout()->getModuleUrl('static/css/groupappearance/' . $this->getConfig()->get('forum_filenameGroupappearanceCSS')));
             $this->getLayout()->add('linkTags', 'groupappearance', $linkTagModel);
         }
 
@@ -134,7 +136,6 @@ class Showposts extends Frontend
         $this->getView()->set('forum', $forum);
         $this->getView()->set('prefix', $prefix);
         $this->getView()->set('pagination', $pagination);
-        $this->getView()->set('userAccess', new Accesses($this->getRequest()));
         $this->getView()->set('rankMapper', $rankMapper);
         $this->getView()->set('postVoting', $this->getConfig()->get('forum_postVoting'));
         $this->getView()->set('topicSubscription', $this->getConfig()->get('forum_topicSubscription'));
@@ -388,10 +389,10 @@ class Showposts extends Frontend
                             $date = new Date();
                             $mailContent = $emailsMapper->getEmail('forum', 'post_reportedPost_mail', $this->getTranslator()->getLocale());
                             $layout = $_SESSION['layout'] ?? '';
-                            if ($layout == $this->getConfig()->get('default_layout') && file_exists(APPLICATION_PATH.'/layouts/'.$this->getConfig()->get('default_layout').'/views/modules/forum/layouts/mail/reportedPost.php')) {
-                                $messageTemplate = file_get_contents(APPLICATION_PATH.'/layouts/'.$this->getConfig()->get('default_layout').'/views/modules/forum/layouts/mail/reportedPost.php');
+                            if ($layout == $this->getConfig()->get('default_layout') && file_exists(APPLICATION_PATH . '/layouts/' . $this->getConfig()->get('default_layout') . '/views/modules/forum/layouts/mail/reportedPost.php')) {
+                                $messageTemplate = file_get_contents(APPLICATION_PATH . '/layouts/' . $this->getConfig()->get('default_layout') . '/views/modules/forum/layouts/mail/reportedPost.php');
                             } else {
-                                $messageTemplate = file_get_contents(APPLICATION_PATH.'/modules/forum/layouts/mail/reportedPost.php');
+                                $messageTemplate = file_get_contents(APPLICATION_PATH . '/modules/forum/layouts/mail/reportedPost.php');
                             }
                             $messageReplace = [
                                 '{content}' => $this->getLayout()->purify($mailContent->getText()),

--- a/application/modules/forum/controllers/Showtopics.php
+++ b/application/modules/forum/controllers/Showtopics.php
@@ -10,9 +10,7 @@ use Ilch\Controller\Frontend;
 use Ilch\Pagination;
 use Modules\Forum\Mappers\Forum as ForumMapper;
 use Modules\Forum\Mappers\Topic as TopicMapper;
-use Modules\Forum\Mappers\Post as PostMapper;
 use Modules\Forum\Mappers\TrackRead;
-use Modules\User\Mappers\User as UserMapper;
 
 class Showtopics extends Frontend
 {
@@ -20,9 +18,7 @@ class Showtopics extends Frontend
     {
         $forumMapper = new ForumMapper();
         $topicMapper = new TopicMapper();
-        $postMapper = new PostMapper();
         $pagination = new Pagination();
-        $userMapper = new UserMapper();
 
         $forumId = $this->getRequest()->getParam('forumid');
         if (empty($forumId) || !is_numeric($forumId)) {
@@ -30,7 +26,7 @@ class Showtopics extends Frontend
             return;
         }
 
-        $forum = $forumMapper->getForumById($forumId);
+        $forum = $forumMapper->getForumByIdUser($forumId, $this->getUser());
         if ($forum === null) {
             $this->redirect(['module' => 'error', 'controller' => 'index', 'action' => 'index', 'error' => 'Forum', 'errorText' => 'notFound']);
             return;
@@ -38,42 +34,27 @@ class Showtopics extends Frontend
 
         $cat = $forumMapper->getCatByParentId($forum->getParentId());
 
-        $groupIds = [3];
-
         if ($this->getRequest()->isPost() && $this->getRequest()->getPost('forumEdit') === 'forumEdit') {
             $this->getView()->set('forumEdit', true);
         }
 
-        if ($this->getUser()) {
-            $userId = $this->getUser()->getId();
-            $user = $userMapper->getUserById($userId);
-
-            $groupIds = [];
-            foreach ($user->getGroups() as $groups) {
-                $groupIds[] = $groups->getId();
-            }
-        }
-
         $this->getLayout()->getTitle()
-                ->add($this->getTranslator()->trans('forum'))
-                ->add($cat->getTitle())
-                ->add($forum->getTitle());
+            ->add($this->getTranslator()->trans('forum'))
+            ->add($cat->getTitle())
+            ->add($forum->getTitle());
         $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('forum').' - '.$forum->getDesc());
         $this->getLayout()->getHmenu()
-                ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
-                ->add($cat->getTitle(), ['controller' => 'showcat','action' => 'index', 'id' => $cat->getId()])
-                ->add($forum->getTitle(), ['action' => 'index', 'forumid' => $forumId]);
+            ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
+            ->add($cat->getTitle(), ['controller' => 'showcat','action' => 'index', 'id' => $cat->getId()])
+            ->add($forum->getTitle(), ['action' => 'index', 'forumid' => $forumId]);
 
         $pagination->setRowsPerPage(!$this->getConfig()->get('forum_threadsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_threadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $this->getView()->set('forum', $forum);
         $this->getView()->set('cat', $cat);
-        $this->getView()->set('forumMapper', $forumMapper);
         $this->getView()->set('topicMapper', $topicMapper);
-        $this->getView()->set('postMapper', $postMapper);
         $this->getView()->set('topics', $topicMapper->getTopicsByForumId($forumId, $pagination));
-        $this->getView()->set('groupIdsArray', $groupIds);
         $this->getView()->set('pagination', $pagination);
         $this->getView()->set('DESCPostorder', $this->getConfig()->get('forum_DESCPostorder'));
         $this->getView()->set('postsPerPage', !$this->getConfig()->get('forum_postsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));
@@ -103,26 +84,16 @@ class Showtopics extends Frontend
             $forumMapper = new ForumMapper();
             $topicMapper = new TopicMapper();
             $trackRead = new TrackRead();
-            $userMapper = new UserMapper();
 
             $adminAccess = $this->getUser()->isAdmin();
             $topicIds = [];
-            $user = $userMapper->getUserById($this->getUser()->getId());
+            $forum = $forumMapper->getForumByIdUser($this->getRequest()->getParam('forumid'), $this->getUser());
 
-            $groupIds = [];
-            foreach ($user->getGroups() as $groups) {
-                $groupIds[] = $groups->getId();
-            }
-
-            $forum = $forumMapper->getForumById($this->getRequest()->getParam('forumid'));
-
-            if (!empty($forum) && $forum->getType() === 1) {
+            // If the topic belongs to a forum and the user is either admin or has read access then the topic can be marked as read.
+            if (!empty($forum) && $forum->getType() === 1 && ($adminAccess || $forum->getReadAccess())) {
                 $topics = $topicMapper->getTopicsByForumId($this->getRequest()->getParam('forumid'));
                 foreach ($topics as $topic) {
-                    // If the topic belongs to a forum and the user is either admin or has read access then the topic can be marked as read.
-                    if ($adminAccess || is_in_array($groupIds, explode(',', $forum->getReadAccess()))) {
-                        $topicIds[] = $topic->getId();
-                    }
+                    $topicIds[] = $topic->getId();
                 }
 
                 if (!empty($topicIds)) {

--- a/application/modules/forum/controllers/Showtopics.php
+++ b/application/modules/forum/controllers/Showtopics.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -42,7 +43,7 @@ class Showtopics extends Frontend
             ->add($this->getTranslator()->trans('forum'))
             ->add($cat->getTitle())
             ->add($forum->getTitle());
-        $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('forum').' - '.$forum->getDesc());
+        $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('forum') . ' - ' . $forum->getDesc());
         $this->getLayout()->getHmenu()
             ->add($this->getTranslator()->trans('forum'), ['controller' => 'index', 'action' => 'index'])
             ->add($cat->getTitle(), ['controller' => 'showcat','action' => 'index', 'id' => $cat->getId()])
@@ -54,7 +55,7 @@ class Showtopics extends Frontend
 
         $posts = $topicMapper->getLastPostsByTopicIds(array_keys($topics), ($this->getUser()) ? $this->getUser()->getId() : null);
         $postTopicRelation = [];
-        foreach($posts ?? [] as $index => $post) {
+        foreach ($posts ?? [] as $index => $post) {
             $postTopicRelation[$post->getTopicId()] = $index;
         }
 

--- a/application/modules/forum/controllers/Showtopics.php
+++ b/application/modules/forum/controllers/Showtopics.php
@@ -50,11 +50,19 @@ class Showtopics extends Frontend
 
         $pagination->setRowsPerPage(!$this->getConfig()->get('forum_threadsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_threadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
+        $topics = $topicMapper->getTopicsByForumId($forumId, $pagination);
+
+        $posts = $topicMapper->getLastPostsByTopicIds(array_keys($topics), ($this->getUser()) ? $this->getUser()->getId() : null);
+        $postTopicRelation = [];
+        foreach($posts ?? [] as $index => $post) {
+            $postTopicRelation[$post->getTopicId()] = $index;
+        }
 
         $this->getView()->set('forum', $forum);
         $this->getView()->set('cat', $cat);
-        $this->getView()->set('topicMapper', $topicMapper);
-        $this->getView()->set('topics', $topicMapper->getTopicsByForumId($forumId, $pagination));
+        $this->getView()->set('topics', $topics);
+        $this->getView()->set('posts', $posts);
+        $this->getView()->set('postTopicRelation', $postTopicRelation);
         $this->getView()->set('pagination', $pagination);
         $this->getView()->set('DESCPostorder', $this->getConfig()->get('forum_DESCPostorder'));
         $this->getView()->set('postsPerPage', !$this->getConfig()->get('forum_postsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('forum_postsPerPage'));

--- a/application/modules/forum/controllers/Showunansweredtopics.php
+++ b/application/modules/forum/controllers/Showunansweredtopics.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/controllers/Showunansweredtopics.php
+++ b/application/modules/forum/controllers/Showunansweredtopics.php
@@ -30,15 +30,22 @@ class Showunansweredtopics extends Frontend
         $forums = $forumMapper->getForumItemsUser($this->getUser());
         $topics = $topicMapper->getTopicsByForumIds(array_keys($forums));
 
+        $topicIds = [];
         $topicsToShow = [];
         foreach ($topics as $topic) {
             if (($topic->getCountPosts() === 1) && ($isAdmin || $forums[$topic->getForumId()]->getReadAccess())) {
-                $topicsToShow[] = [
-                    'topic' => $topic,
-                    'forumPrefix' => $forums[$topic->getForumId()]->getPrefix(),
-                    'lastPost' => ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId()),
-                ];
+                $topicIds[] = $topic->getId();
             }
+        }
+
+        $posts = $topicMapper->getLastPostsByTopicIds($topicIds, ($this->getUser()) ? $this->getUser()->getId() : null);
+
+        foreach ($posts as $post) {
+            $topicsToShow[] = [
+                'topic' => $topics[$post->getTopicId()],
+                'forumPrefix' => $forums[$topics[$post->getTopicId()]->getForumId()]->getPrefix(),
+                'lastPost' => $post,
+            ];
         }
 
         $this->getView()->set('topics', $topicsToShow);

--- a/application/modules/forum/controllers/admin/Index.php
+++ b/application/modules/forum/controllers/admin/Index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/controllers/admin/Index.php
+++ b/application/modules/forum/controllers/admin/Index.php
@@ -148,7 +148,6 @@ class Index extends Admin
         }
 
         $this->getView()->set('forumItems', $forumMapper->getForumItemsByParent(0));
-        $this->getView()->set('forumMapper', $forumMapper);
         $this->getView()->set('userGroupList', $userGroupMapper->getGroupList());
     }
 }

--- a/application/modules/forum/controllers/admin/Index.php
+++ b/application/modules/forum/controllers/admin/Index.php
@@ -147,7 +147,7 @@ class Index extends Admin
             $this->redirect(['action' => 'index']);
         }
 
-        $this->getView()->set('forumItems', $forumMapper->getForumItemsByParent(0));
+        $this->getView()->set('forumItems', $forumMapper->getForumItemsAdmincenterByParentIds([0]));
         $this->getView()->set('userGroupList', $userGroupMapper->getGroupList());
     }
 }

--- a/application/modules/forum/controllers/admin/Index.php
+++ b/application/modules/forum/controllers/admin/Index.php
@@ -78,15 +78,11 @@ class Index extends Admin
                     }
                 }
 
-                $oldItems = $forumMapper->getForumItems();
+                $oldItems = $forumMapper->getForumItemsIds();
 
                 // Deletes old entries from database.
                 if (!empty($oldItems)) {
-                    foreach ($oldItems as $oldItem) {
-                        if (!isset($items[$oldItem->getId()])) {
-                            $forumMapper->deleteItem($oldItem->getId());
-                        }
-                    }
+                    $forumMapper->deleteItems(array_diff($oldItems, array_keys($items)));
                 }
 
                 if ($items) {

--- a/application/modules/forum/controllers/admin/Ranks.php
+++ b/application/modules/forum/controllers/admin/Ranks.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/controllers/admin/Reports.php
+++ b/application/modules/forum/controllers/admin/Reports.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/controllers/admin/Settings.php
+++ b/application/modules/forum/controllers/admin/Settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -140,21 +141,21 @@ class Settings extends Admin
                 continue;
             }
 
-            $content .= '#forum .appearance'.$key.' {'.PHP_EOL;
-            $content .= 'color: '.$value['textcolor'].';'.PHP_EOL;
+            $content .= '#forum .appearance' . $key . ' {' . PHP_EOL;
+            $content .= 'color: ' . $value['textcolor'] . ';' . PHP_EOL;
 
             if (isset($value['bold'])) {
-                $content .= 'font-weight: bold;'.PHP_EOL;
+                $content .= 'font-weight: bold;' . PHP_EOL;
             }
 
             if (isset($value['italic'])) {
-                $content .= 'font-style: italic;'.PHP_EOL;
+                $content .= 'font-style: italic;' . PHP_EOL;
             }
-            $content .= '}'.PHP_EOL;
+            $content .= '}' . PHP_EOL;
         }
 
         // Delete old stylesheets
-        $files = glob(APPLICATION_PATH.'/modules/forum/static/css/groupappearance/*');
+        $files = glob(APPLICATION_PATH . '/modules/forum/static/css/groupappearance/*');
         foreach ($files as $file) {
             if (is_file($file)) {
                 unlink($file);
@@ -165,8 +166,8 @@ class Settings extends Admin
             return '';
         }
 
-        $filename = uniqid().'.css';
-        $returnValue = file_put_contents(APPLICATION_PATH.'/modules/forum/static/css/groupappearance/'.$filename, $content);
+        $filename = uniqid() . '.css';
+        $returnValue = file_put_contents(APPLICATION_PATH . '/modules/forum/static/css/groupappearance/' . $filename, $content);
         if ($returnValue !== false && $returnValue != 0) {
             return $filename;
         }

--- a/application/modules/forum/mappers/Forum.php
+++ b/application/modules/forum/mappers/Forum.php
@@ -11,12 +11,12 @@ use Ilch\Mapper;
 use Modules\Forum\Models\ForumItem;
 use Modules\Forum\Models\ForumPost as PostModel;
 use Modules\User\Mappers\User as UserMapper;
-use Modules\Forum\Mappers\Topic as TopicMapper;
+use Modules\User\Models\User;
 
 class Forum extends Mapper
 {
     /**
-     * Get all forumItems by its parent (specified by its id)
+     * Get all forumItems by its parent (specified by its id).
      *
      * @param int $itemId
      * @param int|null $userId
@@ -29,7 +29,9 @@ class Forum extends Mapper
     }
 
     /**
-     * Get all forumItems by their parent ids (specified by their ids)
+     * Get all forumItems by their parent ids (specified by their ids).
+     * Use getForumItemsByParentIdsUser if you don't need to know all user groups that have
+     * read, reply or create access for performance reasons.
      *
      * @param int[] $itemIds An array of parent ids.
      * @param int|null $userId
@@ -89,6 +91,73 @@ class Forum extends Mapper
     }
 
     /**
+     * Get all forumItems by their parent ids (specified by their ids).
+     * Takes the user into account. This function only returns if the user or guest has access and
+     * doesn't return all groups that have read, reply or create access.
+     *
+     * @param array $itemIds
+     * @param User|null $user
+     * @return array
+     * @throws Exception
+     */
+    public function getForumItemsByParentIdsUser(array $itemIds, User $user = null): array
+    {
+        $groupIds = [3];
+        foreach ($user ? $user->getGroups() : [] as $group) {
+            $groupIds[] = $group->getId();
+        }
+
+        $itemRows = $this->db()->select(['i.id', 'i.parent_id', 'i.type', 'i.title', 'i.description', 'i.prefix'])
+            ->from(['i' => 'forum_items'])
+            ->join(['aa' => 'forum_accesses'], ['i.id = aa.item_id', 'aa.access_type' => 0, 'aa.group_id' => $groupIds], 'LEFT', ['read_access' => 'aa.group_id'])
+            ->join(['ab' => 'forum_accesses'], ['i.id = ab.item_id', 'ab.access_type' => 1, 'ab.group_id' => $groupIds], 'LEFT', ['reply_access' => 'ab.group_id'])
+            ->join(['ac' => 'forum_accesses'], ['i.id = ac.item_id', 'ac.access_type' => 2, 'ac.group_id' => $groupIds], 'LEFT', ['create_access' => 'ac.group_id'])
+            ->join(['t' => 'forum_topics'], 'i.id = t.forum_id', 'LEFT', ['topicCount' => 'COUNT(DISTINCT t.id)'])
+            ->join(['p' => 'forum_posts'], 'i.id = p.forum_id', 'LEFT', ['postCount' => 'COUNT(DISTINCT p.id)'])
+            ->where(['i.parent_id' => $itemIds], 'or')
+            ->group(['i.id'])
+            ->order(['i.sort' => 'ASC'])
+            ->execute()
+            ->fetchRows();
+
+        if (empty($itemRows)) {
+            return [];
+        }
+
+        $subItemsIds = array_column($itemRows, 'id');
+        $subItems = $this->getForumItemsByParentIdsUser($subItemsIds, $user);
+
+        $subItemsRelation = [];
+        foreach ($subItems as $subItem) {
+            $subItemsRelation[$subItem->getParentId()][] = $subItem;
+        }
+
+        $items = [];
+
+        foreach ($itemRows as $itemRow) {
+            $itemModel = new ForumItem();
+            $itemModel->setId($itemRow['id']);
+            $itemModel->setType($itemRow['type']);
+            $itemModel->setTitle($itemRow['title']);
+            $itemModel->setDesc($itemRow['description']);
+            $itemModel->setParentId($itemRow['parent_id']);
+            $itemModel->setPrefix($itemRow['prefix']);
+            $itemModel->setReadAccess($itemRow['read_access'] ?? '');
+            $itemModel->setReplyAccess($itemRow['reply_access'] ?? '');
+            $itemModel->setCreateAccess($itemRow['create_access'] ?? '');
+            $itemModel->setSubItems($subItemsRelation[$itemRow['id']] ?? []);
+            $itemModel->setTopics($itemRow['topicCount']);
+            if ($itemRow['type'] == 1) {
+                $itemModel->setLastPost($this->getLastPostByForumId($itemRow['id'], $user ? $user->getId() : null));
+            }
+            $itemModel->setPosts($itemRow['postCount']);
+            $items[] = $itemModel;
+        }
+
+        return $items;
+    }
+
+    /**
      * Get forum by id.
      *
      * @param int $id
@@ -126,6 +195,75 @@ class Forum extends Mapper
     }
 
     /**
+     * Get forum by id. Takes the user into account.
+     * This function only returns if the user or guest has access and doesn't return all groups that have read,
+     * reply or create access.
+     *
+     * @param int $id
+     * @param User|null $user
+     * @return ForumItem|null
+     */
+    public function getForumByIdUser(int $id, User $user = null): ?ForumItem
+    {
+        $forums = $this->getForumsByIdsUser([$id], $user);
+
+        if (!empty($forums)) {
+            return reset($forums);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get forums by their ids. Takes the user into account.
+     * This function only returns if the user or guest has access and doesn't return all groups that have read,
+     * reply or create access.
+     *
+     * @param array $ids
+     * @param User|null $user
+     * @return ForumItem[]|null
+     */
+    public function getForumsByIdsUser(array $ids, User $user = null): ?array
+    {
+        $groupIds = [3];
+        foreach ($user ? $user->getGroups() : [] as $group) {
+            $groupIds[] = $group->getId();
+        }
+
+        $itemRows = $this->db()->select(['i.id', 'i.type', 'i.title', 'i.description', 'i.parent_id', 'i.prefix'])
+            ->from(['i' => 'forum_items'])
+            ->join(['aa' => 'forum_accesses'], ['i.id = aa.item_id', 'aa.access_type' => 0, 'aa.group_id' => $groupIds], 'LEFT', ['read_access' => 'aa.group_id'])
+            ->join(['ab' => 'forum_accesses'], ['i.id = ab.item_id', 'ab.access_type' => 1, 'ab.group_id' => $groupIds], 'LEFT', ['reply_access' => 'ab.group_id'])
+            ->join(['ac' => 'forum_accesses'], ['i.id = ac.item_id', 'ac.access_type' => 2, 'ac.group_id' => $groupIds], 'LEFT', ['create_access' => 'ac.group_id'])
+            ->where(['i.id' => $ids], 'or')
+            ->group(['i.id'])
+            ->order(['i.sort' => 'DESC'])
+            ->execute()
+            ->fetchRows();
+
+        if (empty($itemRows)) {
+            return null;
+        }
+
+        $forumItems = [];
+        foreach ($itemRows as $itemRow) {
+            $itemModel = new ForumItem();
+            $itemModel->setId($itemRow['id']);
+            $itemModel->setType($itemRow['type']);
+            $itemModel->setTitle($itemRow['title']);
+            $itemModel->setDesc($itemRow['description']);
+            $itemModel->setParentId($itemRow['parent_id']);
+            $itemModel->setPrefix($itemRow['prefix']);
+            $itemModel->setReadAccess($itemRow['read_access'] ?? '');
+            $itemModel->setReplyAccess($itemRow['reply_access'] ?? '');
+            $itemModel->setCreateAccess($itemRow['create_access'] ?? '');
+            $forumItems[$itemRow['id']] = $itemModel;
+        }
+
+        return $forumItems;
+    }
+
+    /**
      * Get forum by topic id.
      *
      * @param int $topicId
@@ -140,6 +278,50 @@ class Forum extends Mapper
             ->join(['aa' => 'forum_accesses'], ['i.id = aa.item_id', 'aa.access_type' => 0], 'LEFT', ['read_access' => 'GROUP_CONCAT(DISTINCT aa.group_id)'])
             ->join(['ab' => 'forum_accesses'], ['i.id = ab.item_id', 'ab.access_type' => 1], 'LEFT', ['reply_access' => 'GROUP_CONCAT(DISTINCT ab.group_id)'])
             ->join(['ac' => 'forum_accesses'], ['i.id = ac.item_id', 'ac.access_type' => 2], 'LEFT', ['create_access' => 'GROUP_CONCAT(DISTINCT ac.group_id)'])
+            ->where(['t.id' => $topicId])
+            ->group(['i.id'])
+            ->execute()
+            ->fetchAssoc();
+
+        if (empty($itemRow)) {
+            return null;
+        }
+
+        $itemModel = new ForumItem();
+        $itemModel->setId($itemRow['id']);
+        $itemModel->setType($itemRow['type']);
+        $itemModel->setTitle($itemRow['title']);
+        $itemModel->setDesc($itemRow['description']);
+        $itemModel->setParentId($itemRow['parent_id']);
+        $itemModel->setPrefix($itemRow['prefix']);
+        $itemModel->setReadAccess($itemRow['read_access'] ?? '');
+        $itemModel->setReplyAccess($itemRow['reply_access'] ?? '');
+        $itemModel->setCreateAccess($itemRow['create_access'] ?? '');
+
+        return $itemModel;
+    }
+
+    /**
+     * Get forum by topic id. Takes the user into account.
+     *
+     * @param int $topicId
+     * @param User|null $user
+     * @return ForumItem|null
+     */
+    public function getForumByTopicIdUser(int $topicId, User $user = null): ?ForumItem
+    {
+        $groupIds = [3];
+        foreach ($user ? $user->getGroups() : [] as $group) {
+            $groupIds[] = $group->getId();
+        }
+
+        $itemRow = $this->db()->select()
+            ->fields(['t.id'])
+            ->from(['t' => 'forum_topics'])
+            ->join(['i' => 'forum_items'], 'i.id = t.forum_id', 'LEFT', ['i.id', 'i.type', 'i.title', 'i.description', 'i.prefix', 'i.parent_id'])
+            ->join(['aa' => 'forum_accesses'], ['i.id = aa.item_id', 'aa.access_type' => 0, 'aa.group_id' => $groupIds], 'LEFT', ['read_access' => 'aa.group_id'])
+            ->join(['ab' => 'forum_accesses'], ['i.id = ab.item_id', 'ab.access_type' => 1, 'ab.group_id' => $groupIds], 'LEFT', ['reply_access' => 'ab.group_id'])
+            ->join(['ac' => 'forum_accesses'], ['i.id = ac.item_id', 'ac.access_type' => 2, 'ac.group_id' => $groupIds], 'LEFT', ['create_access' => 'ac.group_id'])
             ->where(['t.id' => $topicId])
             ->group(['i.id'])
             ->execute()
@@ -242,6 +424,10 @@ class Forum extends Mapper
     }
 
     /**
+     * Get all forum items.
+     * Use getForumItemsUser if you don't need to know all user groups that have
+     * read, reply or create access for performance reasons.
+     *
      * @return array|null
      */
     public function getForumItems(): ?array
@@ -279,6 +465,71 @@ class Forum extends Mapper
     }
 
     /**
+     * Get all forum items.
+     * Only returns if user has read, reply or create access. No full lists of user groups.
+     *
+     * @param User|null $user
+     * @return array|null
+     */
+    public function getForumItemsUser(User $user = null): ?array
+    {
+        $groupIds = [3];
+        foreach ($user ? $user->getGroups() : [] as $group) {
+            $groupIds[] = $group->getId();
+        }
+
+        $items = [];
+        $itemRows = $this->db()->select(['i.id', 'i.type', 'i.title', 'i.description', 'i.parent_id', 'i.prefix'])
+            ->from(['i' => 'forum_items'])
+            ->join(['aa' => 'forum_accesses'], ['i.id = aa.item_id', 'aa.access_type' => 0, 'aa.group_id' => $groupIds], 'LEFT', ['read_access' => 'aa.group_id'])
+            ->join(['ab' => 'forum_accesses'], ['i.id = ab.item_id', 'ab.access_type' => 1, 'ab.group_id' => $groupIds], 'LEFT', ['reply_access' => 'ab.group_id'])
+            ->join(['ac' => 'forum_accesses'], ['i.id = ac.item_id', 'ac.access_type' => 2, 'ac.group_id' => $groupIds], 'LEFT', ['create_access' => 'ac.group_id'])
+            ->group(['i.id'])
+            ->order(['i.sort' => 'ASC'])
+            ->execute()
+            ->fetchRows();
+
+        if (empty($itemRows)) {
+            return null;
+        }
+
+        foreach ($itemRows as $itemRow) {
+            $itemModel = new ForumItem();
+            $itemModel->setId($itemRow['id']);
+            $itemModel->setType($itemRow['type']);
+            $itemModel->setTitle($itemRow['title']);
+            $itemModel->setDesc($itemRow['description']);
+            $itemModel->setParentId($itemRow['parent_id']);
+            $itemModel->setPrefix($itemRow['prefix']);
+            $itemModel->setReadAccess($itemRow['read_access'] ?? '');
+            $itemModel->setReplyAccess($itemRow['reply_access'] ?? '');
+            $itemModel->setCreateAccess($itemRow['create_access'] ?? '');
+            $items[$itemRow['id']] = $itemModel;
+        }
+
+        return $items;
+    }
+
+    /**
+     * Gets a list of all Ids of the forum items.
+     *
+     * @return array|null
+     */
+    public function getForumItemsIds(): ?array
+    {
+        $itemRows = $this->db()->select(['i.id'])
+            ->from(['i' => 'forum_items'])
+            ->execute()
+            ->fetchList();
+
+        if (empty($itemRows)) {
+            return null;
+        }
+
+        return $itemRows;
+    }
+
+    /**
      * @param int $id
      * @return int
      */
@@ -312,6 +563,28 @@ class Forum extends Mapper
         }
 
         return $countOfPosts;
+    }
+
+    /**
+     * Get count of posts by topic ids.
+     *
+     * @param array $topicIds
+     * @return array|null An array with the counts and the topic ids as keys.
+     */
+    public function getCountPostsByTopicIds(array $topicIds): ?array
+    {
+        $countOfPostsRows = $this->db()->select(['count' => 'COUNT(id)', 'topic_id'])
+            ->from('forum_posts')
+            ->where(['topic_id' => $topicIds], 'or')
+            ->group(['id'])
+            ->execute()
+            ->fetchList('count', 'topic_id');
+
+        if (empty($countOfPostsRows)) {
+            return null;
+        }
+
+        return $countOfPostsRows;
     }
 
     /**
@@ -465,13 +738,17 @@ class Forum extends Mapper
      */
     public function deleteItem(int $id)
     {
-        $topicMapper = new TopicMapper();
-        $topics = $topicMapper->getTopicsListByForumId($id);
-        foreach ($topics as $topicId) {
-            $topicMapper->deleteById($topicId);
-        }
+        $this->deleteItems([$id]);
+    }
+
+    /**
+     * @param array $ids
+     * @return void
+     */
+    public function deleteItems(array $ids)
+    {
         $this->db()->delete('forum_items')
-            ->where(['id' => $id])
+            ->where(['id' => $ids])
             ->execute();
     }
 }

--- a/application/modules/forum/mappers/Forum.php
+++ b/application/modules/forum/mappers/Forum.php
@@ -141,7 +141,7 @@ class Forum extends Mapper
         }
 
         if (!empty($subItemsIds)) {
-            $subItems = $this->getForumItemsByParentIds($subItemsIds);
+            $subItems = $this->getForumItemsAdmincenterByParentIds($subItemsIds);
 
             foreach ($subItems as $subItem) {
                 $subItemsRelation[$subItem->getParentId()][] = $subItem;
@@ -241,7 +241,7 @@ class Forum extends Mapper
             $itemModel->setCreateAccess($itemRow['create_access'] ?? '');
             $itemModel->setSubItems($subItemsRelation[$itemRow['id']] ?? []);
             $itemModel->setTopics($itemRow['topicCount']);
-             if ($itemRow['type'] == 1 && isset($lastPosts[$itemRow['id']])) {
+            if ($itemRow['type'] == 1 && isset($lastPosts[$itemRow['id']])) {
                 $itemModel->setLastPost($lastPosts[$itemRow['id']]);
             }
             $itemModel->setPosts($itemRow['postCount']);

--- a/application/modules/forum/mappers/Forum.php
+++ b/application/modules/forum/mappers/Forum.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -35,7 +36,7 @@ class Forum extends Mapper
      *
      * @param int[] $itemIds An array of parent ids.
      * @param int|null $userId
-     * @return array
+     * @return array|ForumItem[]
      * @throws Exception
      */
     public function getForumItemsByParentIds(array $itemIds, int $userId = null): array
@@ -59,7 +60,7 @@ class Forum extends Mapper
 
         $subItemsIds = [];
         $subItemsRelation = [];
-        foreach($itemRows as $itemRow) {
+        foreach ($itemRows as $itemRow) {
             // Don't bother trying to get subitems if the item is already a forum and not a category.
             if ($itemRow['type'] != 1) {
                 $subItemsIds[] = $itemRow['id'];
@@ -111,7 +112,7 @@ class Forum extends Mapper
      * Get forum items with the needed values for the admincenter.
      *
      * @param array $itemIds
-     * @return array
+     * @return array|ForumItem[]
      * @throws Exception
      */
     public function getForumItemsAdmincenterByParentIds(array $itemIds): array
@@ -133,7 +134,7 @@ class Forum extends Mapper
 
         $subItemsIds = [];
         $subItemsRelation = [];
-        foreach($itemRows as $itemRow) {
+        foreach ($itemRows as $itemRow) {
             // Don't bother trying to get subitems if the item is already a forum and not a category.
             if ($itemRow['type'] != 1) {
                 $subItemsIds[] = $itemRow['id'];
@@ -175,7 +176,7 @@ class Forum extends Mapper
      *
      * @param array $itemIds
      * @param User|null $user
-     * @return array
+     * @return array|ForumItem[]
      * @throws Exception
      */
     public function getForumItemsByParentIdsUser(array $itemIds, User $user = null): array
@@ -204,7 +205,7 @@ class Forum extends Mapper
 
         $subItemsIds = [];
         $subItemsRelation = [];
-        foreach($itemRows as $itemRow) {
+        foreach ($itemRows as $itemRow) {
             // Don't bother trying to get subitems if the item is already a forum and not a category.
             if ($itemRow['type'] != 1) {
                 $subItemsIds[] = $itemRow['id'];
@@ -495,7 +496,7 @@ class Forum extends Mapper
      *
      * @param array $forumId
      * @param int|null $userId
-     * @return array|null
+     * @return array|PostModel[]|null
      * @throws Exception
      */
     public function getLastPostsByForumIds(array $forumId, int $userId = null): ?array
@@ -579,7 +580,7 @@ class Forum extends Mapper
      * Use getForumItemsUser if you don't need to know all user groups that have
      * read, reply or create access for performance reasons.
      *
-     * @return array|null
+     * @return array|ForumItem[]|null
      */
     public function getForumItems(): ?array
     {
@@ -620,7 +621,7 @@ class Forum extends Mapper
      * Only returns if user has read, reply or create access. No full lists of user groups.
      *
      * @param User|null $user
-     * @return array|null
+     * @return array|ForumItem[]|null
      */
     public function getForumItemsUser(User $user = null): ?array
     {
@@ -861,7 +862,7 @@ class Forum extends Mapper
             // 'read_access' => 0, 'reply_access' => 1, 'create_access' => 2
             $preparedRows = [];
             foreach ($access_rights as $type => $rights) {
-                foreach($rights as $groupId) {
+                foreach ($rights as $groupId) {
                     if ($groupId) {
                         $preparedRows[] = [$itemId, $groupId, $type];
                     }

--- a/application/modules/forum/mappers/Forum.php
+++ b/application/modules/forum/mappers/Forum.php
@@ -57,12 +57,21 @@ class Forum extends Mapper
             return [];
         }
 
-        $subItemsIds = array_column($itemRows, 'id');
-        $subItems = $this->getForumItemsByParentIds($subItemsIds, $userId);
-
+        $subItemsIds = [];
         $subItemsRelation = [];
-        foreach ($subItems as $subItem) {
-            $subItemsRelation[$subItem->getParentId()][] = $subItem;
+        foreach($itemRows as $itemRow) {
+            // Don't bother trying to get subitems if the item is already a forum and not a category.
+            if ($itemRow['type'] != 1) {
+                $subItemsIds[] = $itemRow['id'];
+            }
+        }
+
+        if (!empty($subItemsIds)) {
+            $subItems = $this->getForumItemsByParentIds($subItemsIds, $userId);
+
+            foreach ($subItems as $subItem) {
+                $subItemsRelation[$subItem->getParentId()][] = $subItem;
+            }
         }
 
         $items = [];
@@ -124,12 +133,21 @@ class Forum extends Mapper
             return [];
         }
 
-        $subItemsIds = array_column($itemRows, 'id');
-        $subItems = $this->getForumItemsByParentIdsUser($subItemsIds, $user);
-
+        $subItemsIds = [];
         $subItemsRelation = [];
-        foreach ($subItems as $subItem) {
-            $subItemsRelation[$subItem->getParentId()][] = $subItem;
+        foreach($itemRows as $itemRow) {
+            // Don't bother trying to get subitems if the item is already a forum and not a category.
+            if ($itemRow['type'] != 1) {
+                $subItemsIds[] = $itemRow['id'];
+            }
+        }
+
+        if (!empty($subItemsIds)) {
+            $subItems = $this->getForumItemsByParentIdsUser($subItemsIds, $user);
+
+            foreach ($subItems as $subItem) {
+                $subItemsRelation[$subItem->getParentId()][] = $subItem;
+            }
         }
 
         $items = [];

--- a/application/modules/forum/mappers/Topic.php
+++ b/application/modules/forum/mappers/Topic.php
@@ -267,7 +267,7 @@ class Topic extends Mapper
     }
 
     /**
-     *  Get last posts by topic ids and user id.
+     * Get last posts by topic ids and user id.
      *
      * @param array $ids
      * @param int|null $userId

--- a/application/modules/forum/mappers/Topic.php
+++ b/application/modules/forum/mappers/Topic.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -7,7 +8,6 @@
 namespace Modules\Forum\Mappers;
 
 use Ilch\Database\Exception;
-use Ilch\Database\Mysql\Result;
 use Ilch\Mapper;
 use Ilch\Pagination;
 use Modules\Forum\Models\ForumTopic as TopicModel;
@@ -30,7 +30,7 @@ class Topic extends Mapper
     /**
      * @param array $ids
      * @param Pagination|null $pagination
-     * @return array
+     * @return array|TopicModel[]
      * @throws Exception
      */
     public function getTopicsByForumIds(array $ids, Pagination $pagination = null): array
@@ -41,7 +41,6 @@ class Topic extends Mapper
             ->where(['topics.forum_id' => $ids])
             ->group(['topics.type', 'topics.id', 'topics.topic_prefix', 'topics.topic_title', 'topics.visits', 'topics.creator_id', 'topics.date_created', 'topics.forum_id', 'topics.status'])
             ->order(['topics.type' => 'DESC', 'latest_post' => 'DESC']);
-
         if ($pagination !== null) {
             $sql->limit($pagination->getLimit())
                 ->useFoundRows();
@@ -52,12 +51,10 @@ class Topic extends Mapper
         }
 
         $topicRows = $result->fetchRows();
-
         $userMapper = new UserMapper();
         $topics = [];
         $dummyUser = null;
         $userCache = [];
-
         foreach ($topicRows as $topicRow) {
             $topicModel = new TopicModel();
             $topicModel->setId($topicRow['id']);
@@ -65,7 +62,6 @@ class Topic extends Mapper
             $topicModel->setForumId($topicRow['forum_id']);
             $topicModel->setType($topicRow['type']);
             $topicModel->setStatus($topicRow['status']);
-
             if (\array_key_exists($topicRow['creator_id'], $userCache)) {
                 $topicModel->setAuthor($userCache[$topicRow['creator_id']]);
             } else {
@@ -104,7 +100,6 @@ class Topic extends Mapper
             ->where(['forum_id' => $id])
             ->execute()
             ->fetchArray();
-
         if (empty($result)) {
             return [];
         }
@@ -127,7 +122,6 @@ class Topic extends Mapper
             ->join(['posts' => 'forum_posts'], 'topics.id = posts.topic_id', 'LEFT', ['countPosts' => 'COUNT(posts.id)'])
             ->group(['topics.type', 'topics.id', 'topics.topic_prefix', 'topics.topic_title', 'topics.visits', 'topics.creator_id', 'topics.date_created', 'topics.forum_id', 'topics.status'])
             ->order(['topics.type' => 'DESC', 'topics.id' => 'DESC']);
-
         if ($pagination !== null) {
             $sql->limit($pagination->getLimit())
                 ->useFoundRows();
@@ -141,12 +135,10 @@ class Topic extends Mapper
         }
 
         $topicRows = $result->fetchRows();
-
         $userMapper = new UserMapper();
         $topics = [];
         $dummyUser = null;
         $userCache = [];
-
         foreach ($topicRows as $topicRow) {
             $topicModel = new TopicModel();
             $topicModel->setId($topicRow['id']);
@@ -154,7 +146,6 @@ class Topic extends Mapper
             $topicModel->setVisits($topicRow['visits']);
             $topicModel->setType($topicRow['type']);
             $topicModel->setStatus($topicRow['status']);
-
             if (\array_key_exists($topicRow['creator_id'], $userCache)) {
                 $topicModel->setAuthor($userCache[$topicRow['creator_id']]);
             } else {
@@ -193,7 +184,6 @@ class Topic extends Mapper
             ->where(['id' => $id])
             ->execute()
             ->fetchAssoc();
-
         if (empty($topic)) {
             return null;
         }
@@ -213,7 +203,6 @@ class Topic extends Mapper
         }
         $topicModel->setDateCreated($topic['date_created']);
         $topicModel->setStatus($topic['status']);
-
         return $topicModel;
     }
 
@@ -228,7 +217,6 @@ class Topic extends Mapper
     public function getLastPostByTopicId(int $id, int $userId = null): ?PostModel
     {
         $lastPost = $this->getLastPostsByTopicIds([$id], $userId);
-
         if (!empty($lastPost)) {
             return reset($lastPost);
         }
@@ -248,7 +236,6 @@ class Topic extends Mapper
     {
         $select = $this->db()->select(['p.id', 'p.topic_id', 'date_created' => 'MAX(p.date_created)', 'p.user_id', 'p.forum_id'])
             ->from(['p' => 'forum_posts']);
-
         if ($userId) {
             $select->join(['tr' => 'forum_topics_read'], ['tr.user_id' => $userId, 'tr.topic_id = p.topic_id', 'tr.datetime >= p.date_created'], 'LEFT', ['topic_read' => 'tr.datetime'])
                 ->join(['fr' => 'forum_read'], ['fr.user_id' => $userId, 'fr.forum_id = p.forum_id', 'fr.datetime >= p.date_created'], 'LEFT', ['forum_read' => 'fr.datetime']);
@@ -259,7 +246,6 @@ class Topic extends Mapper
             ->group(['p.topic_id'])
             ->execute()
             ->fetchRows();
-
         if (empty($lastPostsRows)) {
             return null;
         }
@@ -270,7 +256,6 @@ class Topic extends Mapper
             $userMapper = new UserMapper();
             $postModel->setId($lastPostRow['id']);
             $user = $userMapper->getUserById($lastPostRow['user_id']);
-
             if ($user) {
                 $postModel->setAutor($user);
             } else {
@@ -279,7 +264,6 @@ class Topic extends Mapper
 
             $postModel->setDateCreated($lastPostRow['date_created']);
             $postModel->setTopicId($lastPostRow['topic_id']);
-
             if ($userId) {
                 $postModel->setRead($lastPostRow['topic_read'] || $lastPostRow['forum_read']);
             }
@@ -293,15 +277,16 @@ class Topic extends Mapper
      * Inserts or updates a topic.
      *
      * @param TopicModel $model
-     * @return Result|int
+     * @return int
      */
-    public function save(TopicModel $model)
+    public function save(TopicModel $model): int
     {
         if ($model->getId()) {
-            return $this->db()->update('forum_topics')
+            $this->db()->update('forum_topics')
                 ->values(['forum_id' => $model->getForumId()])
                 ->where(['id' => $model->getId()])
                 ->execute();
+            return $model->getId();
         } else {
             return $this->db()->insert('forum_topics')
                 ->values([
@@ -328,7 +313,6 @@ class Topic extends Mapper
                         ->where(['id' => $id])
                         ->execute()
                         ->fetchCell();
-
         $this->db()->update('forum_topics')
             ->values(['status' => !$status])
             ->where(['id' => $id])
@@ -347,7 +331,6 @@ class Topic extends Mapper
             ->where(['id' => $id])
             ->execute()
             ->fetchCell();
-
         $this->db()->update('forum_topics')
             ->values(['type' => !$type])
             ->where(['id' => $id])
@@ -386,9 +369,8 @@ class Topic extends Mapper
                     ) AS `innerfrom` 
                 GROUP BY `innerfrom`.`topic_id` 
                 ORDER BY `innerfrom`.`date_created` DESC';
-
         if ($limit !== null) {
-            $sql .= ' LIMIT '. $limit;
+            $sql .= ' LIMIT ' . $limit;
         }
 
         return $this->db()->queryArray($sql);

--- a/application/modules/forum/mappers/Topic.php
+++ b/application/modules/forum/mappers/Topic.php
@@ -24,10 +24,21 @@ class Topic extends Mapper
      */
     public function getTopicsByForumId(int $id, Pagination $pagination = null): array
     {
+        return $this->getTopicsByForumIds([$id], $pagination);
+    }
+
+    /**
+     * @param array $ids
+     * @param Pagination|null $pagination
+     * @return array
+     * @throws Exception
+     */
+    public function getTopicsByForumIds(array $ids, Pagination $pagination = null): array
+    {
         $sql = $this->db()->select(['*', 'topics.id', 'topics.visits', 'latest_post' => 'MAX(posts.date_created)', 'countPosts' => 'COUNT(posts.id)'])
             ->from(['topics' => 'forum_topics'])
             ->join(['posts' => 'forum_posts'], 'topics.id = posts.topic_id', 'LEFT')
-            ->where(['topics.forum_id' => (int)$id])
+            ->where(['topics.forum_id' => $ids])
             ->group(['topics.type', 'topics.id', 'topics.topic_prefix', 'topics.topic_title', 'topics.visits', 'topics.creator_id', 'topics.date_created', 'topics.forum_id', 'topics.status'])
             ->order(['topics.type' => 'DESC', 'latest_post' => 'DESC']);
 
@@ -51,6 +62,7 @@ class Topic extends Mapper
             $topicModel = new TopicModel();
             $topicModel->setId($topicRow['id']);
             $topicModel->setVisits($topicRow['visits']);
+            $topicModel->setForumId($topicRow['forum_id']);
             $topicModel->setType($topicRow['type']);
             $topicModel->setStatus($topicRow['status']);
 

--- a/application/modules/forum/mappers/Topic.php
+++ b/application/modules/forum/mappers/Topic.php
@@ -227,43 +227,13 @@ class Topic extends Mapper
      */
     public function getLastPostByTopicId(int $id, int $userId = null): ?PostModel
     {
-        $select = $this->db()->select(['p.id', 'p.topic_id', 'p.date_created', 'p.user_id', 'p.forum_id'])
-            ->from(['p' => 'forum_posts']);
+        $lastPost = $this->getLastPostsByTopicIds([$id], $userId);
 
-        if ($userId) {
-            $select->join(['tr' => 'forum_topics_read'], ['tr.user_id' => $userId, 'tr.topic_id = p.topic_id', 'tr.datetime >= p.date_created'], 'LEFT', ['topic_read' => 'tr.datetime'])
-                ->join(['fr' => 'forum_read'], ['fr.user_id' => $userId, 'fr.forum_id = p.forum_id', 'fr.datetime >= p.date_created'], 'LEFT', ['forum_read' => 'fr.datetime']);
+        if (!empty($lastPost)) {
+            return reset($lastPost);
         }
 
-        $lastPostRow = $select->where(['p.topic_id' => $id])
-            ->order(['p.date_created' => 'DESC'])
-            ->limit(1)
-            ->execute()
-            ->fetchAssoc();
-
-        if (empty($lastPostRow)) {
-            return null;
-        }
-
-        $postModel = new PostModel();
-        $userMapper = new UserMapper();
-        $postModel->setId($lastPostRow['id']);
-        $user = $userMapper->getUserById($lastPostRow['user_id']);
-
-        if ($user) {
-            $postModel->setAutor($user);
-        } else {
-            $postModel->setAutor($userMapper->getDummyUser());
-        }
-
-        $postModel->setDateCreated($lastPostRow['date_created']);
-        $postModel->setTopicId($lastPostRow['topic_id']);
-
-        if ($userId) {
-            $postModel->setRead($lastPostRow['topic_read'] || $lastPostRow['forum_read']);
-        }
-
-        return $postModel;
+        return null;
     }
 
     /**

--- a/application/modules/forum/plugins/AfterDatabaseLoad.php
+++ b/application/modules/forum/plugins/AfterDatabaseLoad.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/plugins/BeforeControllerLoad.php
+++ b/application/modules/forum/plugins/BeforeControllerLoad.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/translations/de.php
+++ b/application/modules/forum/translations/de.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/translations/en.php
+++ b/application/modules/forum/translations/en.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/forum/views/Showunansweredtopics/index.php
+++ b/application/modules/forum/views/Showunansweredtopics/index.php
@@ -1,20 +1,5 @@
 <?php
-use Modules\Forum\Mappers\Forum;
-use Modules\Forum\Mappers\Topic;
-use Modules\Forum\Mappers\Post;
-
 $topics = $this->get('topics');
-/** @var Forum $forumMapper */
-$forumMapper = $this->get('forumMapper');
-/** @var Topic $topicMapper */
-$topicMapper = $this->get('topicMapper');
-/** @var Post $postMapper */
-$postMapper = $this->get('postMapper');
-$groupIdsArray = $this->get('groupIdsArray');
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
 $DESCPostorder = $this->get('DESCPostorder');
 $postsPerPage = $this->get('postsPerPage');
 ?>
@@ -38,92 +23,85 @@ $postsPerPage = $this->get('postsPerPage');
         </ul>
         <ul class="topiclist topics">
             <?php foreach ($topics as $topic): ?>
-                <?php if (($topic->getCountPosts() - 1) == 0): ?>
-                    <?php $forum = $forumMapper->getForumById($topic->getForumId()); ?>
-                    <?php $forumPrefix = $forumMapper->getForumByTopicId($topic->getId()) ?>
-                    <?php $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId()) ?>
-                    <?php if ($adminAccess || is_in_array($groupIdsArray, explode(',', $forum->getReadAccess()))): ?>
-                        <li class="row ilch-border ilch-bg--hover">
-                            <dl class="icon
-                            <?php if ($this->getUser()): ?>
-                                <?php if ($topic->getStatus() == 0 && $lastPost->getRead()): ?>
-                                    topic-read
-                                <?php elseif ($topic->getStatus() == 1 && $lastPost->getRead()): ?>
-                                    topic-read-locked
-                                <?php elseif ($topic->getStatus() == 1): ?>
-                                    topic-unread-locked
-                                <?php else: ?>
-                                    topic-unread
-                                <?php endif; ?>
-                            <?php elseif ($topic->getStatus() == 1): ?>
-                                topic-read-locked
-                            <?php else: ?>
-                                topic-read
-                            <?php endif; ?>
-                        ">
-                                <dt>
-                                    <?php
-                                    if ($forumPrefix->getPrefix() != '' && $topic->getTopicPrefix() > 0) {
-                                        $prefix = explode(',', $forumPrefix->getPrefix());
-                                        array_unshift($prefix, '');
-
-                                        foreach ($prefix as $key => $value) {
-                                            if ($topic->getTopicPrefix() == $key) {
-                                                echo '<span class="label label-default">'.$value.'</span>';
-                                            }
-                                        }
-                                    }
-                                    ?>
-                                    <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic->getId()]) ?>" class="topictitle">
-                                        <?=$topic->getTopicTitle() ?>
-                                    </a>
-                                    <?php if ($topic->getType() == '1'): ?>
-                                        <i class="fa-solid fa-thumbtack"></i>
-                                    <?php endif; ?>
-                                    <br>
-                                    <div class="small">
-                                        <?=$this->getTrans('by') ?>
-                                        <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic->getAuthor()->getId()]) ?>" class="ilch-link-red">
-                                            <?=$this->escape($topic->getAuthor()->getName()) ?>
-                                        </a>
-                                        »
-                                        <?=$topic->getDateCreated() ?>
-                                    </div>
-                                </dt>
-                                <dd class="posts small">
-                                    <div class="pull-left text-nowrap stats">
-                                        <?=$this->getTrans('replies') ?>:
-                                        <br />
-                                        <?=$this->getTrans('views') ?>:
-                                    </div>
-                                    <div class="pull-left text-justify">
-                                        <?=$topic->getCountPosts() - 1 ?>
-                                        <br />
-                                        <?=$topic->getVisits() ?>
-                                    </div>
-                                </dd>
-                                <dd class="lastpost small">
-                                    <div class="pull-left">
-                                        <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
-                                            <img style="width:40px; padding-right: 5px;" src="<?=$this->getBaseUrl($lastPost->getAutor()->getAvatar()) ?>" alt="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
-                                        </a>
-                                    </div>
-                                    <div class="pull-left">
-                                        <?=$this->getTrans('by') ?>
-                                        <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
-                                            <?=$this->escape($lastPost->getAutor()->getName()) ?>
-                                        </a>
-                                        <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $lastPost->getTopicId(), 'page' => ($DESCPostorder ? 1 : ceil($topic->getCountPosts() / $postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
-                                            <img src="<?=$this->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$this->getTrans('viewLastPost') ?>" title="<?=$this->getTrans('viewLastPost') ?>" height="10" width="12">
-                                        </a>
-                                        <br>
-                                        <?=$lastPost->getDateCreated() ?>
-                                    </div>
-                                </dd>
-                            </dl>
-                        </li>
+                <li class="row ilch-border ilch-bg--hover">
+                    <dl class="icon
+                    <?php if ($this->getUser()): ?>
+                        <?php if ($topic['topic']->getStatus() == 0 && $topic['lastPost']->getRead()): ?>
+                            topic-read
+                        <?php elseif ($topic['topic']->getStatus() == 1 && $topic['lastPost']->getRead()): ?>
+                            topic-read-locked
+                        <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                            topic-unread-locked
+                        <?php else: ?>
+                            topic-unread
+                        <?php endif; ?>
+                    <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                        topic-read-locked
+                    <?php else: ?>
+                        topic-read
                     <?php endif; ?>
-                <?php endif; ?>
+                ">
+                        <dt>
+                            <?php
+                            if ($topic['forumPrefix'] != '' && $topic['topic']->getTopicPrefix() > 0) {
+                                $prefix = explode(',', $topic['forumPrefix']);
+                                array_unshift($prefix, '');
+
+                                foreach ($prefix as $key => $value) {
+                                    if ($topic['topic']->getTopicPrefix() == $key) {
+                                        echo '<span class="label label-default">'.$value.'</span>';
+                                    }
+                                }
+                            }
+                            ?>
+                            <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic['topic']->getId()]) ?>" class="topictitle">
+                                <?=$topic['topic']->getTopicTitle() ?>
+                            </a>
+                            <?php if ($topic['topic']->getType() == '1'): ?>
+                                <i class="fa-solid fa-thumbtack"></i>
+                            <?php endif; ?>
+                            <br>
+                            <div class="small">
+                                <?=$this->getTrans('by') ?>
+                                <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['topic']->getAuthor()->getId()]) ?>" class="ilch-link-red">
+                                    <?=$this->escape($topic['topic']->getAuthor()->getName()) ?>
+                                </a>
+                                »
+                                <?=$topic['topic']->getDateCreated() ?>
+                            </div>
+                        </dt>
+                        <dd class="posts small">
+                            <div class="pull-left text-nowrap stats">
+                                <?=$this->getTrans('replies') ?>:
+                                <br />
+                                <?=$this->getTrans('views') ?>:
+                            </div>
+                            <div class="pull-left text-justify">
+                                <?=$topic['topic']->getCountPosts() - 1 ?>
+                                <br />
+                                <?=$topic['topic']->getVisits() ?>
+                            </div>
+                        </dd>
+                        <dd class="lastpost small">
+                            <div class="pull-left">
+                                <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['lastPost']->getAutor()->getId()]) ?>" title="<?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>">
+                                    <img style="width:40px; padding-right: 5px;" src="<?=$this->getBaseUrl($topic['lastPost']->getAutor()->getAvatar()) ?>" alt="<?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>">
+                                </a>
+                            </div>
+                            <div class="pull-left">
+                                <?=$this->getTrans('by') ?>
+                                <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['lastPost']->getAutor()->getId()]) ?>" title="<?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>">
+                                    <?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>
+                                </a>
+                                <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic['lastPost']->getTopicId(), 'page' => ($DESCPostorder ? 1 : ceil($topic['topic']->getCountPosts() / $postsPerPage))]) ?>#<?=$topic['lastPost']->getId() ?>">
+                                    <img src="<?=$this->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$this->getTrans('viewLastPost') ?>" title="<?=$this->getTrans('viewLastPost') ?>" height="10" width="12">
+                                </a>
+                                <br>
+                                <?=$topic['lastPost']->getDateCreated() ?>
+                            </div>
+                        </dd>
+                    </dl>
+                </li>
             <?php endforeach; ?>
         </ul>
     </div>

--- a/application/modules/forum/views/Showunansweredtopics/index.php
+++ b/application/modules/forum/views/Showunansweredtopics/index.php
@@ -1,4 +1,8 @@
 <?php
+
+/** @var \Ilch\View $this */
+
+/** @var array $topics */
 $topics = $this->get('topics');
 $DESCPostorder = $this->get('DESCPostorder');
 $postsPerPage = $this->get('postsPerPage');
@@ -22,22 +26,22 @@ $postsPerPage = $this->get('postsPerPage');
             </li>
         </ul>
         <ul class="topiclist topics">
-            <?php foreach ($topics as $topic): ?>
+            <?php foreach ($topics as $topic) : ?>
                 <li class="row ilch-border ilch-bg--hover">
                     <dl class="icon
-                    <?php if ($this->getUser()): ?>
-                        <?php if ($topic['topic']->getStatus() == 0 && $topic['lastPost']->getRead()): ?>
+                    <?php if ($this->getUser()) : ?>
+                        <?php if ($topic['topic']->getStatus() == 0 && $topic['lastPost']->getRead()) : ?>
                             topic-read
-                        <?php elseif ($topic['topic']->getStatus() == 1 && $topic['lastPost']->getRead()): ?>
+                        <?php elseif ($topic['topic']->getStatus() == 1 && $topic['lastPost']->getRead()) : ?>
                             topic-read-locked
-                        <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                        <?php elseif ($topic['topic']->getStatus() == 1) : ?>
                             topic-unread-locked
-                        <?php else: ?>
+                        <?php else : ?>
                             topic-unread
                         <?php endif; ?>
-                    <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                    <?php elseif ($topic['topic']->getStatus() == 1) : ?>
                         topic-read-locked
-                    <?php else: ?>
+                    <?php else : ?>
                         topic-read
                     <?php endif; ?>
                 ">
@@ -49,7 +53,7 @@ $postsPerPage = $this->get('postsPerPage');
 
                                 foreach ($prefix as $key => $value) {
                                     if ($topic['topic']->getTopicPrefix() == $key) {
-                                        echo '<span class="label label-default">'.$value.'</span>';
+                                        echo '<span class="label label-default">' . $value . '</span>';
                                     }
                                 }
                             }
@@ -57,7 +61,7 @@ $postsPerPage = $this->get('postsPerPage');
                             <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic['topic']->getId()]) ?>" class="topictitle">
                                 <?=$topic['topic']->getTopicTitle() ?>
                             </a>
-                            <?php if ($topic['topic']->getType() == '1'): ?>
+                            <?php if ($topic['topic']->getType() == '1') : ?>
                                 <i class="fa-solid fa-thumbtack"></i>
                             <?php endif; ?>
                             <br>

--- a/application/modules/forum/views/admin/index/index.php
+++ b/application/modules/forum/views/admin/index/index.php
@@ -1,10 +1,13 @@
 <?php
 
+/** @var \Ilch\View $this */
+
 use Modules\Forum\Models\ForumItem;
 
+/** @var ForumItem|null $forumItems */
 $forumItems = $this->get('forumItems');
 
-function rec(ForumItem $item, $obj)
+function rec(ForumItem $item, \Ilch\View $obj)
 {
     $class = 'mjs-nestedSortable-branch mjs-nestedSortable-expanded';
 
@@ -12,19 +15,19 @@ function rec(ForumItem $item, $obj)
         $class = 'mjs-nestedSortable-leaf';
     }
 
-    echo '<li id="list_'.$item->getId().'" class="'.$class.'">
+    echo '<li id="list_' . $item->getId() . '" class="' . $class . '">
         <div><span class="disclose"><i class="fa-solid fa-circle-minus"></i>
-            <input type="hidden" class="hidden_id" name="items['.$item->getId().'][id]" value="'.$item->getId().'" />
-            <input type="hidden" class="hidden_title" name="items['.$item->getId().'][title]" value="'.$item->getTitle().'" />
-            <input type="hidden" class="hidden_desc" name="items['.$item->getId().'][desc]" value="'.$item->getDesc().'" />
-            <input type="hidden" class="hidden_type" name="items['.$item->getId().'][type]" value="'.$item->getType().'" />
-            <input type="hidden" class="hidden_prefix" name="items['.$item->getId().'][prefix]" value="'.$item->getPrefix().'" />
-            <input type="hidden" class="hidden_read_access" name="items['.$item->getId().'][readAccess]" value="'.$item->getReadAccess().'" />
-            <input type="hidden" class="hidden_reply_access" name="items['.$item->getId().'][replyAccess]" value="'.$item->getReplyAccess().'" />
-            <input type="hidden" class="hidden_create_access" name="items['.$item->getId().'][createAccess]" value="'.$item->getCreateAccess().'" />
+            <input type="hidden" class="hidden_id" name="items[' . $item->getId() . '][id]" value="' . $item->getId() . '" />
+            <input type="hidden" class="hidden_title" name="items[' . $item->getId() . '][title]" value="' . $item->getTitle() . '" />
+            <input type="hidden" class="hidden_desc" name="items[' . $item->getId() . '][desc]" value="' . $item->getDesc() . '" />
+            <input type="hidden" class="hidden_type" name="items[' . $item->getId() . '][type]" value="' . $item->getType() . '" />
+            <input type="hidden" class="hidden_prefix" name="items[' . $item->getId() . '][prefix]" value="' . $item->getPrefix() . '" />
+            <input type="hidden" class="hidden_read_access" name="items[' . $item->getId() . '][readAccess]" value="' . $item->getReadAccess() . '" />
+            <input type="hidden" class="hidden_reply_access" name="items[' . $item->getId() . '][replyAccess]" value="' . $item->getReplyAccess() . '" />
+            <input type="hidden" class="hidden_create_access" name="items[' . $item->getId() . '][createAccess]" value="' . $item->getCreateAccess() . '" />
             <span></span>
         </span>
-        <span class="title">'.$item->getTitle().'</span>
+        <span class="title">' . $item->getTitle() . '</span>
         <span class="item_delete">
             <i class="fa-solid fa-circle-xmark"></i>
         </span><span class="item_edit">
@@ -52,9 +55,9 @@ function rec(ForumItem $item, $obj)
     <div class="col-lg-6">
         <ol id="sortable" class="sortable">
             <?php
-                foreach ($forumItems as $item) {
-                    rec($item, $this);
-                }
+            foreach ($forumItems as $item) {
+                rec($item, $this);
+            }
             ?>
         </ol>
     </div>
@@ -167,21 +170,24 @@ $(document).ready (
                         <div class="form-group"><label for="assignedGroupsRead" class="col-lg-3 control-label"><?=$this->getTrans('see') ?></label>\n\
                         <div class="col-lg-6"><select class="chosen-select form-control" id="assignedGroupsRead" name="user[groups][]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>\n\
                         \n\
-                        <?php foreach ($this->get('userGroupList') as $groupList): ?>\n\
+                        <?php foreach ($this->get('userGroupList') as $groupList) :
+                            ?>\n\
                         <option value="<?=$groupList->getId() ?>"><?=$this->escape($groupList->getName()) ?></option>\n\
                         <?php endforeach; ?>\n\
                         </select></div></div>\n\
                         <div class="form-group"><label for="assignedGroupsReply" class="col-lg-3 control-label"><?=$this->getTrans('answer') ?></label>\n\
                         <div class="col-lg-6"><select class="chosen-select form-control" id="assignedGroupsReply" name="user[groups][]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>\n\
                         \n\
-                        <?php foreach ($this->get('userGroupList') as $groupList): ?>\n\
+                        <?php foreach ($this->get('userGroupList') as $groupList) :
+                            ?>\n\
                         <option value="<?=$groupList->getId() ?>"><?=$this->escape($groupList->getName()) ?></option>\n\
                         <?php endforeach; ?>\n\
                         </select></div></div>\n\
                         <div class="form-group"><label for="assignedGroupsCreate" class="col-lg-3 control-label"><?=$this->getTrans('create') ?></label>\n\
                         <div class="col-lg-6"><select class="chosen-select form-control" id="assignedGroupsCreate" name="user[groups][]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>\n\
                         \n\
-                        <?php foreach ($this->get('userGroupList') as $groupList): ?>\n\
+                        <?php foreach ($this->get('userGroupList') as $groupList) :
+                            ?>\n\
                         <option value="<?=$groupList->getId() ?>"><?=$this->escape($groupList->getName()) ?></option>\n\
                         <?php endforeach; ?>\n\
                         </select></div></div>';
@@ -305,8 +311,8 @@ $(document).ready (
 </script>
 <script>
 <?=$this->getMedia()
-        ->addMediaButton($this->getUrl('admin/media/iframe/multi/type/file/id/'.$this->getRequest()->getParam('id')))
-        ->addActionButton($this->getUrl('admin/downloads/downloads/treatdownloads/id/'.$this->getRequest()->getParam('id')))
+        ->addMediaButton($this->getUrl('admin/media/iframe/multi/type/file/id/' . $this->getRequest()->getParam('id')))
+        ->addActionButton($this->getUrl('admin/downloads/downloads/treatdownloads/id/' . $this->getRequest()->getParam('id')))
         ->addUploadController($this->getUrl('admin/media/index/upload'))
 ?>
 

--- a/application/modules/forum/views/admin/index/index.php
+++ b/application/modules/forum/views/admin/index/index.php
@@ -170,24 +170,21 @@ $(document).ready (
                         <div class="form-group"><label for="assignedGroupsRead" class="col-lg-3 control-label"><?=$this->getTrans('see') ?></label>\n\
                         <div class="col-lg-6"><select class="chosen-select form-control" id="assignedGroupsRead" name="user[groups][]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>\n\
                         \n\
-                        <?php foreach ($this->get('userGroupList') as $groupList) :
-                            ?>\n\
+                        <?php foreach ($this->get('userGroupList') as $groupList) : ?>\n\
                         <option value="<?=$groupList->getId() ?>"><?=$this->escape($groupList->getName()) ?></option>\n\
                         <?php endforeach; ?>\n\
                         </select></div></div>\n\
                         <div class="form-group"><label for="assignedGroupsReply" class="col-lg-3 control-label"><?=$this->getTrans('answer') ?></label>\n\
                         <div class="col-lg-6"><select class="chosen-select form-control" id="assignedGroupsReply" name="user[groups][]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>\n\
                         \n\
-                        <?php foreach ($this->get('userGroupList') as $groupList) :
-                            ?>\n\
+                        <?php foreach ($this->get('userGroupList') as $groupList) : ?>\n\
                         <option value="<?=$groupList->getId() ?>"><?=$this->escape($groupList->getName()) ?></option>\n\
                         <?php endforeach; ?>\n\
                         </select></div></div>\n\
                         <div class="form-group"><label for="assignedGroupsCreate" class="col-lg-3 control-label"><?=$this->getTrans('create') ?></label>\n\
                         <div class="col-lg-6"><select class="chosen-select form-control" id="assignedGroupsCreate" name="user[groups][]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>\n\
                         \n\
-                        <?php foreach ($this->get('userGroupList') as $groupList) :
-                            ?>\n\
+                        <?php foreach ($this->get('userGroupList') as $groupList) : ?>\n\
                         <option value="<?=$groupList->getId() ?>"><?=$this->escape($groupList->getName()) ?></option>\n\
                         <?php endforeach; ?>\n\
                         </select></div></div>';

--- a/application/modules/forum/views/admin/index/index.php
+++ b/application/modules/forum/views/admin/index/index.php
@@ -2,15 +2,13 @@
 
 use Modules\Forum\Models\ForumItem;
 
-$forumMapper = $this->get('forumMapper');
 $forumItems = $this->get('forumItems');
 
-function rec(ForumItem $item, $forumMapper, $obj)
+function rec(ForumItem $item, $obj)
 {
-    $subItems = $forumMapper->getforumItemsByParent($item->getId());
     $class = 'mjs-nestedSortable-branch mjs-nestedSortable-expanded';
 
-    if (empty($subItems)) {
+    if (empty($item->getSubItems())) {
         $class = 'mjs-nestedSortable-leaf';
     }
 
@@ -34,11 +32,11 @@ function rec(ForumItem $item, $forumMapper, $obj)
         </span>
     </div>';
 
-    if (!empty($subItems)) {
+    if (!empty($item->getSubItems())) {
         echo '<ol>';
 
-        foreach ($subItems as $subItem) {
-            rec($subItem, $forumMapper, $obj);
+        foreach ($item->getSubItems() as $subItem) {
+            rec($subItem, $obj);
         }
 
         echo '</ol>';
@@ -55,7 +53,7 @@ function rec(ForumItem $item, $forumMapper, $obj)
         <ol id="sortable" class="sortable">
             <?php
                 foreach ($forumItems as $item) {
-                    rec($item, $forumMapper, $this);
+                    rec($item, $this);
                 }
             ?>
         </ol>

--- a/application/modules/forum/views/admin/ranks/index.php
+++ b/application/modules/forum/views/admin/ranks/index.php
@@ -1,3 +1,7 @@
+<?php
+
+/** @var \Ilch\View $this */
+?>
 <h1><?=$this->getTrans('ranks') ?></h1>
 <form class="form-horizontal" method="POST">
     <?=$this->getTokenField() ?>
@@ -20,8 +24,10 @@
                 </tr>
             </thead>
             <tbody>
-                <?php if (!empty($this->get('ranks'))): ?>
-                    <?php foreach ($this->get('ranks') as $rank): ?>
+                <?php if (!empty($this->get('ranks'))) : ?>
+                    <?php
+                    /** @var \Modules\Forum\Models\Rank $rank */
+                    foreach ($this->get('ranks') as $rank) : ?>
                         <tr>
                             <td><?=$this->getDeleteCheckbox('check_forumRanks', $rank->getId()) ?></td>
                             <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $rank->getId()]) ?></td>
@@ -30,7 +36,7 @@
                             <td><?=$rank->getPosts() ?></td>
                         </tr>
                     <?php endforeach; ?>
-                <?php else: ?>
+                <?php else : ?>
                     <tr>
                         <td colspan="5"><?=$this->getTrans('noRanks') ?></td>
                     </tr>

--- a/application/modules/forum/views/admin/ranks/treat.php
+++ b/application/modules/forum/views/admin/ranks/treat.php
@@ -1,3 +1,7 @@
+<?php
+
+/** @var \Ilch\View $this */
+?>
 <h1><?=($this->get('rank')) ? $this->getTrans('edit') : $this->getTrans('add') ?></h1>
 <form class="form-horizontal" method="POST">
     <?=$this->getTokenField() ?>

--- a/application/modules/forum/views/admin/reports/index.php
+++ b/application/modules/forum/views/admin/reports/index.php
@@ -1,4 +1,7 @@
 <?php
+
+/** @var \Ilch\View $this */
+
 $reasonTransKeys = [
     '1' => 'illegalContent',
     '2' => 'spam',
@@ -7,7 +10,7 @@ $reasonTransKeys = [
 ]
 ?>
 <h1><?=$this->getTrans('reports') ?></h1>
-<?php if (!empty($this->get('reports'))): ?>
+<?php if (!empty($this->get('reports'))) : ?>
     <form class="form-horizontal" method="POST">
         <?=$this->getTokenField() ?>
         <div class="table-responsive">
@@ -33,7 +36,9 @@ $reasonTransKeys = [
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($this->get('reports') as $report): ?>
+                    <?php
+                    /** @var \Modules\Forum\Models\Report $report */
+                    foreach ($this->get('reports') as $report) : ?>
                         <tr>
                             <td><?=$this->getDeleteCheckbox('check_forumReports', $report->getId()) ?></td>
                             <td><?=$this->getDeleteIcon(['action' => 'delete', 'id' => $report->getId()]) ?></td>
@@ -41,7 +46,7 @@ $reasonTransKeys = [
                             <td><?=$this->getTrans($reasonTransKeys[$report->getReason()]) ?></td>
                             <td><a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'reports', 'action' => 'show', 'id' => $report->getId()], 'admin') ?>"><?=$this->getTrans('showDetails') ?></a></td>
                             <?php if ($report->getTopicId()) : ?>
-                            <td><a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'showposts', 'action' => 'index', 'topicid' => $report->getTopicId().'#'.$report->getPostId()], '') ?>" target="_blank"><?=$this->getTrans('showPost') ?></a></td>
+                            <td><a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'showposts', 'action' => 'index', 'topicid' => $report->getTopicId() . '#' . $report->getPostId()], '') ?>" target="_blank"><?=$this->getTrans('showPost') ?></a></td>
                             <?php else : ?>
                             <td><?=$this->getTrans('reportPostNotExisting') ?></td>
                             <?php endif; ?>
@@ -53,7 +58,7 @@ $reasonTransKeys = [
         </div>
         <?=$this->getListBar(['delete' => 'delete']) ?>
     </form>
-<?php else: ?>
+<?php else : ?>
     <tr>
         <td colspan="5"><?=$this->getTrans('noReports') ?></td>
     </tr>

--- a/application/modules/forum/views/admin/reports/show.php
+++ b/application/modules/forum/views/admin/reports/show.php
@@ -1,15 +1,18 @@
 <?php
+
+/** @var \Ilch\View $this */
+
 $reasonTransKeys = [
     '1' => 'illegalContent',
     '2' => 'spam',
     '3' => 'wrongTopic',
     '4' => 'other',
 ];
-
+/** @var \Modules\Forum\Models\Report|null $report */
 $report = $this->get('report');
 ?>
 <h1><?=$this->getTrans('report') ?></h1>
-<?php if (!empty($report)): ?>
+<?php if (!empty($report)) : ?>
     <div class="form-group">
         <label for="date" class="col-lg-2 control-label">
             <?=$this->getTrans('date') ?>:
@@ -42,6 +45,6 @@ $report = $this->get('report');
             <p><?=$this->escape($report->getUsername()) ?></p>
         </div>
     </div>
-<?php else: ?>
+<?php else : ?>
     <?=$this->getTrans('noReports') ?>
 <?php endif; ?>

--- a/application/modules/forum/views/admin/settings/groupappearance.php
+++ b/application/modules/forum/views/admin/settings/groupappearance.php
@@ -1,4 +1,8 @@
 <?php
+
+/** @var \Ilch\View $this */
+
+/** @var array $appearances */
 $appearances = $this->get('appearances');
 ?>
 <h1><?=$this->getTrans('groupAppearanceSettings') ?></h1>
@@ -21,10 +25,13 @@ $appearances = $this->get('appearances');
             </tr>
             </thead>
             <tbody>
-            <?php foreach ($this->get('groupList') as $group) : ?>
-                <?php if ($group->getId() == 3) {
-    continue;
-} ?>
+            <?php
+            /** @var \Modules\User\Models\Group $group */
+            foreach ($this->get('groupList') as $group) : ?>
+                <?php
+                if ($group->getId() == 3) {
+                    continue;
+                } ?>
                 <tr>
                     <td>
                         <input type="checkbox" id="active<?=$group->getId() ?>" name="appearances[<?=$group->getId() ?>][active]" <?=(isset($appearances[$group->getId()]['active'])) ? 'checked' : '' ?>>

--- a/application/modules/forum/views/admin/settings/index.php
+++ b/application/modules/forum/views/admin/settings/index.php
@@ -1,3 +1,7 @@
+<?php
+
+/** @var \Ilch\View $this */
+?>
 <h1><?=$this->getTrans('settings') ?></h1>
 <form class="form-horizontal" method="POST">
     <?=$this->getTokenField() ?>
@@ -51,6 +55,7 @@
                     data-placeholder="<?=$this->getTrans('excludeFloodProtection') ?>"
                     multiple>
                 <?php
+                /** @var \Modules\User\Models\Group $group */
                 foreach ($this->get('groupList') as $group) {
                     ?>
                     <option value="<?=$group->getId() ?>"

--- a/application/modules/forum/views/edittopic/index.php
+++ b/application/modules/forum/views/edittopic/index.php
@@ -1,10 +1,9 @@
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 <?php
 $forumItems = $this->get('forumItems');
-$readAccess = $this->get('groupIdsArray');
 $editTopicItems = $this->get('editTopicItems');
 
-function rec($item, $obj, $readAccess, $i)
+function rec($item, $obj, $i)
 {
     $subItems = $item->getSubItems();
     $adminAccess = null;
@@ -14,7 +13,7 @@ function rec($item, $obj, $readAccess, $i)
     $subItemsFalse = false;
     if (!empty($subItems) && ($item->getType() === 0)) {
         foreach ($subItems as $subItem) {
-            if ($adminAccess || is_in_array($readAccess, explode(',', $subItem->getReadAccess()))) {
+            if ($adminAccess || $subItem->getReadAccess()) {
                 $subItemsFalse = true;
             }
         }
@@ -23,7 +22,7 @@ function rec($item, $obj, $readAccess, $i)
         <optgroup label="<?=$item->getTitle() ?>"></optgroup>
     <?php endif; ?>
 
-    <?php if ($adminAccess || is_in_array($readAccess, explode(',', $item->getReadAccess()))): ?>
+    <?php if ($adminAccess || $item->getReadAccess()): ?>
         <?php if ($item->getType() != 0): ?>
             <?php $selected = ''; ?>
             <?php if ($item->getId() == $obj->getRequest()->getParam('forumid')): ?>
@@ -36,7 +35,7 @@ function rec($item, $obj, $readAccess, $i)
     if (!empty($subItems) && $i == 0) {
         $i++;
         foreach ($subItems as $subItem) {
-            rec($subItem, $obj, $readAccess, $i);
+            rec($subItem, $obj, $i);
         }
     }
 }
@@ -60,7 +59,7 @@ function rec($item, $obj, $readAccess, $i)
                         <div class="col-lg-6">
                             <select class="form-control" id="selectForum" name="edit">
                                 <?php foreach ($forumItems as $item): ?>
-                                    <?php rec($item, $this, $readAccess, $i = null) ?>
+                                    <?php rec($item, $this, $i = null) ?>
                                 <?php endforeach; ?>
                             </select>
                             <?php foreach ($editTopicItems as $editId): ?>

--- a/application/modules/forum/views/edittopic/index.php
+++ b/application/modules/forum/views/edittopic/index.php
@@ -1,9 +1,14 @@
+<?php
+
+/** @var \Ilch\View $this */
+?>
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 <?php
+/** @var \Modules\Forum\Models\ForumItem[]|null $forumItems */
 $forumItems = $this->get('forumItems');
 $editTopicItems = $this->get('editTopicItems');
 
-function rec($item, $obj, $i)
+function rec(\Modules\Forum\Models\ForumItem $item, \Ilch\View $obj, ?int $i)
 {
     $subItems = $item->getSubItems();
     $adminAccess = null;
@@ -18,14 +23,14 @@ function rec($item, $obj, $i)
             }
         }
     } ?>
-    <?php if ($subItemsFalse && $item->getType() === 0): ?>
+    <?php if ($subItemsFalse && $item->getType() === 0) : ?>
         <optgroup label="<?=$item->getTitle() ?>"></optgroup>
     <?php endif; ?>
 
-    <?php if ($adminAccess || $item->getReadAccess()): ?>
-        <?php if ($item->getType() != 0): ?>
+    <?php if ($adminAccess || $item->getReadAccess()) : ?>
+        <?php if ($item->getType() != 0) : ?>
             <?php $selected = ''; ?>
-            <?php if ($item->getId() == $obj->getRequest()->getParam('forumid')): ?>
+            <?php if ($item->getId() == $obj->getRequest()->getParam('forumid')) : ?>
                 <?php $selected = 'selected="selected"'; ?>
             <?php endif; ?>
                 <option value="<?=$item->getId() ?>" <?=$selected?>><?=$item->getTitle() ?></option>
@@ -58,11 +63,11 @@ function rec($item, $obj, $i)
                         </label>
                         <div class="col-lg-6">
                             <select class="form-control" id="selectForum" name="edit">
-                                <?php foreach ($forumItems as $item): ?>
+                                <?php foreach ($forumItems as $item) : ?>
                                     <?php rec($item, $this, $i = null) ?>
                                 <?php endforeach; ?>
                             </select>
-                            <?php foreach ($editTopicItems as $editId): ?>
+                            <?php foreach ($editTopicItems as $editId) : ?>
                                 <input type="hidden" name="topicids[]" value="<?=$editId ?>" />
                             <?php endforeach; ?>
                         </div>

--- a/application/modules/forum/views/index/index.php
+++ b/application/modules/forum/views/index/index.php
@@ -3,7 +3,6 @@
 use Modules\Forum\Mappers\Forum as ForumMapper;
 
 $forumItems = $this->get('forumItems');
-$readAccess = $this->get('groupIdsArray');
 $usersOnlineList = $this->get('usersOnlineList');
 $usersWhoWasOnline = $this->get('usersWhoWasOnline');
 $usersOnline = $this->get('usersOnline');
@@ -11,7 +10,7 @@ $guestOnline = $this->get('guestOnline');
 $forumStatistics = $this->get('forumStatics');
 $onlineUsersHighestRankedGroup = $this->get('onlineUsersHighestRankedGroup');
 
-function rec($item, $obj, $readAccess, $i)
+function rec($item, $obj, $i)
 {
     $DESCPostorder = $obj->get('DESCPostorder');
     $postsPerPage = $obj->get('postsPerPage');
@@ -27,7 +26,7 @@ function rec($item, $obj, $readAccess, $i)
     $subItemsFalse = false;
     if (!empty($subItems) && ($item->getType() === 0)) {
         foreach ($subItems as $subItem) {
-            if ($adminAccess || is_in_array($readAccess, explode(',', $subItem->getReadAccess()))) {
+            if ($adminAccess || $subItem->getReadAccess()) {
                 $subItemsFalse = true;
             }
         }
@@ -52,7 +51,7 @@ function rec($item, $obj, $readAccess, $i)
         </ul>
     <?php endif; ?>
 
-    <?php if ($adminAccess || is_in_array($readAccess, explode(',', $item->getReadAccess()))): ?>
+    <?php if ($adminAccess || $item->getReadAccess()): ?>
         <?php if ($item->getType() != 0): ?>
             <ul class="forenlist forums">
                 <li class="row ilch-border ilch-bg--hover">
@@ -127,7 +126,7 @@ function rec($item, $obj, $readAccess, $i)
     if (!empty($subItems) && $i == 0) {
         $i++;
         foreach ($subItems as $subItem) {
-            rec($subItem, $obj, $readAccess, $i);
+            rec($subItem, $obj, $i);
         }
     }
 }
@@ -139,7 +138,7 @@ function rec($item, $obj, $readAccess, $i)
     <h1><?=$this->getTrans('forum') ?></h1>
     <?php foreach ($forumItems as $item): ?>
         <div class="forabg">
-            <?php rec($item, $this, $readAccess, $i = null) ?>
+            <?php rec($item, $this, $i = null) ?>
         </div>
     <?php endforeach; ?>
     <div class="foren-actions clearfix">

--- a/application/modules/forum/views/index/index.php
+++ b/application/modules/forum/views/index/index.php
@@ -1,16 +1,25 @@
 <?php
 
+/** @var \Ilch\View $this */
+
 use Modules\Forum\Mappers\Forum as ForumMapper;
 
+/** @var \Modules\Forum\Models\ForumItem[]|null $forumItems */
 $forumItems = $this->get('forumItems');
+/** @var Modules\User\Models\User[] $usersOnlineList */
 $usersOnlineList = $this->get('usersOnlineList');
+/** @var Modules\User\Models\User[] $usersWhoWasOnline */
 $usersWhoWasOnline = $this->get('usersWhoWasOnline');
+/** @var int $usersOnline */
 $usersOnline = $this->get('usersOnline');
+/** @var int $guestOnline */
 $guestOnline = $this->get('guestOnline');
+/** @var \Modules\Forum\Models\ForumStatistics $forumStatistics */
 $forumStatistics = $this->get('forumStatics');
+/** @var array $onlineUsersHighestRankedGroup */
 $onlineUsersHighestRankedGroup = $this->get('onlineUsersHighestRankedGroup');
 
-function rec($item, $obj, $i)
+function rec(\Modules\Forum\Models\ForumItem $item, \Ilch\View $obj, ?int $i)
 {
     $DESCPostorder = $obj->get('DESCPostorder');
     $postsPerPage = $obj->get('postsPerPage');
@@ -30,9 +39,8 @@ function rec($item, $obj, $i)
                 $subItemsFalse = true;
             }
         }
-    }
-?>
-    <?php if ($subItemsFalse && $item->getType() === 0): ?>
+    } ?>
+    <?php if ($subItemsFalse && $item->getType() === 0) : ?>
         <ul class="forenlist">
             <li class="header">
                 <dl class="title ilch-head">
@@ -42,7 +50,7 @@ function rec($item, $obj, $i)
                         </a>
                     </dt>
                 </dl>
-                <?php if ($item->getDesc() != ''): ?>
+                <?php if ($item->getDesc() != '') : ?>
                     <dl class="desc small ilch-bg ilch-border">
                         <?=$obj->escape($item->getDesc()) ?>
                     </dl>
@@ -51,18 +59,18 @@ function rec($item, $obj, $i)
         </ul>
     <?php endif; ?>
 
-    <?php if ($adminAccess || $item->getReadAccess()): ?>
-        <?php if ($item->getType() != 0): ?>
+    <?php if ($adminAccess || $item->getReadAccess()) : ?>
+        <?php if ($item->getType() != 0) : ?>
             <ul class="forenlist forums">
                 <li class="row ilch-border ilch-bg--hover">
                     <dl class="icon 
-                        <?php if ($obj->getUser()): ?>
-                            <?php if (!in_array($item->getId(), $obj->get('containsUnreadTopics'))): ?>
+                        <?php if ($obj->getUser()) : ?>
+                            <?php if (!in_array($item->getId(), $obj->get('containsUnreadTopics'))) : ?>
                                 topic-read
-                            <?php else: ?>
+                            <?php else : ?>
                                 topic-unread
                             <?php endif; ?>
-                        <?php else: ?>
+                        <?php else : ?>
                             topic-read
                         <?php endif; ?>
                     ">
@@ -88,12 +96,11 @@ function rec($item, $obj, $i)
                             </div>
                         </dd>
                         <dd class="lastpost small">
-                            <?php if ($lastPost): ?>
+                            <?php if ($lastPost) : ?>
                                 <?php
                                 /** @var ForumMapper $forumMapper */
                                 $forumMapper = $obj->get('forumMapper');
-                                $countPosts = $forumMapper->getCountPostsByTopicId($lastPost->getTopicId());
-                                ?>
+                                $countPosts = $forumMapper->getCountPostsByTopicId($lastPost->getTopicId()); ?>
                                 <div class="pull-left">
                                     <a href="<?=$obj->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$obj->escape($lastPost->getAutor()->getName()) ?>">
                                         <img style="width:40px; padding-right: 5px;" src="<?=$obj->getBaseUrl($lastPost->getAutor()->getAvatar()) ?>" alt="<?=$obj->escape($lastPost->getAutor()->getName()) ?>">
@@ -136,7 +143,7 @@ function rec($item, $obj, $i)
 
 <div id="forum">
     <h1><?=$this->getTrans('forum') ?></h1>
-    <?php foreach ($forumItems as $item): ?>
+    <?php foreach ($forumItems as $item) : ?>
         <div class="forabg">
             <?php rec($item, $this, $i = null) ?>
         </div>
@@ -144,15 +151,15 @@ function rec($item, $obj, $i)
     <div class="foren-actions clearfix">
         <ul class="pull-left">
             <li><a href="<?=$this->getUrl(['controller' => 'showunansweredtopics', 'action' => 'index']) ?>" class="ilch-link"><?=$this->getTrans('showUnansweredTopics') ?></a></li>
-            <?php if ($this->getUser()): ?>
+            <?php if ($this->getUser()) : ?>
                 <li><a href="<?=$this->getUrl(['controller' => 'shownewposts', 'action' => 'index']) ?>" class="ilch-link"><?=$this->getTrans('showNewPosts') ?></a></li>
             <?php endif; ?>
             <li><a href="<?=$this->getUrl(['controller' => 'showactivetopics', 'action' => 'index']) ?>" class="ilch-link"><?=$this->getTrans('showActiveTopics') ?></a></li>
-            <?php if ($this->getUser()): ?>
+            <?php if ($this->getUser()) : ?>
                 <li><a href="<?=$this->getUrl(['controller' => 'rememberedposts', 'action' => 'index']) ?>" class="ilch-link"><?=$this->getTrans('showRememberedPosts') ?></a></li>
             <?php endif; ?>
         </ul>
-        <?php if ($this->getUser()): ?>          
+        <?php if ($this->getUser()) : ?>          
             <div class="pull-right">
                 <a href="<?=$this->getUrl(['controller' => 'index', 'action' => 'markallasread'], null, true) ?>" class="ilch-link"><?=$this->getTrans('markAllAsRead') ?></a>
             </div>
@@ -164,12 +171,12 @@ function rec($item, $obj, $i)
         <div class="content ilch-border">
             <h5><i class="fa-solid fa-user"></i> <?=$this->getTrans('activeUser') ?></h5>
             <div class="statistics">
-                <a href="<?=$this->getUrl(['module' => 'statistic', 'controller' => 'index', 'action' => 'online']) ?>" class="ilch-link"><?=$usersOnline+$guestOnline ?> <?=$this->getTrans('usersOnline') ?></a>. <?=$this->getTrans('registeredUsers') ?>: <?=$usersOnline ?>, <?=$this->getTrans('guests') ?>: <?=$guestOnline ?><br />
+                <a href="<?=$this->getUrl(['module' => 'statistic', 'controller' => 'index', 'action' => 'online']) ?>" class="ilch-link"><?=$usersOnline + $guestOnline ?> <?=$this->getTrans('usersOnline') ?></a>. <?=$this->getTrans('registeredUsers') ?>: <?=$usersOnline ?>, <?=$this->getTrans('guests') ?>: <?=$guestOnline ?><br />
                 <ul class="user-list">
-                    <?php foreach ($usersOnlineList as $user): ?>
+                    <?php foreach ($usersOnlineList as $user) : ?>
                         <?php if (!empty($onlineUsersHighestRankedGroup[$user->getId()])) : ?>
                             <li><a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId()]) ?>" class="ilch-link"><span class="forum appearance<?=$onlineUsersHighestRankedGroup[$user->getId()] ?>"><?=$this->escape($user->getName()) ?></span></a></li>
-                        <?php else: ?>
+                        <?php else : ?>
                             <li><a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId()]) ?>" class="ilch-link"><?=$this->escape($user->getName()) ?></a></li>
                         <?php endif; ?>
                     <?php endforeach; ?>
@@ -178,8 +185,8 @@ function rec($item, $obj, $i)
                 <div class="small">
                     <ul class="group-legend">
                         <li><i class="fa-solid fa-bars"></i> <?=$this->getTrans('legend') ?>:</li>
-                        <?php foreach ($this->get('listGroups') as $group): ?>
-                            <?php if ($group->getName() !== 'Guest'): ?>
+                        <?php foreach ($this->get('listGroups') as $group) : ?>
+                            <?php if ($group->getName() !== 'Guest') : ?>
                                 <li class="group"><span class="forum appearance<?=$group->getId() ?>"><?=$group->getName() ?></span></li>
                             <?php endif; ?>
                         <?php endforeach; ?>
@@ -190,7 +197,7 @@ function rec($item, $obj, $i)
             <h5><i class="fa-solid fa-users"></i> <?=$this->getTrans('whoWasHere') ?></h5>
             <div class="statistics">
                 <ul class="user-list">
-                    <?php foreach ($usersWhoWasOnline as $user): ?>
+                    <?php foreach ($usersWhoWasOnline as $user) : ?>
                         <li><a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $user->getId()]) ?>" class="ilch-link"><?=$this->escape($user->getName()) ?></a></li>
                     <?php endforeach; ?>
                 </ul>

--- a/application/modules/forum/views/newpost/index.php
+++ b/application/modules/forum/views/newpost/index.php
@@ -1,20 +1,26 @@
 <?php
-$forumMapper = $this->get('forumMapper');
-$cat = $this->get('cat');
-$topicpost = $this->get('topicPost');
-$postTextAsQuote = $this->get('postTextAsQuote');
-$forum = $this->get('forum');
 
+/** @var \Ilch\View $this */
+
+/** @var \Modules\Forum\Mappers\Forum $forumMapper */
+$forumMapper = $this->get('forumMapper');
+/** @var \Modules\Forum\Models\ForumItem $cat */
+$cat = $this->get('cat');
+/** @var \Modules\Forum\Models\ForumTopic $topicpost */
+$topicpost = $this->get('topicPost');
+/** @var string $postTextAsQuote */
+$postTextAsQuote = $this->get('postTextAsQuote');
+/** @var \Modules\Forum\Models\ForumItem $forum */
+$forum = $this->get('forum');
 $forumPrefix = $forumMapper->getForumByTopicId($topicpost->getId());
 $prefix = '';
 if ($forumPrefix->getPrefix() != '' && $topicpost->getTopicPrefix() > 0) {
     $prefix = explode(',', $forumPrefix->getPrefix());
     array_unshift($prefix, '');
-
     foreach ($prefix as $key => $value) {
         if ($topicpost->getTopicPrefix() == $key) {
             $value = trim($value);
-            $prefix = '['.$value.'] ';
+            $prefix = '[' . $value . '] ';
         }
     }
 }
@@ -27,7 +33,7 @@ if ($forumPrefix->getPrefix() != '' && $topicpost->getTopicPrefix() > 0) {
         <a href="<?=$this->getUrl(['controller' => 'index', 'action' => 'index']) ?>"><?=$this->getTrans('forum') ?></a>
         <i class="fa-solid fa-chevron-right"></i> <a href="<?=$this->getUrl(['controller' => 'showcat', 'action' => 'index', 'id' => $cat->getId()]) ?>"><?=$cat->getTitle() ?></a>
         <i class="fa-solid fa-chevron-right"></i> <a href="<?=$this->getUrl(['controller' => 'showtopics', 'action' => 'index', 'forumid' => $forum->getId()]) ?>"><?=$forum->getTitle() ?></a>
-        <i class="fa-solid fa-chevron-right"></i> <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index', 'topicid' => $this->getRequest()->getParam('topicid')]) ?>"><?=$prefix.$topicpost->getTopicTitle() ?></a>
+        <i class="fa-solid fa-chevron-right"></i> <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index', 'topicid' => $this->getRequest()->getParam('topicid')]) ?>"><?=$prefix . $topicpost->getTopicTitle() ?></a>
         <i class="fa-solid fa-chevron-right"></i> <?=$this->getTrans('newPost') ?>
     </h1>
     <div class="row">

--- a/application/modules/forum/views/newtopic/index.php
+++ b/application/modules/forum/views/newtopic/index.php
@@ -1,7 +1,6 @@
 <?php
 $forum = $this->get('forum');
 $cat = $this->get('cat');
-$readAccess = $this->get('readAccess');
 
 $adminAccess = null;
 if ($this->getUser()) {
@@ -11,7 +10,7 @@ if ($this->getUser()) {
 
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 
-<?php if ($adminAccess || is_in_array($readAccess, explode(',', $forum->getCreateAccess()))): ?>
+<?php if ($adminAccess || $forum->getCreateAccess()): ?>
     <div id="forum">
         <h1>
             <a href="<?=$this->getUrl(['controller' => 'index', 'action' => 'index']) ?>"><?=$this->getTrans('forum') ?></a>

--- a/application/modules/forum/views/newtopic/index.php
+++ b/application/modules/forum/views/newtopic/index.php
@@ -1,5 +1,10 @@
 <?php
+
+/** @var \Ilch\View $this */
+
+/** @var \Modules\Forum\Models\ForumItem $forum */
 $forum = $this->get('forum');
+/** @var \Modules\Forum\Models\ForumItem $cat */
 $cat = $this->get('cat');
 
 $adminAccess = null;
@@ -10,7 +15,7 @@ if ($this->getUser()) {
 
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 
-<?php if ($adminAccess || $forum->getCreateAccess()): ?>
+<?php if ($adminAccess || $forum->getCreateAccess()) : ?>
     <div id="forum">
         <h1>
             <a href="<?=$this->getUrl(['controller' => 'index', 'action' => 'index']) ?>"><?=$this->getTrans('forum') ?></a>
@@ -34,14 +39,14 @@ if ($this->getUser()) {
                                     <label for="topicTitle" class="col-lg-2 control-label">
                                         <?=$this->getTrans('topicTitle') ?>
                                     </label>
-                                    <?php if ($forum->getPrefix() != ''): ?>
+                                    <?php if ($forum->getPrefix() != '') : ?>
                                         <?php $prefix = explode(',', $forum->getPrefix()); ?>
                                         <?php array_unshift($prefix, ''); ?>
                                         <div class="col-lg-2 prefix">
                                             <select class="form-control" id="topicPrefix" name="topicPrefix">
-                                                <?php foreach ($prefix as $key => $value): ?>
+                                                <?php foreach ($prefix as $key => $value) : ?>
                                                     <?php $selected = ''; ?>
-                                                    <?php if ($key == $this->originalInput('topicPrefix')): ?>
+                                                    <?php if ($key == $this->originalInput('topicPrefix')) : ?>
                                                         <?php $selected = 'selected="selected"'; ?>
                                                     <?php endif; ?>
 
@@ -69,7 +74,7 @@ if ($this->getUser()) {
                                               toolbar="ilch_html_frontend"><?=$this->originalInput('text') ?></textarea>
                                     </div>
                                 </div>
-                                <?php if ($this->getUser()->isAdmin()): ?>
+                                <?php if ($this->getUser()->isAdmin()) : ?>
                                     <div class="form-group">
                                         <div class="col-lg-2 control-label">
                                             <?=$this->getTrans('forumOptions') ?>
@@ -101,9 +106,9 @@ if ($this->getUser()) {
             </div>
         </div>
     </div>
-<?php else: ?>
+<?php else : ?>
     <?php
-    header('location: ' .$this->getUrl(['controller' => 'index', 'action' => 'index', 'access' => 'noaccess']));
+    header('location: ' . $this->getUrl(['controller' => 'index', 'action' => 'index', 'access' => 'noaccess']));
     exit;
     ?>
 <?php endif; ?>

--- a/application/modules/forum/views/rememberedposts/index.php
+++ b/application/modules/forum/views/rememberedposts/index.php
@@ -1,10 +1,14 @@
 <?php
+
+/** @var \Ilch\View $this */
+
+/** @var \Modules\Forum\Models\ForumPost[]|null $rememberedPosts */
 $rememberedPosts = $this->get('rememberedPosts');
 ?>
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 
 <h1><?=$this->getTrans('rememberedPosts') ?></h1>
-<?php if (!empty($rememberedPosts)): ?>
+<?php if (!empty($rememberedPosts)) : ?>
     <form class="form-horizontal" method="POST">
         <?=$this->getTokenField() ?>
         <div id="rememberedPosts" class="table-responsive">
@@ -28,12 +32,12 @@ $rememberedPosts = $this->get('rememberedPosts');
                 </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($rememberedPosts as $post): ?>
+                    <?php foreach ($rememberedPosts as $post) : ?>
                         <tr>
                             <td><?=$this->getDeleteCheckbox('check_rememberedPosts', $post->getId()) ?></td>
                             <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $post->getId()]) ?></td>
                             <td><?=$this->getDeleteIcon(['action' => 'delete', 'id' => $post->getId()]) ?></td>
-                            <td><a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'showposts', 'action' => 'index', 'topicid' => $post->getTopicId().'#'.$post->getPostId()], '') ?>" target="_blank"><?=$this->escape($post->getTopicTitle()) ?></a></td>
+                            <td><a href="<?=$this->getUrl(['module' => 'forum', 'controller' => 'showposts', 'action' => 'index', 'topicid' => $post->getTopicId() . '#' . $post->getPostId()], '') ?>" target="_blank"><?=$this->escape($post->getTopicTitle()) ?></a></td>
                             <td><?=$this->escape($post->getNote()) ?></td>
                             <td><?=$post->getDate() ?></td>
                         </tr>
@@ -43,7 +47,7 @@ $rememberedPosts = $this->get('rememberedPosts');
         </div>
         <?=$this->getListBar(['delete' => 'delete']) ?>
     </form>
-<?php else: ?>
+<?php else : ?>
     <p><?=$this->getTrans('noRememberedPosts') ?></p>
 <?php endif; ?>
 

--- a/application/modules/forum/views/rememberedposts/treat.php
+++ b/application/modules/forum/views/rememberedposts/treat.php
@@ -1,3 +1,7 @@
+<?php
+
+/** @var \Ilch\View $this */
+?>
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 
 <h1><?=$this->getTrans('editRememberedPost') ?></h1>

--- a/application/modules/forum/views/showactivetopics/index.php
+++ b/application/modules/forum/views/showactivetopics/index.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @var \Ilch\View $this */
+
+/** @var array $topics */
 $topics = $this->get('topics');
 $DESCPostorder = $this->get('DESCPostorder');
 $postsPerPage = $this->get('postsPerPage');
@@ -23,22 +26,22 @@ $postsPerPage = $this->get('postsPerPage');
             </li>
         </ul>
         <ul class="topiclist topics">
-            <?php foreach ($topics as $topic): ?>
+            <?php foreach ($topics as $topic) : ?>
                 <li class="row ilch-border ilch-bg--hover">
                     <dl class="icon
-                        <?php if ($this->getUser()): ?>
-                            <?php if ($topic['topic']->getStatus() == 0 && $topic['lastPost']->getRead()): ?>
+                        <?php if ($this->getUser()) : ?>
+                            <?php if ($topic['topic']->getStatus() == 0 && $topic['lastPost']->getRead()) : ?>
                                 topic-read
-                            <?php elseif ($topic['topic']->getStatus() == 1 && $topic['lastPost']->getRead()): ?>
+                            <?php elseif ($topic['topic']->getStatus() == 1 && $topic['lastPost']->getRead()) : ?>
                                 topic-read-locked
-                            <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                            <?php elseif ($topic['topic']->getStatus() == 1) : ?>
                                 topic-unread-locked
-                            <?php else: ?>
+                            <?php else : ?>
                                 topic-unread
                             <?php endif; ?>
-                        <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                        <?php elseif ($topic['topic']->getStatus() == 1) : ?>
                             topic-read-locked
-                        <?php else: ?>
+                        <?php else : ?>
                             topic-read
                         <?php endif; ?>
                     ">
@@ -50,7 +53,7 @@ $postsPerPage = $this->get('postsPerPage');
 
                                 foreach ($prefix as $key => $value) {
                                     if ($topic['topic']->getTopicPrefix() == $key) {
-                                        echo '<span class="label label-default">'.$value.'</span>';
+                                        echo '<span class="label label-default">' . $value . '</span>';
                                     }
                                 }
                             }
@@ -58,7 +61,7 @@ $postsPerPage = $this->get('postsPerPage');
                             <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic['topic']->getId()]) ?>" class="topictitle">
                                 <?=$topic['topic']->getTopicTitle() ?>
                             </a>
-                            <?php if ($topic['topic']->getType() == '1'): ?>
+                            <?php if ($topic['topic']->getType() == '1') : ?>
                                 <i class="fa-solid fa-thumbtack"></i>
                             <?php endif; ?>
                             <br>

--- a/application/modules/forum/views/showactivetopics/index.php
+++ b/application/modules/forum/views/showactivetopics/index.php
@@ -1,24 +1,6 @@
 <?php
 
-use Ilch\Date;
-use Modules\Forum\Mappers\Forum;
-use Modules\Forum\Mappers\Topic;
-use Modules\Forum\Mappers\Post;
-
 $topics = $this->get('topics');
-/** @var Forum $forumMapper */
-$forumMapper = $this->get('forumMapper');
-/** @var Topic $topicMapper */
-$topicMapper = $this->get('topicMapper');
-/** @var Post $postMapper */
-$postMapper = $this->get('postMapper');
-$date = new Date();
-$dateLessHours = new Date('-1 day');
-$groupIdsArray = $this->get('groupIdsArray');
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
 $DESCPostorder = $this->get('DESCPostorder');
 $postsPerPage = $this->get('postsPerPage');
 ?>
@@ -42,92 +24,85 @@ $postsPerPage = $this->get('postsPerPage');
         </ul>
         <ul class="topiclist topics">
             <?php foreach ($topics as $topic): ?>
-                <?php $forum = $forumMapper->getForumById($topic->getForumId()); ?>
-                <?php if ($adminAccess || is_in_array($groupIdsArray, explode(',', $forum->getReadAccess()))): ?>
-                    <?php $forumPrefix = $forumMapper->getForumByTopicId($topic->getId()) ?>
-                    <?php $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId()) ?>
-                    <?php if ($lastPost->getDateCreated() < $date->format('Y-m-d H:i:s', true) && $lastPost->getDateCreated() > $dateLessHours->format('Y-m-d H:i:s', true)): ?>
-                        <li class="row ilch-border ilch-bg--hover">
-                            <dl class="icon 
-                                <?php if ($this->getUser()): ?>
-                                    <?php if ($topic->getStatus() == 0 && $lastPost->getRead()): ?>
-                                        topic-read
-                                    <?php elseif ($topic->getStatus() == 1 && $lastPost->getRead()): ?>
-                                        topic-read-locked
-                                    <?php elseif ($topic->getStatus() == 1): ?>
-                                        topic-unread-locked
-                                    <?php else: ?>
-                                        topic-unread
-                                    <?php endif; ?>
-                                <?php elseif ($topic->getStatus() == 1): ?>
-                                    topic-read-locked
-                                <?php else: ?>
-                                    topic-read
-                                <?php endif; ?>
-                            ">
-                                <dt>
-                                    <?php
-                                    if ($forumPrefix->getPrefix() != '' && $topic->getTopicPrefix() > 0) {
-                                        $prefix = explode(',', $forumPrefix->getPrefix());
-                                        array_unshift($prefix, '');
+                <li class="row ilch-border ilch-bg--hover">
+                    <dl class="icon
+                        <?php if ($this->getUser()): ?>
+                            <?php if ($topic['topic']->getStatus() == 0 && $topic['lastPost']->getRead()): ?>
+                                topic-read
+                            <?php elseif ($topic['topic']->getStatus() == 1 && $topic['lastPost']->getRead()): ?>
+                                topic-read-locked
+                            <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                                topic-unread-locked
+                            <?php else: ?>
+                                topic-unread
+                            <?php endif; ?>
+                        <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                            topic-read-locked
+                        <?php else: ?>
+                            topic-read
+                        <?php endif; ?>
+                    ">
+                        <dt>
+                            <?php
+                            if ($topic['forumPrefix'] != '' && $topic['topic']->getTopicPrefix() > 0) {
+                                $prefix = explode(',', $topic['forumPrefix']);
+                                array_unshift($prefix, '');
 
-                                        foreach ($prefix as $key => $value) {
-                                            if ($topic->getTopicPrefix() == $key) {
-                                                echo '<span class="label label-default">'.$value.'</span>';
-                                            }
-                                        }
+                                foreach ($prefix as $key => $value) {
+                                    if ($topic['topic']->getTopicPrefix() == $key) {
+                                        echo '<span class="label label-default">'.$value.'</span>';
                                     }
-                                    ?>
-                                    <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic->getId()]) ?>" class="topictitle">
-                                        <?=$topic->getTopicTitle() ?>
-                                    </a>
-                                    <?php if ($topic->getType() == '1'): ?>
-                                        <i class="fa-solid fa-thumbtack"></i>
-                                    <?php endif; ?>
-                                    <br>
-                                    <div class="small">
-                                        <?=$this->getTrans('by') ?>
-                                        <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic->getAuthor()->getId()]) ?>" class="ilch-link-red">
-                                            <?=$this->escape($topic->getAuthor()->getName()) ?>
-                                        </a>
-                                        »
-                                        <?=$topic->getDateCreated() ?>
-                                    </div>
-                                </dt>
-                                <dd class="posts small">
-                                    <div class="pull-left text-nowrap stats">
-                                        <?=$this->getTrans('replies') ?>:
-                                        <br />
-                                        <?=$this->getTrans('views') ?>:
-                                    </div>
-                                    <div class="pull-left text-justify">
-                                        <?=$topic->getCountPosts() - 1 ?>
-                                        <br />
-                                        <?=$topic->getVisits() ?>
-                                    </div>
-                                </dd>
-                                <dd class="lastpost small">
-                                    <div class="pull-left">
-                                        <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
-                                            <img style="width:40px; padding-right: 5px;" src="<?=$this->getBaseUrl($lastPost->getAutor()->getAvatar()) ?>" alt="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
-                                        </a>
-                                    </div>
-                                    <div class="pull-left">
-                                        <?=$this->getTrans('by') ?>
-                                        <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
-                                            <?=$this->escape($lastPost->getAutor()->getName()) ?>
-                                        </a>
-                                        <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index', 'topicid' => $lastPost->getTopicId(), 'page' => ($DESCPostorder ? 1 : ceil($topic->getCountPosts() / $postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
-                                            <img src="<?=$this->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$this->getTrans('viewLastPost') ?>" title="<?=$this->getTrans('viewLastPost') ?>" height="10" width="12">
-                                        </a>
-                                        <br>
-                                        <?=$lastPost->getDateCreated() ?>
-                                    </div>
-                                </dd>
-                            </dl>
-                        </li>
-                    <?php endif; ?>
-                <?php endif; ?>
+                                }
+                            }
+                            ?>
+                            <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic['topic']->getId()]) ?>" class="topictitle">
+                                <?=$topic['topic']->getTopicTitle() ?>
+                            </a>
+                            <?php if ($topic['topic']->getType() == '1'): ?>
+                                <i class="fa-solid fa-thumbtack"></i>
+                            <?php endif; ?>
+                            <br>
+                            <div class="small">
+                                <?=$this->getTrans('by') ?>
+                                <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['topic']->getAuthor()->getId()]) ?>" class="ilch-link-red">
+                                    <?=$this->escape($topic['topic']->getAuthor()->getName()) ?>
+                                </a>
+                                »
+                                <?=$topic['topic']->getDateCreated() ?>
+                            </div>
+                        </dt>
+                        <dd class="posts small">
+                            <div class="pull-left text-nowrap stats">
+                                <?=$this->getTrans('replies') ?>:
+                                <br />
+                                <?=$this->getTrans('views') ?>:
+                            </div>
+                            <div class="pull-left text-justify">
+                                <?=$topic['topic']->getCountPosts() - 1 ?>
+                                <br />
+                                <?=$topic['topic']->getVisits() ?>
+                            </div>
+                        </dd>
+                        <dd class="lastpost small">
+                            <div class="pull-left">
+                                <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['lastPost']->getAutor()->getId()]) ?>" title="<?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>">
+                                    <img style="width:40px; padding-right: 5px;" src="<?=$this->getBaseUrl($topic['lastPost']->getAutor()->getAvatar()) ?>" alt="<?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>">
+                                </a>
+                            </div>
+                            <div class="pull-left">
+                                <?=$this->getTrans('by') ?>
+                                <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['lastPost']->getAutor()->getId()]) ?>" title="<?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>">
+                                    <?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>
+                                </a>
+                                <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index', 'topicid' => $topic['lastPost']->getTopicId(), 'page' => ($DESCPostorder ? 1 : ceil($topic['topic']->getCountPosts() / $postsPerPage))]) ?>#<?=$topic['lastPost']->getId() ?>">
+                                    <img src="<?=$this->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$this->getTrans('viewLastPost') ?>" title="<?=$this->getTrans('viewLastPost') ?>" height="10" width="12">
+                                </a>
+                                <br>
+                                <?=$topic['lastPost']->getDateCreated() ?>
+                            </div>
+                        </dd>
+                    </dl>
+                </li>
             <?php endforeach; ?>
         </ul>
     </div>

--- a/application/modules/forum/views/showcat/index.php
+++ b/application/modules/forum/views/showcat/index.php
@@ -1,14 +1,19 @@
 <?php
 
+/** @var \Ilch\View $this */
+
 use Modules\Forum\Mappers\Forum;
 
-/** @var Forum $forumMapper */
-$forumMapper = $this->get('forumMapper');
+/** @var \Modules\Forum\Models\ForumItem[]|null $forumItems */
 $forumItems = $this->get('forumItems');
+/** @var \Modules\Forum\Models\ForumItem $cat */
 $cat = $this->get('cat');
 
-function rec($item, $forumMapper, $obj)
+function rec($item, \Ilch\View $obj)
 {
+    /** @var Forum $forumMapper */
+    $forumMapper = $obj->get('forumMapper');
+
     $DESCPostorder = $obj->get('DESCPostorder');
     $postsPerPage = $obj->get('postsPerPage');
     $subItems = $item->getSubItems();
@@ -18,9 +23,8 @@ function rec($item, $forumMapper, $obj)
     $adminAccess = null;
     if ($obj->getUser()) {
         $adminAccess = $obj->getUser()->isAdmin();
-    }
-?>
-    <?php if ($item->getType() === 0): ?>
+    } ?>
+    <?php if ($item->getType() === 0) : ?>
         <ul class="forenlist">
             <li class="header">
                 <dl class="title ilch-head">
@@ -30,7 +34,7 @@ function rec($item, $forumMapper, $obj)
                         </a>
                     </dt>
                 </dl>
-                <?php if ($item->getDesc() != ''): ?>
+                <?php if ($item->getDesc() != '') : ?>
                     <dl class="desc small">
                         <?=$obj->escape($item->getDesc()) ?>
                     </dl>
@@ -39,18 +43,18 @@ function rec($item, $forumMapper, $obj)
         </ul>
     <?php endif; ?>
 
-    <?php if ($adminAccess || $item->getReadAccess()): ?>
-        <?php if ($item->getType() != 0): ?>
+    <?php if ($adminAccess || $item->getReadAccess()) : ?>
+        <?php if ($item->getType() != 0) : ?>
             <ul class="forenlist forums">
                 <li class="row ilch-border ilch-bg--hover">
                     <dl class="icon 
-                        <?php if ($obj->getUser()): ?>
-                            <?php if (!in_array($item->getId(), $obj->get('containsUnreadTopics'))): ?>
+                        <?php if ($obj->getUser()) : ?>
+                            <?php if (!in_array($item->getId(), $obj->get('containsUnreadTopics'))) : ?>
                                 topic-read
-                            <?php else: ?>
+                            <?php else : ?>
                                 topic-unread
                             <?php endif; ?>
-                        <?php else: ?>
+                        <?php else : ?>
                             topic-read
                         <?php endif; ?>
                     ">
@@ -76,7 +80,7 @@ function rec($item, $forumMapper, $obj)
                             </div>
                         </dd>
                         <dd class="lastpost small">
-                            <?php if ($lastPost): ?>
+                            <?php if ($lastPost) : ?>
                                 <?php $countPosts = $forumMapper->getCountPostsByTopicId($lastPost->getTopicId()) ?>
                                 <div class="pull-left">
                                     <a href="<?=$obj->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$obj->escape($lastPost->getAutor()->getName()) ?>">
@@ -108,7 +112,7 @@ function rec($item, $forumMapper, $obj)
     <?php
     if (!empty($subItems)) {
         foreach ($subItems as $subItem) {
-            rec($subItem, $forumMapper, $obj);
+            rec($subItem, $obj);
         }
     }
 }
@@ -127,13 +131,13 @@ function rec($item, $forumMapper, $obj)
         $adminAccess = $this->getUser()->isAdmin();
     }
     $subItemsFalse = false;
-        foreach ($forumItems as $subItem) {
-            if ($adminAccess || $subItem->getReadAccess()) {
-                $subItemsFalse = true;
-            }
+    foreach ($forumItems as $subItem) {
+        if ($adminAccess || $subItem->getReadAccess()) {
+            $subItemsFalse = true;
         }
+    }
     ?>
-    <?php if (!empty($forumItems) && $subItemsFalse): ?>
+    <?php if (!empty($forumItems) && $subItemsFalse) : ?>
         <div class="forabg">
             <ul class="forenlist">
                 <li class="header">
@@ -144,7 +148,7 @@ function rec($item, $forumMapper, $obj)
                             </a>
                         </dt>
                     </dl>
-                    <?php if ($cat->getDesc() != ''): ?>
+                    <?php if ($cat->getDesc() != '') : ?>
                         <dl class="desc small ilch-bg ilch-border">
                             <?=$cat->getDesc() ?>
                         </dl>
@@ -153,16 +157,16 @@ function rec($item, $forumMapper, $obj)
             </ul>
             <?php
             foreach ($forumItems as $item) {
-                rec($item, $forumMapper, $this);
+                rec($item, $this);
             }
             ?>
         </div>
-    <?php else: ?>
-        <?php header('location: ' .$this->getUrl(['controller' => 'index', 'action' => 'index']));
+    <?php else : ?>
+        <?php header('location: ' . $this->getUrl(['controller' => 'index', 'action' => 'index']));
         exit; ?>
     <?php endif; ?>
     <div class="topic-actions">
-    <?php if ($this->getUser()): ?>
+    <?php if ($this->getUser()) : ?>
         <div class="pull-right">
             <a href="<?=$this->getUrl(['controller' => 'showcat', 'action' => 'markallasread', 'id' => $this->getRequest()->getParam('id')], null, true) ?>" class="ilch-link"><?=$this->getTrans('markAllAsRead') ?></a>
         </div>

--- a/application/modules/forum/views/showcat/index.php
+++ b/application/modules/forum/views/showcat/index.php
@@ -6,9 +6,8 @@ use Modules\Forum\Mappers\Forum;
 $forumMapper = $this->get('forumMapper');
 $forumItems = $this->get('forumItems');
 $cat = $this->get('cat');
-$readAccess = $this->get('readAccess');
 
-function rec($item, $forumMapper, $obj, $readAccess)
+function rec($item, $forumMapper, $obj)
 {
     $DESCPostorder = $obj->get('DESCPostorder');
     $postsPerPage = $obj->get('postsPerPage');
@@ -40,7 +39,7 @@ function rec($item, $forumMapper, $obj, $readAccess)
         </ul>
     <?php endif; ?>
 
-    <?php if ($adminAccess || is_in_array($readAccess, explode(',', $item->getReadAccess()))): ?>
+    <?php if ($adminAccess || $item->getReadAccess()): ?>
         <?php if ($item->getType() != 0): ?>
             <ul class="forenlist forums">
                 <li class="row ilch-border ilch-bg--hover">
@@ -109,7 +108,7 @@ function rec($item, $forumMapper, $obj, $readAccess)
     <?php
     if (!empty($subItems)) {
         foreach ($subItems as $subItem) {
-            rec($subItem, $forumMapper, $obj, $readAccess);
+            rec($subItem, $forumMapper, $obj);
         }
     }
 }
@@ -129,7 +128,7 @@ function rec($item, $forumMapper, $obj, $readAccess)
     }
     $subItemsFalse = false;
         foreach ($forumItems as $subItem) {
-            if ($adminAccess || is_in_array($readAccess, explode(',', $subItem->getReadAccess()))) {
+            if ($adminAccess || $subItem->getReadAccess()) {
                 $subItemsFalse = true;
             }
         }
@@ -154,7 +153,7 @@ function rec($item, $forumMapper, $obj, $readAccess)
             </ul>
             <?php
             foreach ($forumItems as $item) {
-                rec($item, $forumMapper, $this, $readAccess);
+                rec($item, $forumMapper, $this);
             }
             ?>
         </div>

--- a/application/modules/forum/views/shownewposts/index.php
+++ b/application/modules/forum/views/shownewposts/index.php
@@ -1,4 +1,8 @@
 <?php
+
+/** @var \Ilch\View $this */
+
+/** @var array $topics */
 $topics = $this->get('topics');
 $DESCPostorder = $this->get('DESCPostorder');
 $postsPerPage = $this->get('postsPerPage');
@@ -22,18 +26,18 @@ $postsPerPage = $this->get('postsPerPage');
             </li>
         </ul>
         <ul class="topiclist topics">
-            <?php foreach ($topics as $topic): ?>
+            <?php foreach ($topics as $topic) : ?>
                 <li class="row ilch-border ilch-bg--hover">
                     <dl class="icon
-                    <?php if ($this->getUser()): ?>
-                        <?php if ($topic['topic']->getStatus() == 1): ?>
+                    <?php if ($this->getUser()) : ?>
+                        <?php if ($topic['topic']->getStatus() == 1) : ?>
                             topic-unread-locked
-                        <?php else: ?>
+                        <?php else : ?>
                             topic-unread
                         <?php endif; ?>
-                    <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                    <?php elseif ($topic['topic']->getStatus() == 1) : ?>
                         topic-read-locked
-                    <?php else: ?>
+                    <?php else : ?>
                         topic-read
                     <?php endif; ?>
                 ">
@@ -45,7 +49,7 @@ $postsPerPage = $this->get('postsPerPage');
 
                                 foreach ($prefix as $key => $value) {
                                     if ($topic['topic']->getTopicPrefix() == $key) {
-                                        echo '<span class="label label-default">'.$value.'</span>';
+                                        echo '<span class="label label-default">' . $value . '</span>';
                                     }
                                 }
                             }
@@ -53,7 +57,7 @@ $postsPerPage = $this->get('postsPerPage');
                             <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic['topic']->getId()]) ?>" class="topictitle">
                                 <?=$topic['topic']->getTopicTitle() ?>
                             </a>
-                            <?php if ($topic['topic']->getType() == '1'): ?>
+                            <?php if ($topic['topic']->getType() == '1') : ?>
                                 <i class="fa-solid fa-thumbtack"></i>
                             <?php endif; ?>
                             <br>

--- a/application/modules/forum/views/shownewposts/index.php
+++ b/application/modules/forum/views/shownewposts/index.php
@@ -1,20 +1,5 @@
 <?php
-use Modules\Forum\Mappers\Forum;
-use Modules\Forum\Mappers\Topic;
-use Modules\Forum\Mappers\Post;
-
 $topics = $this->get('topics');
-/** @var Forum $forumMapper */
-$forumMapper = $this->get('forumMapper');
-/** @var Topic $topicMapper */
-$topicMapper = $this->get('topicMapper');
-/** @var Post $postMapper */
-$postMapper = $this->get('postMapper');
-$groupIdsArray = $this->get('groupIdsArray');
-$adminAccess = null;
-if ($this->getUser()) {
-    $adminAccess = $this->getUser()->isAdmin();
-}
 $DESCPostorder = $this->get('DESCPostorder');
 $postsPerPage = $this->get('postsPerPage');
 ?>
@@ -38,88 +23,81 @@ $postsPerPage = $this->get('postsPerPage');
         </ul>
         <ul class="topiclist topics">
             <?php foreach ($topics as $topic): ?>
-                <?php $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId()) ?>
-                <?php if (!$lastPost->getRead()): ?>
-                    <?php $forum = $forumMapper->getForumById($topic->getForumId()); ?>
-                    <?php $forumPrefix = $forumMapper->getForumByTopicId($topic->getId()) ?>
-                    <?php if ($adminAccess || is_in_array($groupIdsArray, explode(',', $forum->getReadAccess()))): ?>
-                        <li class="row ilch-border ilch-bg--hover">
-                            <dl class="icon
-                            <?php if ($this->getUser()): ?>
-                                <?php if ($topic->getStatus() == 1): ?>
-                                    topic-unread-locked
-                                <?php else: ?>
-                                    topic-unread
-                                <?php endif; ?>
-                            <?php elseif ($topic->getStatus() == 1): ?>
-                                topic-read-locked
-                            <?php else: ?>
-                                topic-read
-                            <?php endif; ?>
-                        ">
-                                <dt>
-                                    <?php
-                                    if ($forumPrefix->getPrefix() != '' && $topic->getTopicPrefix() > 0) {
-                                        $prefix = explode(',', $forumPrefix->getPrefix());
-                                        array_unshift($prefix, '');
-
-                                        foreach ($prefix as $key => $value) {
-                                            if ($topic->getTopicPrefix() == $key) {
-                                                echo '<span class="label label-default">'.$value.'</span>';
-                                            }
-                                        }
-                                    }
-                                    ?>
-                                    <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic->getId()]) ?>" class="topictitle">
-                                        <?=$topic->getTopicTitle() ?>
-                                    </a>
-                                    <?php if ($topic->getType() == '1'): ?>
-                                        <i class="fa-solid fa-thumbtack"></i>
-                                    <?php endif; ?>
-                                    <br>
-                                    <div class="small">
-                                        <?=$this->getTrans('by') ?>
-                                        <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic->getAuthor()->getId()]) ?>" class="ilch-link-red">
-                                            <?=$this->escape($topic->getAuthor()->getName()) ?>
-                                        </a>
-                                        »
-                                        <?=$topic->getDateCreated() ?>
-                                    </div>
-                                </dt>
-                                <dd class="posts small">
-                                    <div class="pull-left text-nowrap stats">
-                                        <?=$this->getTrans('replies') ?>:
-                                        <br />
-                                        <?=$this->getTrans('views') ?>:
-                                    </div>
-                                    <div class="pull-left text-justify">
-                                        <?=$topic->getCountPosts() - 1 ?>
-                                        <br />
-                                        <?=$topic->getVisits() ?>
-                                    </div>
-                                </dd>
-                                <dd class="lastpost small">
-                                    <div class="pull-left">
-                                        <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
-                                            <img style="width:40px; padding-right: 5px;" src="<?=$this->getBaseUrl($lastPost->getAutor()->getAvatar()) ?>" alt="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
-                                        </a>
-                                    </div>
-                                    <div class="pull-left">
-                                        <?=$this->getTrans('by') ?>
-                                        <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $lastPost->getAutor()->getId()]) ?>" title="<?=$this->escape($lastPost->getAutor()->getName()) ?>">
-                                            <?=$this->escape($lastPost->getAutor()->getName()) ?>
-                                        </a>
-                                        <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $lastPost->getTopicId(), 'page' => ($DESCPostorder ? 1 : ceil($topic->getCountPosts() / $postsPerPage))]) ?>#<?=$lastPost->getId() ?>">
-                                            <img src="<?=$this->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$this->getTrans('viewLastPost') ?>" title="<?=$this->getTrans('viewLastPost') ?>" height="10" width="12">
-                                        </a>
-                                        <br>
-                                        <?=$lastPost->getDateCreated() ?>
-                                    </div>
-                                </dd>
-                            </dl>
-                        </li>
+                <li class="row ilch-border ilch-bg--hover">
+                    <dl class="icon
+                    <?php if ($this->getUser()): ?>
+                        <?php if ($topic['topic']->getStatus() == 1): ?>
+                            topic-unread-locked
+                        <?php else: ?>
+                            topic-unread
+                        <?php endif; ?>
+                    <?php elseif ($topic['topic']->getStatus() == 1): ?>
+                        topic-read-locked
+                    <?php else: ?>
+                        topic-read
                     <?php endif; ?>
-                <?php endif; ?>
+                ">
+                        <dt>
+                            <?php
+                            if ($topic['forumPrefix'] != '' && $topic['topic']->getTopicPrefix() > 0) {
+                                $prefix = explode(',', $topic['forumPrefix']);
+                                array_unshift($prefix, '');
+
+                                foreach ($prefix as $key => $value) {
+                                    if ($topic['topic']->getTopicPrefix() == $key) {
+                                        echo '<span class="label label-default">'.$value.'</span>';
+                                    }
+                                }
+                            }
+                            ?>
+                            <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic['topic']->getId()]) ?>" class="topictitle">
+                                <?=$topic['topic']->getTopicTitle() ?>
+                            </a>
+                            <?php if ($topic['topic']->getType() == '1'): ?>
+                                <i class="fa-solid fa-thumbtack"></i>
+                            <?php endif; ?>
+                            <br>
+                            <div class="small">
+                                <?=$this->getTrans('by') ?>
+                                <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['topic']->getAuthor()->getId()]) ?>" class="ilch-link-red">
+                                    <?=$this->escape($topic['topic']->getAuthor()->getName()) ?>
+                                </a>
+                                »
+                                <?=$topic['topic']->getDateCreated() ?>
+                            </div>
+                        </dt>
+                        <dd class="posts small">
+                            <div class="pull-left text-nowrap stats">
+                                <?=$this->getTrans('replies') ?>:
+                                <br />
+                                <?=$this->getTrans('views') ?>:
+                            </div>
+                            <div class="pull-left text-justify">
+                                <?=$topic['topic']->getCountPosts() - 1 ?>
+                                <br />
+                                <?=$topic['topic']->getVisits() ?>
+                            </div>
+                        </dd>
+                        <dd class="lastpost small">
+                            <div class="pull-left">
+                                <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['lastPost']->getAutor()->getId()]) ?>" title="<?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>">
+                                    <img style="width:40px; padding-right: 5px;" src="<?=$this->getBaseUrl($topic['lastPost']->getAutor()->getAvatar()) ?>" alt="<?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>">
+                                </a>
+                            </div>
+                            <div class="pull-left">
+                                <?=$this->getTrans('by') ?>
+                                <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'profil', 'action' => 'index', 'user' => $topic['lastPost']->getAutor()->getId()]) ?>" title="<?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>">
+                                    <?=$this->escape($topic['lastPost']->getAutor()->getName()) ?>
+                                </a>
+                                <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic['lastPost']->getTopicId(), 'page' => ($DESCPostorder ? 1 : ceil($topic['topic']->getCountPosts() / $postsPerPage))]) ?>#<?=$topic['lastPost']->getId() ?>">
+                                    <img src="<?=$this->getModuleUrl('static/img/icon_topic_latest.png') ?>" alt="<?=$this->getTrans('viewLastPost') ?>" title="<?=$this->getTrans('viewLastPost') ?>" height="10" width="12">
+                                </a>
+                                <br>
+                                <?=$topic['lastPost']->getDateCreated() ?>
+                            </div>
+                        </dd>
+                    </dl>
+                </li>
             <?php endforeach; ?>
         </ul>
     </div>

--- a/application/modules/forum/views/showposts/edit.php
+++ b/application/modules/forum/views/showposts/edit.php
@@ -1,6 +1,12 @@
 <?php
+
+/** @var \Ilch\View $this */
+
+/** @var \Modules\Forum\Models\ForumItem $forum */
 $forum = $this->get('forum');
+/** @var \Modules\Forum\Models\ForumTopic $topic */
 $topic = $this->get('topic');
+/** @var \Modules\Forum\Models\ForumPost $post */
 $post = $this->get('post');
 ?>
 
@@ -22,14 +28,14 @@ $post = $this->get('post');
                         <label for="topicTitle" class="col-lg-2 control-label">
                             <?=$this->getTrans('topicTitle') ?>
                         </label>
-                        <?php if ($forum->getPrefix() != ''): ?>
+                        <?php if ($forum->getPrefix() != '') : ?>
                             <?php $prefix = explode(',', $forum->getPrefix()); ?>
                             <?php array_unshift($prefix, ''); ?>
                             <div class="col-lg-2 prefix">
                                 <select class="form-control" id="topicPrefix" name="topicPrefix">
-                                    <?php foreach ($prefix as $key => $value): ?>
+                                    <?php foreach ($prefix as $key => $value) : ?>
                                         <?php $selected = ''; ?>
-                                        <?php if ($key == $topic->getTopicPrefix()): ?>
+                                        <?php if ($key == $topic->getTopicPrefix()) : ?>
                                             <?php $selected = 'selected="selected"'; ?>
                                         <?php endif; ?>
                                         <option <?=$selected ?> value="<?=$key ?>"><?=$this->escape($value) ?></option>

--- a/application/modules/forum/views/showposts/index.php
+++ b/application/modules/forum/views/showposts/index.php
@@ -7,7 +7,6 @@ $rankMapper = $this->get('rankMapper');
 $posts = $this->get('posts');
 $cat = $this->get('cat');
 $topicpost = $this->get('post');
-$readAccess = $this->get('readAccess');
 $forum = $this->get('forum');
 $reportedPostsIds = $this->get('reportedPostsIds');
 $rememberedPostIds = $this->get('rememberedPostIds');
@@ -34,7 +33,7 @@ if ($forumPrefix->getPrefix() != '' && $topicpost->getTopicPrefix() > 0) {
 
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 
-<?php if ($adminAccess || is_in_array($readAccess, explode(',', $forum->getReadAccess()))): ?>
+<?php if ($adminAccess || $forum->getReadAccess()): ?>
     <div id="forum">
         <h1>
             <a href="<?=$this->getUrl(['controller' => 'index', 'action' => 'index']) ?>"><?=$this->getTrans('forum') ?></a>
@@ -46,7 +45,7 @@ if ($forumPrefix->getPrefix() != '' && $topicpost->getTopicPrefix() > 0) {
             <div class="col-lg-12">
                 <?php if ($topicpost->getStatus() == 0): ?>
                     <?php if ($this->getUser()): ?>
-                        <?php if ($adminAccess || is_in_array($readAccess, explode(',', $forum->getReplyAccess()))): ?>
+                        <?php if ($adminAccess || $forum->getReplyAccess()): ?>
                             <a href="<?=$this->getUrl(['controller' => 'newpost', 'action' => 'index','topicid' => $this->getRequest()->getParam('topicid')]) ?>" class="btn btn-primary">
                                 <span class="btn-label">
                                     <i class="fa-solid fa-plus"></i>
@@ -192,7 +191,7 @@ if ($forumPrefix->getPrefix() != '' && $topicpost->getTopicPrefix() > 0) {
                     <?php endif; ?>
                     <?php if ($this->getUser()): ?>
                         <div class="quote">
-                            <?php if ($adminAccess || is_in_array($readAccess, explode(',', $forum->getReplyAccess()))): ?>
+                            <?php if ($adminAccess || $forum->getReplyAccess()): ?>
                                 <p class="quote-post">
                                     <a href="<?=$this->getUrl(['controller' => 'newpost', 'action' => 'index','topicid' => $this->getRequest()->getParam('topicid'), 'quote' => $post->getId()]) ?>" class="btn btn-primary btn-xs">
                         <span class="btn-label">
@@ -231,7 +230,7 @@ if ($forumPrefix->getPrefix() != '' && $topicpost->getTopicPrefix() > 0) {
         <div class="topic-actions">
             <?php if ($topicpost->getStatus() == 0): ?>
                 <?php if ($this->getUser()): ?>
-                    <?php if ($adminAccess || is_in_array($readAccess, explode(',', $forum->getReplyAccess()))): ?>
+                    <?php if ($adminAccess || $forum->getReplyAccess()): ?>
                         <a href="<?=$this->getUrl(['controller' => 'newpost', 'action' => 'index','topicid' => $this->getRequest()->getParam('topicid')]) ?>" class="btn btn-primary">
                             <span class="btn-label">
                                 <i class="fa-solid fa-plus"></i>

--- a/application/modules/forum/views/showposts/index.php
+++ b/application/modules/forum/views/showposts/index.php
@@ -2,32 +2,18 @@
 
 use Ilch\Date;
 
-$forumMapper = $this->get('forumMapper');
 $rankMapper = $this->get('rankMapper');
 $posts = $this->get('posts');
 $cat = $this->get('cat');
 $topicpost = $this->get('post');
 $forum = $this->get('forum');
+$prefix = $this->get('prefix');
 $reportedPostsIds = $this->get('reportedPostsIds');
 $rememberedPostIds = $this->get('rememberedPostIds');
 $adminAccess = null;
 if ($this->getUser()) {
     $adminAccess = $this->getUser()->isAdmin();
     $userAccess = $this->get('userAccess');
-}
-
-$forumPrefix = $forumMapper->getForumByTopicId($topicpost->getId());
-$prefix = '';
-if ($forumPrefix->getPrefix() != '' && $topicpost->getTopicPrefix() > 0) {
-    $prefix = explode(',', $forumPrefix->getPrefix());
-    array_unshift($prefix, '');
-
-    foreach ($prefix as $key => $value) {
-        if ($topicpost->getTopicPrefix() == $key) {
-            $value = trim($value);
-            $prefix = '[' . $value . '] ';
-        }
-    }
 }
 ?>
 

--- a/application/modules/forum/views/showposts/index.php
+++ b/application/modules/forum/views/showposts/index.php
@@ -1,37 +1,46 @@
 <?php
 
+/** @var \Ilch\View $this */
+
 use Ilch\Date;
 
+/** @var \Modules\Forum\Mappers\Rank $rankMapper */
 $rankMapper = $this->get('rankMapper');
+/** @var \Modules\Forum\Models\ForumPost[] $posts */
 $posts = $this->get('posts');
+/** @var \Modules\Forum\Models\ForumItem $cat */
 $cat = $this->get('cat');
+/** @var \Modules\Forum\Models\ForumTopic|null $topicpost */
 $topicpost = $this->get('post');
+/** @var \Modules\Forum\Models\ForumItem $forum */
 $forum = $this->get('forum');
+/** @var string $prefix */
 $prefix = $this->get('prefix');
+/** @var array $reportedPostsIds */
 $reportedPostsIds = $this->get('reportedPostsIds');
+/** @var array $rememberedPostIds */
 $rememberedPostIds = $this->get('rememberedPostIds');
 $adminAccess = null;
 if ($this->getUser()) {
     $adminAccess = $this->getUser()->isAdmin();
-    $userAccess = $this->get('userAccess');
 }
 ?>
 
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 
-<?php if ($adminAccess || $forum->getReadAccess()): ?>
+<?php if ($adminAccess || $forum->getReadAccess()) : ?>
     <div id="forum">
         <h1>
             <a href="<?=$this->getUrl(['controller' => 'index', 'action' => 'index']) ?>"><?=$this->getTrans('forum') ?></a>
             <i class="fa-solid fa-chevron-right"></i> <a href="<?=$this->getUrl(['controller' => 'showcat', 'action' => 'index', 'id' => $cat->getId()]) ?>"><?=$this->escape($cat->getTitle()) ?></a>
             <i class="fa-solid fa-chevron-right"></i> <a href="<?=$this->getUrl(['controller' => 'showtopics', 'action' => 'index', 'forumid' => $forum->getId()]) ?>"><?=$this->escape($forum->getTitle()) ?></a>
-            <i class="fa-solid fa-chevron-right"></i> <?=$this->escape($prefix.$topicpost->getTopicTitle()) ?>
+            <i class="fa-solid fa-chevron-right"></i> <?=$this->escape($prefix . $topicpost->getTopicTitle()) ?>
         </h1>
         <div class="row">
             <div class="col-lg-12">
-                <?php if ($topicpost->getStatus() == 0): ?>
-                    <?php if ($this->getUser()): ?>
-                        <?php if ($adminAccess || $forum->getReplyAccess()): ?>
+                <?php if ($topicpost->getStatus() == 0) : ?>
+                    <?php if ($this->getUser()) : ?>
+                        <?php if ($adminAccess || $forum->getReplyAccess()) : ?>
                             <a href="<?=$this->getUrl(['controller' => 'newpost', 'action' => 'index','topicid' => $this->getRequest()->getParam('topicid')]) ?>" class="btn btn-primary">
                                 <span class="btn-label">
                                     <i class="fa-solid fa-plus"></i>
@@ -53,7 +62,7 @@ if ($this->getUser()) {
                                 <?php endif; ?>
                             <?php endif; ?>
                         <?php endif; ?>
-                    <?php else: ?>
+                    <?php else : ?>
                         <?php $_SESSION['redirect'] = $this->getRouter()->getQuery(); ?>
                         <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'login', 'action' => 'index']) ?>" class="btn btn-primary">
                             <span class="btn-label">
@@ -61,7 +70,7 @@ if ($this->getUser()) {
                             </span><?=$this->getTrans('loginPost') ?>
                         </a>
                     <?php endif; ?>
-                <?php else: ?>
+                <?php else : ?>
                     <div class="btn btn-primary">
                         <span class="btn-label">
                             <i class="fa-solid fa-lock"></i>
@@ -72,11 +81,11 @@ if ($this->getUser()) {
             </div>
             <div class="col-lg-12">
                 <div class="posts-head ilch-head">
-                    <?=$this->escape($prefix.$topicpost->getTopicTitle()) ?>
+                    <?=$this->escape($prefix . $topicpost->getTopicTitle()) ?>
                 </div>
             </div>
         </div>
-        <?php foreach ($posts as $post): ?>
+        <?php foreach ($posts as $post) : ?>
             <?php
             $date = new Date($post->getDateCreated());
             $reported = in_array($post->getId(), $reportedPostsIds);
@@ -99,8 +108,8 @@ if ($this->getUser()) {
                             </div>
                             <div class="col-lg-6 pull-right">
                                 <div class="delete">
-                                    <?php if ($this->getUser()): ?>
-                                        <?php if ($this->getUser()->isAdmin()): ?>
+                                    <?php if ($this->getUser()) : ?>
+                                        <?php if ($this->getUser()->isAdmin()) : ?>
                                             <p class="delete-post">
                                                 <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'delete', 'id' => $post->getId(), 'topicid' => $this->getRequest()->getParam('topicid'), 'forumid' => $forum->getId()], null, true) ?>" id="delete" class="btn btn-primary btn-xs">
                                                     <span class="btn-label">
@@ -112,8 +121,8 @@ if ($this->getUser()) {
                                     <?php endif; ?>
                                 </div>
                                 <div class="edit">
-                                    <?php if ($this->getUser()): ?>
-                                        <?php if ($this->getUser()->isAdmin() || $this->getUser()->hasAccess('module_forum') || $this->getUser()->getId() == $post->getAutor()->getId()): ?>
+                                    <?php if ($this->getUser()) : ?>
+                                        <?php if ($this->getUser()->isAdmin() || $this->getUser()->hasAccess('module_forum') || $this->getUser()->getId() == $post->getAutor()->getId()) : ?>
                                             <p class="edit-post">
                                                 <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'edit', 'id' => $post->getId(), 'topicid' => $this->getRequest()->getParam('topicid')]) ?>" class="btn btn-primary btn-xs">
                                                     <span class="btn-label">
@@ -134,7 +143,7 @@ if ($this->getUser()) {
                         <?=$this->alwaysPurify($post->getText()) ?>
                     </div>
 
-                    <?php if ($post->getAutor()->getSignature()): ?>
+                    <?php if ($post->getAutor()->getSignature()) : ?>
                         <hr />
                         <?=$this->alwaysPurify($post->getAutor()->getSignature()) ?>
                     <?php endif; ?>
@@ -148,7 +157,7 @@ if ($this->getUser()) {
                         </a>
                     </dt>
                     <dd>
-                        <?php foreach ($post->getAutor()->getGroups() as $group): ?>
+                        <?php foreach ($post->getAutor()->getGroups() as $group) : ?>
                             <i class="forum appearance<?=$group->getId() ?>"><?=$this->escape($group->getName()) ?></i><br>
                         <?php endforeach; ?>
                         <i><?=($post->getAutorAllPost()) ? $this->escape($rankMapper->getRankByPosts($post->getAutorAllPost())->getTitle()) : '' ?></i>
@@ -158,7 +167,7 @@ if ($this->getUser()) {
                     <dd><b><?=$this->getTrans('joined') ?>:</b> <?=$post->getAutor()->getDateCreated() ?></dd>
                 </dl>
             </div>
-            <?php if ($this->getUser() || $this->get('postVoting')): ?>
+            <?php if ($this->getUser() || $this->get('postVoting')) : ?>
                 <div class="post-footer ilch-bg">
                     <?php if ($this->get('postVoting')) : ?>
                         <?php if ($this->getUser() && !$post->isUserHasVoted()) : ?>
@@ -175,9 +184,9 @@ if ($this->getUser()) {
                             </button>
                         <?php endif; ?>
                     <?php endif; ?>
-                    <?php if ($this->getUser()): ?>
+                    <?php if ($this->getUser()) : ?>
                         <div class="quote">
-                            <?php if ($adminAccess || $forum->getReplyAccess()): ?>
+                            <?php if ($adminAccess || $forum->getReplyAccess()) : ?>
                                 <p class="quote-post">
                                     <a href="<?=$this->getUrl(['controller' => 'newpost', 'action' => 'index','topicid' => $this->getRequest()->getParam('topicid'), 'quote' => $post->getId()]) ?>" class="btn btn-primary btn-xs">
                         <span class="btn-label">
@@ -214,9 +223,9 @@ if ($this->getUser()) {
             <?php endif; ?>
         <?php endforeach; ?>
         <div class="topic-actions">
-            <?php if ($topicpost->getStatus() == 0): ?>
-                <?php if ($this->getUser()): ?>
-                    <?php if ($adminAccess || $forum->getReplyAccess()): ?>
+            <?php if ($topicpost->getStatus() == 0) : ?>
+                <?php if ($this->getUser()) : ?>
+                    <?php if ($adminAccess || $forum->getReplyAccess()) : ?>
                         <a href="<?=$this->getUrl(['controller' => 'newpost', 'action' => 'index','topicid' => $this->getRequest()->getParam('topicid')]) ?>" class="btn btn-primary">
                             <span class="btn-label">
                                 <i class="fa-solid fa-plus"></i>
@@ -238,7 +247,7 @@ if ($this->getUser()) {
                             <?php endif; ?>
                         <?php endif; ?>
                     <?php endif; ?>
-                <?php else: ?>
+                <?php else : ?>
                     <?php $_SESSION['redirect'] = $this->getRouter()->getQuery(); ?>
                     <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'login', 'action' => 'index']) ?>" class="btn btn-primary">
                         <span class="btn-label">
@@ -246,7 +255,7 @@ if ($this->getUser()) {
                         </span><?=$this->getTrans('loginPost') ?>
                     </a>
                 <?php endif; ?>
-            <?php else: ?>
+            <?php else : ?>
                 <div class="btn btn-primary">
                     <span class="btn-label">
                         <i class="fa-solid fa-lock"></i>
@@ -289,9 +298,9 @@ if ($this->getUser()) {
         </div>
     </form>
 
-<?php else: ?>
+<?php else : ?>
     <?php
-    header('location: ' .$this->getUrl(['controller' => 'index', 'action' => 'index', 'access' => 'noaccess']));
+    header('location: ' . $this->getUrl(['controller' => 'index', 'action' => 'index', 'access' => 'noaccess']));
     exit;
     ?>
 <?php endif; ?>

--- a/application/modules/forum/views/showposts/report.php
+++ b/application/modules/forum/views/showposts/report.php
@@ -1,3 +1,7 @@
+<?php
+
+/** @var \Ilch\View $this */
+?>
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 
 <div id="forum">

--- a/application/modules/forum/views/showtopics/index.php
+++ b/application/modules/forum/views/showtopics/index.php
@@ -1,10 +1,18 @@
 <?php
 
+/** @var \Ilch\View $this */
+
+/** @var \Modules\Forum\Models\ForumItem $forum */
 $forum = $this->get('forum');
+/** @var \Modules\Forum\Models\ForumItem $cat */
 $cat = $this->get('cat');
+/** @var bool $forumEdit */
 $forumEdit = $this->get('forumEdit');
+/** @var \Modules\Forum\Models\ForumTopic[]|null $topics */
 $topics = $this->get('topics');
+/** @var \Modules\Forum\Models\ForumPost[]|null $posts */
 $posts = $this->get('posts');
+/** @var array $postTopicRelation */
 $postTopicRelation = $this->get('postTopicRelation');
 $adminAccess = null;
 if ($this->getUser()) {
@@ -15,7 +23,7 @@ $postsPerPage = $this->get('postsPerPage');
 ?>
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 
-<?php if ($adminAccess || $forum->getReadAccess()): ?>
+<?php if ($adminAccess || $forum->getReadAccess()) : ?>
     <div id="forum">
         <h1>
             <a href="<?=$this->getUrl(['controller' => 'index', 'action' => 'index']) ?>"><?=$this->getTrans('forum') ?></a>
@@ -23,13 +31,13 @@ $postsPerPage = $this->get('postsPerPage');
             <i class="fa-solid fa-chevron-right"></i> <?=$forum->getTitle() ?>
         </h1>
         <div class="topic-actions">
-            <?php if ($this->getUser()): ?>
+            <?php if ($this->getUser()) : ?>
                 <a href="<?=$this->getUrl(['controller' => 'newtopic', 'action' => 'index','id' => $forum->getId()]) ?>" class="btn btn-primary">
                     <span class="btn-label">
                         <i class="fa-solid fa-plus"></i>
                     </span><?=$this->getTrans('createNewTopic') ?>
                 </a>
-            <?php else: ?>
+            <?php else : ?>
                 <?php $_SESSION['redirect'] = $this->getRouter()->getQuery(); ?>
                 <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'login', 'action' => 'index']) ?>" class="btn btn-primary">
                     <span class="btn-label">
@@ -39,7 +47,7 @@ $postsPerPage = $this->get('postsPerPage');
             <?php endif; ?>
             <?=$this->get('pagination')->getHtml($this, ['action' => 'index', 'forumid' => $this->getRequest()->getParam('forumid')]) ?>
         </div>
-        <?php if ($forumEdit): ?>
+        <?php if ($forumEdit) : ?>
             <form class="form-horizontal" name="editForm" method="POST">
                 <?=$this->getTokenField() ?>
         <?php endif; ?>
@@ -50,31 +58,31 @@ $postsPerPage = $this->get('postsPerPage');
                         <dt><?=$this->getTrans('topics') ?></dt>
                         <dd class="posts"><?=$this->getTrans('replies') ?> / <?=$this->getTrans('views') ?></dd>
                         <dd class="lastpost"><span><?=$this->getTrans('lastPost') ?></span></dd>
-                        <?php if ($forumEdit): ?>
+                        <?php if ($forumEdit) : ?>
                             <dd class="forumEdit"><input type="checkbox" class="check_all" id="allTopics" data-childs="check_topics" /></dd>
                         <?php endif; ?>
                     </dl>
                 </li>
             </ul>
             <ul class="topiclist topics">
-                <?php if (!empty($topics)): ?>
-                    <?php foreach ($topics as $topic): ?>
+                <?php if (!empty($topics)) : ?>
+                    <?php foreach ($topics as $topic) : ?>
                         <?php $lastPost = $posts[$postTopicRelation[$topic->getId()]] ?>
                         <li class="row ilch-border ilch-bg--hover <?=($topic->getType() == '1') ? 'tack' : '' ?>">
                             <dl class="icon
-                                <?php if ($this->getUser()): ?>
-                                    <?php if ($topic->getStatus() == 0 && $lastPost->getRead()): ?>
+                                <?php if ($this->getUser()) : ?>
+                                    <?php if ($topic->getStatus() == 0 && $lastPost->getRead()) : ?>
                                         topic-read
-                                    <?php elseif ($topic->getStatus() == 1 && $lastPost->getRead()): ?>
+                                    <?php elseif ($topic->getStatus() == 1 && $lastPost->getRead()) : ?>
                                         topic-read-locked
-                                    <?php elseif ($topic->getStatus() == 1): ?>
+                                    <?php elseif ($topic->getStatus() == 1) : ?>
                                         topic-unread-locked
-                                    <?php else: ?>
+                                    <?php else : ?>
                                         topic-unread
                                     <?php endif; ?>
-                                <?php elseif ($topic->getStatus() == 1): ?>
+                                <?php elseif ($topic->getStatus() == 1) : ?>
                                     topic-read-locked
-                                <?php else: ?>
+                                <?php else : ?>
                                     topic-read
                                 <?php endif; ?>
                             ">
@@ -86,7 +94,7 @@ $postsPerPage = $this->get('postsPerPage');
 
                                         foreach ($prefix as $key => $value) {
                                             if ($topic->getTopicPrefix() == $key) {
-                                                echo '<span class="label label-default">'.$value.'</span>';
+                                                echo '<span class="label label-default">' . $value . '</span>';
                                             }
                                         }
                                     }
@@ -94,7 +102,7 @@ $postsPerPage = $this->get('postsPerPage');
                                     <a href="<?=$this->getUrl(['controller' => 'showposts', 'action' => 'index','topicid' => $topic->getId()]) ?>" class="topictitle">
                                         <?=$this->escape($topic->getTopicTitle()) ?>
                                     </a>
-                                    <?php if ($topic->getType() == '1'): ?>
+                                    <?php if ($topic->getType() == '1') : ?>
                                         <i class="fa-solid fa-thumbtack"></i>
                                     <?php endif; ?>
                                     <br>
@@ -137,25 +145,25 @@ $postsPerPage = $this->get('postsPerPage');
                                         <?=$lastPost->getDateCreated() ?>
                                     </div>
                                 </dd>
-                                <?php if ($forumEdit): ?>
+                                <?php if ($forumEdit) : ?>
                                     <dd class="forumEdit"><input type="checkbox" name="check_topics[]" value="<?=$topic->getId() ?>" /></dd>
                                 <?php endif; ?>
                             </dl>
                         </li>
                     <?php endforeach; ?>
-                <?php else: ?>
+                <?php else : ?>
                     <li class="row ilch-border text-center"><?=$this->getTrans('noThreads') ?></li>
                 <?php endif; ?>
             </ul>
         </div>
         <div class="topic-actions">
-            <?php if ($this->getUser()): ?>
+            <?php if ($this->getUser()) : ?>
                 <a href="<?=$this->getUrl(['controller' => 'newtopic', 'action' => 'index','id' => $forum->getId()]) ?>" class="btn btn-primary">
                     <span class="btn-label">
                         <i class="fa-solid fa-plus"></i>
                     </span><?=$this->getTrans('createNewTopic') ?>
                 </a>
-            <?php else: ?>
+            <?php else : ?>
                 <?php $_SESSION['redirect'] = $this->getRouter()->getQuery(); ?>
                 <a href="<?=$this->getUrl(['module' => 'user', 'controller' => 'login', 'action' => 'index']) ?>" class="btn btn-primary">
                     <span class="btn-label">
@@ -166,13 +174,13 @@ $postsPerPage = $this->get('postsPerPage');
             <?=$this->get('pagination')->getHtml($this, ['action' => 'index', 'forumid' => $this->getRequest()->getParam('forumid')]) ?>
         </div>
         <div class="topic-actions">
-            <?php if ($adminAccess || ($this->getUser() && $this->getUser()->hasAccess('module_forum'))): ?>
-                <?php if (!$forumEdit): ?>
+            <?php if ($adminAccess || ($this->getUser() && $this->getUser()->hasAccess('module_forum'))) : ?>
+                <?php if (!$forumEdit) : ?>
                     <form method="post">
                         <?=$this->getTokenField() ?>
                         <button class="btn btn-default" name="forumEdit" value="forumEdit"><?=$this->getTrans('forumEdit') ?></button>
                     </form>
-                <?php else: ?>
+                <?php else : ?>
                     <button class="btn btn-primary" name="topicDelete" value="topicDelete" id="topicDelete" OnClick="SetAction1()" disabled><?=$this->getTrans('topicDelete') ?></button>
                     <button class="btn btn-primary" name="topicMove" value="topicMove" id="topicMove" OnClick="SetAction2()" disabled><?=$this->getTrans('topicMove') ?></button>
                     <button class="btn btn-primary" name="topicChangeStatus" value="topicChangeStatus" id="topicChangeStatus" OnClick="SetAction3()" disabled><?=$this->getTrans('topicChangeStatus') ?></button>
@@ -197,19 +205,19 @@ $postsPerPage = $this->get('postsPerPage');
                     </script>
                 <?php endif; ?>
             <?php endif; ?>
-            <?php if ($this->getUser()): ?>
+            <?php if ($this->getUser()) : ?>
                 <div class="pull-right foren-actions">
                     <a href="<?=$this->getUrl(['controller' => 'showtopics', 'action' => 'marktopicsasread', 'forumid' => $this->getRequest()->getParam('forumid')], null, true) ?>" class="ilch-link"><?=$this->getTrans('markTopicsAsRead') ?></a>
                 </div>
             <?php endif; ?>
         </div>
-        <?php if ($forumEdit): ?>
+        <?php if ($forumEdit) : ?>
             </form>
         <?php endif; ?>
     </div>
-<?php else: ?>
+<?php else : ?>
     <?php
-    header('location: ' .$this->getUrl(['controller' => 'index', 'action' => 'index', 'access' => 'noaccess']));
+    header('location: ' . $this->getUrl(['controller' => 'index', 'action' => 'index', 'access' => 'noaccess']));
     exit;
     ?>
 <?php endif; ?>

--- a/application/modules/forum/views/showtopics/index.php
+++ b/application/modules/forum/views/showtopics/index.php
@@ -1,5 +1,4 @@
 <?php
-use Modules\Forum\Mappers\Forum;
 use Modules\Forum\Mappers\Topic;
 
 $forum = $this->get('forum');
@@ -8,9 +7,6 @@ $forumEdit = $this->get('forumEdit');
 $topics = $this->get('topics');
 /** @var Topic $topicMapper */
 $topicMapper = $this->get('topicMapper');
-/** @var Forum $forumMapper */
-$forumMapper = $this->get('forumMapper');
-$groupIdsArray = $this->get('groupIdsArray');
 $adminAccess = null;
 if ($this->getUser()) {
     $adminAccess = $this->getUser()->isAdmin();
@@ -20,7 +16,7 @@ $postsPerPage = $this->get('postsPerPage');
 ?>
 <link href="<?=$this->getModuleUrl('static/css/forum.css') ?>" rel="stylesheet">
 
-<?php if ($adminAccess || is_in_array($groupIdsArray, explode(',', $forum->getReadAccess()))): ?>
+<?php if ($adminAccess || $forum->getReadAccess()): ?>
     <div id="forum">
         <h1>
             <a href="<?=$this->getUrl(['controller' => 'index', 'action' => 'index']) ?>"><?=$this->getTrans('forum') ?></a>
@@ -65,7 +61,6 @@ $postsPerPage = $this->get('postsPerPage');
                 <?php if (!empty($topics)): ?>
                     <?php foreach ($topics as $topic): ?>
                         <?php $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId()) ?>
-                        <?php $forumPrefix = $forumMapper->getForumByTopicId($topic->getId()) ?>
                         <li class="row ilch-border ilch-bg--hover <?=($topic->getType() == '1') ? 'tack' : '' ?>">
                             <dl class="icon
                                 <?php if ($this->getUser()): ?>
@@ -86,8 +81,8 @@ $postsPerPage = $this->get('postsPerPage');
                             ">
                                 <dt>
                                     <?php
-                                    if ($forumPrefix->getPrefix() != '' && $topic->getTopicPrefix() > 0) {
-                                        $prefix = explode(',', $forumPrefix->getPrefix());
+                                    if ($forum->getPrefix() != '' && $topic->getTopicPrefix() > 0) {
+                                        $prefix = explode(',', $forum->getPrefix());
                                         array_unshift($prefix, '');
 
                                         foreach ($prefix as $key => $value) {

--- a/application/modules/forum/views/showtopics/index.php
+++ b/application/modules/forum/views/showtopics/index.php
@@ -1,12 +1,11 @@
 <?php
-use Modules\Forum\Mappers\Topic;
 
 $forum = $this->get('forum');
 $cat = $this->get('cat');
 $forumEdit = $this->get('forumEdit');
 $topics = $this->get('topics');
-/** @var Topic $topicMapper */
-$topicMapper = $this->get('topicMapper');
+$posts = $this->get('posts');
+$postTopicRelation = $this->get('postTopicRelation');
 $adminAccess = null;
 if ($this->getUser()) {
     $adminAccess = $this->getUser()->isAdmin();
@@ -60,7 +59,7 @@ $postsPerPage = $this->get('postsPerPage');
             <ul class="topiclist topics">
                 <?php if (!empty($topics)): ?>
                     <?php foreach ($topics as $topic): ?>
-                        <?php $lastPost = ($this->getUser()) ? $topicMapper->getLastPostByTopicId($topic->getId(), $this->getUser()->getId()) : $topicMapper->getLastPostByTopicId($topic->getId()) ?>
+                        <?php $lastPost = $posts[$postTopicRelation[$topic->getId()]] ?>
                         <li class="row ilch-border ilch-bg--hover <?=($topic->getType() == '1') ? 'tack' : '' ?>">
                             <dl class="icon
                                 <?php if ($this->getUser()): ?>


### PR DESCRIPTION
# Description
- Instead of getting all groups that are allowed to read, reply and create for every forum just get if the current user is allowed to read, reply and create. Only the admincenter needs all groups. This avoids usage of the costly group_concat().
- Reduced database queries for the box of the forum.
- Reduced database queries in various places by querying the needed data in one go.
- Reduced database queries by avoiding calls of getUserById if the current user can be used.
- Removed is_in_array calls to check access rights in the views if not necessary.
- Don't get the prefix in the index view of showposts again if it is already available from a previous query for the forum.
- Reduced database queries in admincenter index controller index action.
- Reduced database queries for shownewposts.
- Reduced database queries for showactivetopics.
- Reduced database queries for showtopics.
- Reduced database queries for showunansweredtopics.
- Fix bug when a previously selected prefix got deleted.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge