### PR TITLE
V2.1.55

### DIFF
--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -11,6 +11,15 @@ use Ilch\Validation;
 
 class Index extends \Ilch\Controller\Frontend
 {
+    /**
+     * @var string
+     */
+    private const MARIADBVERSION = '5.5';
+    /**
+     * @var string
+     */
+    private const MYSQLVERSION = '5.5.3';
+
     public function init()
     {
         if (!extension_loaded('openssl')) {
@@ -181,9 +190,8 @@ class Index extends \Ilch\Controller\Frontend
     public function systemcheckAction()
     {
         $errors = [];
-        $phpVersion = '7.3';
-        $this->getView()->set('phpVersion', $phpVersion);
-        if (!version_compare(PHP_VERSION, $phpVersion, '>=')) {
+        $this->getView()->set('phpVersion', PHPVERSION);
+        if (!version_compare(PHP_VERSION, PHPVERSION, '>=')) {
             $errors['phpVersion'] = true;
         }
 
@@ -192,10 +200,10 @@ class Index extends \Ilch\Controller\Frontend
         $dbLinkIdentifier = mysqli_connect($_SESSION['install']['dbHost'], $_SESSION['install']['dbUser'], $_SESSION['install']['dbPassword'], null, $port);
         $dbVersion = mysqli_get_server_info($dbLinkIdentifier);
         if (strpos($dbVersion, 'MariaDB') !== false) {
-            $requiredVersion = '5.5';
-            $this->getView()->set('dbServerInfo', 'MariaDB');
+            $requiredVersion = $this::MARIADBVERSION;
+            $this->getView()->set('dbServerInfo', ' MariaDB');
         } else {
-            $requiredVersion = '5.5.3';
+            $requiredVersion = $this::MYSQLVERSION;
             $this->getView()->set('dbServerInfo', 'MySQL');
         }
         if (!version_compare($dbVersion, $requiredVersion, '>=')) {
@@ -573,7 +581,7 @@ class Index extends \Ilch\Controller\Frontend
             if ($reload) {
                 unset($_SESSION['install']['modulesToInstall'][$type]);
             } else {
-                    $modulesToInstall = $_SESSION['install']['modulesToInstall'][$type];
+                $modulesToInstall = $_SESSION['install']['modulesToInstall'][$type];
             }
         }
 

--- a/composer.lock
+++ b/composer.lock
@@ -182,16 +182,16 @@
         },
         {
             "name": "fortawesome/font-awesome",
-            "version": "6.4.2",
+            "version": "6.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FortAwesome/Font-Awesome.git",
-                "reference": "f0c25837a3fe0e03783b939559e088abcbfb3c4b"
+                "reference": "deeea78c52bfe00b6e251ffddccf5570d5fdb05e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/f0c25837a3fe0e03783b939559e088abcbfb3c4b",
-                "reference": "f0c25837a3fe0e03783b939559e088abcbfb3c4b",
+                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/deeea78c52bfe00b6e251ffddccf5570d5fdb05e",
+                "reference": "deeea78c52bfe00b6e251ffddccf5570d5fdb05e",
                 "shasum": ""
             },
             "type": "library",
@@ -223,7 +223,7 @@
                 "issues": "https://github.com/FortAwesome/Font-Awesome/issues",
                 "source": "https://github.com/FortAwesome/Font-Awesome"
             },
-            "time": "2023-08-02T20:27:06+00:00"
+            "time": "2023-11-30T22:38:48+00:00"
         },
         {
             "name": "harvesthq/chosen",
@@ -1290,16 +1290,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.13",
+            "version": "9.6.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
                 "shasum": ""
             },
             "require": {
@@ -1373,7 +1373,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
             },
             "funding": [
                 {
@@ -1389,7 +1389,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-19T05:39:22+00:00"
+            "time": "2023-12-01T16:55:19+00:00"
         },
         {
             "name": "psr/log",

--- a/index.php
+++ b/index.php
@@ -5,7 +5,8 @@
  * @package ilch
  */
 
-if (!version_compare(PHP_VERSION, '7.3', '>=')) {
+define('PHPVERSION', '7.3');
+if (!version_compare(PHP_VERSION, PHPVERSION, '>=')) {
     die('Ilch CMS 2 needs at least php version 7.3');
 }
 
@@ -30,7 +31,7 @@ header('Content-Type: text/html; charset=utf-8');
 $serverTimeZone = @date_default_timezone_get();
 date_default_timezone_set('UTC');
 
-define('VERSION', '2.1.54');
+define('VERSION', '2.1.55');
 define('SERVER_TIMEZONE', $serverTimeZone);
 define('DEFAULT_MODULE', 'page');
 define('DEFAULT_LAYOUT', 'index');


### PR DESCRIPTION
**Version 2.1.55**

<a href="https://github.com/IlchCMS/Ilch-2.0/wiki/Hinweise-f%C3%BCr-Entwickler" target="_blank">Hinweise für Entwickler</a>  
**Ilch:**  
- Boxen waren für Gäste nicht sichtbar.  
- HTMLPurifier: Base64 encodierte Bilder sind nun erlaubt.  
- CKEditor auf Version 4.23 aktualisiert.  
- HTMLPurifier auf Version 4.17 aktualisiert.  
- PHPMailer auf Version 6.9.1 aktualisiert.
- FontAwesome auf Version 6.5.1 aktualisiert.

**Auszeichnungen-Modul (1.10.1):**

- Fehler bei fehlenden Eingaben beim Erstellen/Bearbeiten einer Auszeichnung behoben.

**BBCode-Konvertierung-Modul (1.0.3):**

- Unterstützung für die aktuelle Version des Forum-, Gästebuch- und Teams-Modul hinzugefügt.

**Kalender-Modul (1.9.1, veröffentlicht am 02.11.23):**

- Fehlende Übersetzung für "jährlich" zu einigen Ansichten hinzugefügt.

**Kalender-Modul (1.9.2):**

- Darstellungsfehler behoben mit bestimmten Zeichen im Titel eines Kalendereintrages.

**Downloads-Modul (1.13.5):**

- Fehler behoben, welcher auftrat, wenn eine Datei im Medien-Modul gelöscht wurde, welche einem Download zugeordnet ist.

**Forum-Modul (1.34.3, veröffentlicht am 02.11.23):**

- Mehrere Fehler behoben, wenn ein Forum leer war oder kein Forum und/oder Kategorie existierte.

**Forum-Modul (1.34.4):**

- Fehler in der Box behoben, wenn ein Forum leer war.  
- Einträge in der Box wurden falsch sortiert und nicht als ungelesen dargestellt.  
- Es wurde nicht das richtige Thema als neuestes Thema eines Forums dargestellt.  
- Beim Verfassen eines Beitrages wurden doppelte Einträge für gelesene Themen erstellt.  
- Datum und Uhrzeit in der lokalen Zeitzone anzeigen (vorher war dies überwiegend UTC).

**Regeln-Modul (1.8.1):**

- Positionen waren falsch.

**Teams-Modul (1.23.1):**

- Fehler beim Bild hochladen behoben.

**Wie halte ich Ilch auf den aktuellen Stand?**
https://github.com/IlchCMS/Ilch-2.0/wiki/Doku-Benutzer-Ilch-aktuell-halten