### PR TITLE
Calendar: escape() breaks title

### DIFF
--- a/application/modules/calendar/config/config.php
+++ b/application/modules/calendar/config/config.php
@@ -14,7 +14,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'calendar',
-        'version' => '1.9.1',
+        'version' => '1.9.2',
         'icon_small' => 'fa-solid fa-calendar',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/calendar/views/events/index.php
+++ b/application/modules/calendar/views/events/index.php
@@ -6,7 +6,7 @@ $events = [];
 // calendar entries
 foreach ($this->get('calendarList') ?? [] as $calendarList) {
     $e = [];
-    $e['title'] = $this->escape($calendarList->getTitle());
+    $e['title'] = $calendarList->getTitle();
     $e['start'] = $calendarList->getStart();
     $e['end'] = $calendarList->getEnd();
     $e['color'] = $calendarList->getColor();


### PR DESCRIPTION
# Description
- escape() breaks title

Fixes #858

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
