### PR TITLE
calendar: add yearly translation to views

### DIFF
--- a/application/modules/calendar/config/config.php
+++ b/application/modules/calendar/config/config.php
@@ -14,7 +14,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'calendar',
-        'version' => '1.9.0',
+        'version' => '1.9.1',
         'icon_small' => 'fa-solid fa-calendar',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/calendar/views/admin/index/index.php
+++ b/application/modules/calendar/views/admin/index/index.php
@@ -13,6 +13,7 @@ $periodTypes = [
     'weekly' => $this->getTranslator()->trans('weekly'),
     'monthly' => $this->getTranslator()->trans('monthly'),
     'quarterly' => $this->getTranslator()->trans('quarterly'),
+    'yearly' => $this->getTranslator()->trans('yearly'),
     'days' => $this->getTranslator()->trans('days'),
 ];
 ?>

--- a/application/modules/calendar/views/events/show.php
+++ b/application/modules/calendar/views/events/show.php
@@ -15,6 +15,7 @@ $periodTypes = [
     'weekly' => $this->getTranslator()->trans('weekly'),
     'monthly' => $this->getTranslator()->trans('monthly'),
     'quarterly' => $this->getTranslator()->trans('quarterly'),
+    'yearly' => $this->getTranslator()->trans('yearly'),
     'days' => $this->getTranslator()->trans('days'),
 ];
 


### PR DESCRIPTION
# Description
- add yearly translation to views

Fixes #842 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
