### PR TITLE
Fix "argument must be of type array|object, null given"

### DIFF
--- a/application/modules/link/controllers/admin/Index.php
+++ b/application/modules/link/controllers/admin/Index.php
@@ -183,7 +183,7 @@ class Index extends \Ilch\Controller\Admin
         if ($this->getRequest()->getParam('id')) {
             $this->getLayout()->getAdminHmenu()
                     ->add($this->getTranslator()->trans('menuLinks'), ['action' => 'index'])
-                    ->add($this->getTranslator()->trans('edit'), ['action' => 'treat']);
+                    ->add($this->getTranslator()->trans('menuActionEditLink'), ['action' => 'treat']);
 
             $model = $linkMapper->getLinkById($this->getRequest()->getParam('id'));
 
@@ -193,7 +193,7 @@ class Index extends \Ilch\Controller\Admin
         } else {
             $this->getLayout()->getAdminHmenu()
                     ->add($this->getTranslator()->trans('menuLinks'), ['action' => 'index'])
-                    ->add($this->getTranslator()->trans('add'), ['action' => 'treat']);
+                    ->add($this->getTranslator()->trans('menuActionNewLink'), ['action' => 'treat']);
         }
         $this->getView()->set('link', $model);
 
@@ -243,7 +243,7 @@ class Index extends \Ilch\Controller\Admin
             }
         }
 
-        $this->getView()->set('cats', $categoryMapper->getCategories());
+        $this->getView()->set('cats', $categoryMapper->getCategories() ?? []);
     }
 
     public function treatCatAction()
@@ -254,7 +254,7 @@ class Index extends \Ilch\Controller\Admin
         if ($this->getRequest()->getParam('id')) {
             $this->getLayout()->getAdminHmenu()
                     ->add($this->getTranslator()->trans('menuLinks'), ['action' => 'index'])
-                    ->add($this->getTranslator()->trans('edit'), ['action' => 'treat']);
+                    ->add($this->getTranslator()->trans('menuActionEditCategory'), ['action' => 'treat']);
 
             $model = $categorykMapper->getCategoryById($this->getRequest()->getParam('id'));
 
@@ -264,7 +264,7 @@ class Index extends \Ilch\Controller\Admin
         } else {
             $this->getLayout()->getAdminHmenu()
                     ->add($this->getTranslator()->trans('menuLinks'), ['action' => 'index'])
-                    ->add($this->getTranslator()->trans('add'), ['action' => 'treat']);
+                    ->add($this->getTranslator()->trans('menuActionNewCategory'), ['action' => 'treat']);
         }
         $this->getView()->set('category', $model);
 

--- a/application/modules/link/translations/de.php
+++ b/application/modules/link/translations/de.php
@@ -22,7 +22,7 @@ return [
     'description' => 'Beschreibung',
     'noLinks' => 'Keine Links vorhanden',
     'noCategory' => 'Keine Kategorie vorhanden',
-    'httpOrMedia' => 'http:// oder Medien',
+    'httpOrMedia' => 'https:// oder Medien',
     'deleteFailed' => 'Es befinden sich noch Einträge in der Kategorie',
     'linkInfoText' => 'Die Links einer Kategorie können innerhalb der Kategorie bearbeitet werden. Links und Kategorien können durch ziehen und ablegen sortiert werden.',
     'categoryNotFound' => 'Kategorie nicht gefunden.',

--- a/application/modules/link/translations/en.php
+++ b/application/modules/link/translations/en.php
@@ -22,7 +22,7 @@ return [
     'description' => 'Description',
     'noLinks' => 'No links',
     'noCategory' => 'No category',
-    'httpOrMedia' => 'http:// or Media',
+    'httpOrMedia' => 'https:// or Media',
     'deleteFailed' => 'There are still entries in the category',
     'linkInfoText' => 'The links of a category can be edited inside the category. Links and categories can be sorted by drag and drop.',
     'categoryNotFound' => 'Category not found.',


### PR DESCRIPTION
# Description
- Fixed "argument must be of type array|object, null given"
- Improved the menus.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
