### PR TITLE
Fix "file_exists(): Passing null to parameter"

### DIFF
--- a/application/modules/user/mappers/Dialog.php
+++ b/application/modules/user/mappers/Dialog.php
@@ -58,7 +58,7 @@ class Dialog extends \Ilch\Mapper
             }
             $readLastOneDialog = $this->getReadLastOneDialog($dialog['c_id']);
             $dialogModel->setRead($readLastOneDialog && $readLastOneDialog->getRead());
-            if (file_exists($dialog['avatar'])) {
+            if (isset($dialog['avatar']) && file_exists($dialog['avatar'])) {
                 $dialogModel->setAvatar($dialog['avatar']);
             } else {
                 $dialogModel->setAvatar('static/img/noavatar.jpg');


### PR DESCRIPTION
# Description
- Fix "file_exists(): Passing null to parameter"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
