### PR TITLE
Forum: Fix errors in the box and more

### DIFF
--- a/application/modules/forum/boxes/Forum.php
+++ b/application/modules/forum/boxes/Forum.php
@@ -36,7 +36,7 @@ class Forum extends Box
 
         $posts = $topicMapper->getLastPostsByTopicIds($topicIds, ($this->getUser()) ? $this->getUser()->getId() : null);
 
-        foreach ($posts as $post) {
+        foreach ($posts ?? [] as $post) {
             $foundTopic = null;
             foreach ($lastActiveTopics as $topic) {
                 if ($topic['topic_id'] == $post->getTopicId()) {

--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'forum',
-        'version' => '1.34.3',
+        'version' => '1.34.4',
         'icon_small' => 'fa-solid fa-list',
         'author' => 'Stantin Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/forum/mappers/Forum.php
+++ b/application/modules/forum/mappers/Forum.php
@@ -505,7 +505,7 @@ class Forum extends Mapper
      */
     public function getLastPostsByForumIds(array $forumId, int $userId = null): ?array
     {
-        $select = $this->db()->select(['p.id', 'p.topic_id', 'p.user_id', 'p.date_created', 'p.forum_id'])
+        $select = $this->db()->select(['p.id', 'p.topic_id', 'p.user_id', 'date_created' => 'MAX(p.date_created)', 'p.forum_id'])
             ->from(['p' => 'forum_posts'])
             ->join(['t' => 'forum_topics'], 't.id = p.topic_id', 'LEFT', ['t.topic_title']);
 
@@ -515,8 +515,8 @@ class Forum extends Mapper
         }
 
         $lastPostRows = $select->where(['p.forum_id' => $forumId])
-            ->order(['p.date_created' => 'DESC', 'p.id' => 'DESC'])
-            ->group(['p.forum_id'])
+            ->order(['date_created' => 'ASC'])
+            ->group(['p.forum_id', 'p.topic_id'])
             ->execute()
             ->fetchRows();
 

--- a/application/modules/forum/mappers/Forum.php
+++ b/application/modules/forum/mappers/Forum.php
@@ -320,6 +320,10 @@ class Forum extends Mapper
      */
     public function getForumsByIdsUser(array $ids, User $user = null): ?array
     {
+        if (empty($ids)) {
+            return null;
+        }
+
         $groupIds = [3];
         foreach ($user ? $user->getGroups() : [] as $group) {
             $groupIds[] = $group->getId();
@@ -725,6 +729,10 @@ class Forum extends Mapper
      */
     public function getCountPostsByTopicIds(array $topicIds): ?array
     {
+        if (empty($topicIds)) {
+            return null;
+        }
+
         $countOfPostsRows = $this->db()->select(['count' => 'COUNT(id)', 'topic_id'])
             ->from('forum_posts')
             ->where(['topic_id' => $topicIds], 'or')

--- a/application/modules/forum/mappers/Topic.php
+++ b/application/modules/forum/mappers/Topic.php
@@ -273,7 +273,7 @@ class Topic extends Mapper
             $postModel->setDateCreated($lastPostRow['date_created']);
             $postModel->setTopicId($lastPostRow['topic_id']);
             if ($userId) {
-                $postModel->setRead($lastPostRow['topic_read'] || $lastPostRow['forum_read']);
+                $postModel->setRead($lastPostRow['topic_read'] >= $lastPostRow['date_created'] || $lastPostRow['forum_read'] >= $lastPostRow['date_created']);
             }
             $lastPosts[] = $postModel;
         }

--- a/application/modules/forum/mappers/Topic.php
+++ b/application/modules/forum/mappers/Topic.php
@@ -273,6 +273,7 @@ class Topic extends Mapper
             $postModel->setDateCreated($lastPostRow['date_created']);
             $postModel->setTopicId($lastPostRow['topic_id']);
             if ($userId) {
+                // Needs an additional check if datetime is newer than the newest post of the topic as topic_read was always set.
                 $postModel->setRead($lastPostRow['topic_read'] >= $lastPostRow['date_created'] || $lastPostRow['forum_read'] >= $lastPostRow['date_created']);
             }
             $lastPosts[] = $postModel;

--- a/application/modules/forum/mappers/Topic.php
+++ b/application/modules/forum/mappers/Topic.php
@@ -250,7 +250,7 @@ class Topic extends Mapper
         }
 
         $lastPostsRows = $select->where(['p.topic_id' => $ids])
-            ->order(['p.date_created' => 'DESC'])
+            ->order(['date_created' => 'DESC'])
             ->group(['p.topic_id'])
             ->execute()
             ->fetchRows();


### PR DESCRIPTION
# Description
- Fixed errors in the box with nothing to show.
- Fixed sorting of topics with the newest posts in getLastPostsByTopicIds.
- Fixed sorting in getLastPostsByForumIds.
- Fixed read status in getLastPostsByTopicIds.

getLastPostsByTopicIds needs an additional check if datetime is newer than the newest post of the topic as topic_read was always set.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
