### PR TITLE
Install: fix translation license file

### DIFF
--- a/application/modules/install/translations/de.php
+++ b/application/modules/install/translations/de.php
@@ -20,7 +20,7 @@ return [
     'ilchInstallVersion' => 'CMS %s',
     'welcomeToInstall' => 'Willkommen zur Ilch CMS %s Installation',
     'chooseLanguage' => 'Sprache',
-    'licenseMissing' => 'Es wurde keine Lizenz gefunden<br /><small>Bitte lade die license.html mit hoch</small>',
+    'licenseMissing' => 'Es wurde keine Lizenz gefunden.<br /><small>Bitte laden Sie die Datei LICENSE mit hoch.</small>',
     'acceptLicense' => 'Nutzungslizenz gelesen und akzeptiert',
     'required' => 'Erforderlich',
     'available' => 'Vorhanden',

--- a/application/modules/install/translations/en.php
+++ b/application/modules/install/translations/en.php
@@ -20,7 +20,7 @@ return [
     'ilchInstallVersion' => 'CMS %s',
     'welcomeToInstall' => 'Welcome to Ilch CMS %s installation',
     'chooseLanguage' => 'language',
-    'licenseMissing' => 'There was no license found<br /><small>Please upload the license.html</small>',
+    'licenseMissing' => 'There was no license found.<br /><small>Please upload the LICENSE file.</small>',
     'acceptLicense' => 'Read license and accepted',
     'required' => 'Required',
     'available' => 'Available',


### PR DESCRIPTION
# Description
Install: fix translation license file

A file called license.html no longer exists.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
