### PR TITLE
Install: remove space in front of "MariaDB"

### DIFF
--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -193,7 +193,7 @@ class Index extends \Ilch\Controller\Frontend
         $dbVersion = mysqli_get_server_info($dbLinkIdentifier);
         if (strpos($dbVersion, 'MariaDB') !== false) {
             $requiredVersion = '5.5';
-            $this->getView()->set('dbServerInfo', ' MariaDB');
+            $this->getView()->set('dbServerInfo', 'MariaDB');
         } else {
             $requiredVersion = '5.5.3';
             $this->getView()->set('dbServerInfo', 'MySQL');


### PR DESCRIPTION
# Description
Install: remove space in front of "MariaDB"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
