### PR TITLE
Awards: Fix "in_array(): Argument 2 must be of type array, string given"

### DIFF
--- a/application/modules/awards/config/config.php
+++ b/application/modules/awards/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'awards',
-        'version' => '1.10.0',
+        'version' => '1.10.1',
         'icon_small' => 'fa-solid fa-trophy',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/awards/views/admin/index/treat.php
+++ b/application/modules/awards/views/admin/index/treat.php
@@ -74,7 +74,7 @@ if ($awards != '') {
                 <optgroup label="<?=$this->getTrans('user') ?>">
                     <?php foreach ($this->get('users') as $user) {
                             $selected = '';
-                            if ($this->validation()->hasErrors() && in_array('1_'.$user->getId(), $this->originalInput('utId'))) {
+                            if ($this->validation()->hasErrors() && $this->originalInput('utId') && in_array('1_'.$user->getId(), $this->originalInput('utId'))) {
                                 $selected = 'selected="selected"';
                             } elseif (!$this->validation()->hasErrors() && $awards) {
                                 foreach($awards->getRecipients() as $recipient) {


### PR DESCRIPTION
# Description
- Fix "in_array(): Argument 2 must be of type array, string given"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
