### PR TITLE
Empty instead isset

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,9 @@
 # Description
-
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
 Fixes # (issue)
 
 ## Type of change
-
 Please delete options that are not relevant.
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
@@ -14,7 +12,6 @@ Please delete options that are not relevant.
 - [ ] This change requires a documentation update
 
 # This PR has been tested in the following browsers:
-
 - [ ] Chrome
 - [ ] Firefox
 - [ ] Opera

--- a/application/modules/user/mappers/Dialog.php
+++ b/application/modules/user/mappers/Dialog.php
@@ -58,7 +58,7 @@ class Dialog extends \Ilch\Mapper
             }
             $readLastOneDialog = $this->getReadLastOneDialog($dialog['c_id']);
             $dialogModel->setRead($readLastOneDialog && $readLastOneDialog->getRead());
-            if (isset($dialog['avatar']) && file_exists($dialog['avatar'])) {
+            if (!empty($dialog['avatar']) && file_exists($dialog['avatar'])) {
                 $dialogModel->setAvatar($dialog['avatar']);
             } else {
                 $dialogModel->setAvatar('static/img/noavatar.jpg');


### PR DESCRIPTION
# Description
- Use empty instead of isset

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
