### PR TITLE
Only take fr.datetime into consideration if there is not a newer tr.d…

### DIFF
--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'forum',
-        'version' => '1.34.4',
+        'version' => '1.34.5',
         'icon_small' => 'fa-solid fa-list',
         'author' => 'Stantin Thomas',
         'link' => 'https://ilch.de',


### PR DESCRIPTION
# Description
- Only take fr.datetime into consideration if there is not a newer tr.datetime. Read topics where wrongly shown as unread.

https://www.ilch.de/forum-showposts-58649.html

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
