### PR TITLE
Forum: Fix errors with empty forums, categories or none existing

### DIFF
--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'forum',
-        'version' => '1.34.2',
+        'version' => '1.34.3',
         'icon_small' => 'fa-solid fa-list',
         'author' => 'Stantin Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/forum/controllers/Showactivetopics.php
+++ b/application/modules/forum/controllers/Showactivetopics.php
@@ -31,7 +31,7 @@ class Showactivetopics extends Frontend
 
         $isAdmin = $this->getUser() && $this->getUser()->isAdmin();
         $forums = $forumMapper->getForumItemsUser($this->getUser());
-        $topics = $topicMapper->getTopicsByForumIds(array_keys($forums));
+        $topics = $topicMapper->getTopicsByForumIds(array_keys($forums ?? []));
 
         $topicIds = [];
         $topicsToShow = [];
@@ -43,7 +43,7 @@ class Showactivetopics extends Frontend
 
         $posts = $topicMapper->getLastPostsByTopicIds($topicIds, ($this->getUser()) ? $this->getUser()->getId() : null);
 
-        foreach ($posts as $post) {
+        foreach ($posts ?? [] as $post) {
             if ($post->getDateCreated() < $date->format('Y-m-d H:i:s', true) && $post->getDateCreated() > $dateLessHours->format('Y-m-d H:i:s', true)) {
                 $topicsToShow[] = [
                     'topic' => $topics[$post->getTopicId()],

--- a/application/modules/forum/controllers/Shownewposts.php
+++ b/application/modules/forum/controllers/Shownewposts.php
@@ -30,7 +30,7 @@ class Shownewposts extends Frontend
             $isAdmin = $this->getUser() && $this->getUser()->isAdmin();
 
             $forums = $forumMapper->getForumItemsUser($this->getUser());
-            $topics = $topicMapper->getTopicsByForumIds(array_keys($forums));
+            $topics = $topicMapper->getTopicsByForumIds(array_keys($forums ?? []));
 
             $topicIds = [];
             $topicsToShow = [];
@@ -42,7 +42,7 @@ class Shownewposts extends Frontend
 
             $posts = $topicMapper->getLastPostsByTopicIds($topicIds, ($this->getUser()) ? $this->getUser()->getId() : null);
 
-            foreach ($posts as $post) {
+            foreach ($posts ?? [] as $post) {
                 if (!$post->getRead()) {
                     $topicsToShow[] = [
                         'topic' => $topics[$post->getTopicId()],

--- a/application/modules/forum/controllers/Showunansweredtopics.php
+++ b/application/modules/forum/controllers/Showunansweredtopics.php
@@ -29,7 +29,7 @@ class Showunansweredtopics extends Frontend
         $isAdmin = $this->getUser() && $this->getUser()->isAdmin();
 
         $forums = $forumMapper->getForumItemsUser($this->getUser());
-        $topics = $topicMapper->getTopicsByForumIds(array_keys($forums));
+        $topics = $topicMapper->getTopicsByForumIds(array_keys($forums ?? []));
 
         $topicIds = [];
         $topicsToShow = [];
@@ -41,7 +41,7 @@ class Showunansweredtopics extends Frontend
 
         $posts = $topicMapper->getLastPostsByTopicIds($topicIds, ($this->getUser()) ? $this->getUser()->getId() : null);
 
-        foreach ($posts as $post) {
+        foreach ($posts ?? [] as $post) {
             $topicsToShow[] = [
                 'topic' => $topics[$post->getTopicId()],
                 'forumPrefix' => $forums[$topics[$post->getTopicId()]->getForumId()]->getPrefix(),

--- a/application/modules/forum/mappers/Forum.php
+++ b/application/modules/forum/mappers/Forum.php
@@ -795,6 +795,10 @@ class Forum extends Mapper
      */
     public function getListOfForumIdsWithUnreadTopics(int $userId, array $forumIds): array
     {
+        if (empty($forumIds)) {
+            return [];
+        }
+
         return $this->db()->select(['i.id'])
             ->from(['t' => 'forum_topics'])
             ->join(['i' => 'forum_items'], 'i.id = t.forum_id', 'LEFT')

--- a/application/modules/forum/mappers/Topic.php
+++ b/application/modules/forum/mappers/Topic.php
@@ -35,6 +35,10 @@ class Topic extends Mapper
      */
     public function getTopicsByForumIds(array $ids, Pagination $pagination = null): array
     {
+        if (empty($ids)) {
+            return [];
+        }
+
         $sql = $this->db()->select(['*', 'topics.id', 'topics.visits', 'latest_post' => 'MAX(posts.date_created)', 'countPosts' => 'COUNT(posts.id)'])
             ->from(['topics' => 'forum_topics'])
             ->join(['posts' => 'forum_posts'], 'topics.id = posts.topic_id', 'LEFT')
@@ -234,6 +238,10 @@ class Topic extends Mapper
      */
     public function getLastPostsByTopicIds(array $ids, int $userId = null): ?array
     {
+        if (empty($ids)) {
+            return null;
+        }
+
         $select = $this->db()->select(['p.id', 'p.topic_id', 'date_created' => 'MAX(p.date_created)', 'p.user_id', 'p.forum_id'])
             ->from(['p' => 'forum_posts']);
         if ($userId) {


### PR DESCRIPTION
# Description
- Fixed errors with empty forums, categories or none existing
- Fixed some "Invalid argument supplied for foreach()" errors.

Fixes #846

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
