### PR TITLE
Newsletter: Add support for double opt in

### DIFF
--- a/application/modules/newsletter/boxes/Newsletter.php
+++ b/application/modules/newsletter/boxes/Newsletter.php
@@ -76,8 +76,8 @@ class Newsletter extends Box
                     $subscriberModel->setConfirmCode($confirmedCode);
                     $subscriberModel->setEmail($this->getRequest()->getPost('email'));
                     $subscriberModel->setDoubleOptInDate($date);
-                    $subscriberModel->setDoubleOptInConfirmed(false);
-                    $subscriberMapper->saveEmail($subscriberModel);
+                    $subscriberModel->setDoubleOptInConfirmed(!$this->getConfig()->get('newsletter_doubleOptIn'));
+                    $subscriberMapper->saveSubscriber($subscriberModel);
                 }
                 $this->getView()->set('success', 'true');
             } else {

--- a/application/modules/newsletter/boxes/Newsletter.php
+++ b/application/modules/newsletter/boxes/Newsletter.php
@@ -80,6 +80,7 @@ class Newsletter extends Box
                     $subscriberMapper->saveSubscriber($subscriberModel);
                 }
                 $this->getView()->set('success', 'true');
+                $this->getView()->set('doubleOptIn', $this->getConfig()->get('newsletter_doubleOptIn'));
             } else {
                 $this->getView()->set('success', 'false');
             }

--- a/application/modules/newsletter/boxes/Newsletter.php
+++ b/application/modules/newsletter/boxes/Newsletter.php
@@ -6,15 +6,19 @@
 
 namespace Modules\Newsletter\Boxes;
 
-use Modules\Newsletter\Mappers\Newsletter as NewsletterMapper;
-use Modules\Newsletter\Models\Newsletter as NewsletterModel;
+use Ilch\Box;
+use Ilch\Date;
+use Ilch\Mail;
+use Modules\Admin\Mappers\Emails as EmailsMapper;
+use Modules\Newsletter\Mappers\Subscriber as SubscriberMapper;
 use Ilch\Validation;
+use Modules\Newsletter\Models\Subscriber as SubscriberModel;
 
-class Newsletter extends \Ilch\Box
+class Newsletter extends Box
 {
     public function render()
     {
-        $newsletterMapper = new NewsletterMapper();
+        $subscriberMapper = new SubscriberMapper();
 
         $this->getView()->set('success', '');
         if ($this->getRequest()->getPost('saveNewsletterBox')) {
@@ -23,13 +27,57 @@ class Newsletter extends \Ilch\Box
             ]);
 
             if ($validation->isValid()) {
-                $countEmails = $newsletterMapper->countEmails($this->getRequest()->getPost('email'));
+                // Delete possible old unconfirmed entries before checking if an e-mail is already registered.
+                $subscriberMapper->deleteOldUnconfirmedDoubleOptIn();
+                $countEmails = $subscriberMapper->countEmails($this->getRequest()->getPost('email'));
                 if ($countEmails == 0) {
-                    $newsletterModel = new NewsletterModel();
-                    $newsletterModel->setSelector(bin2hex(random_bytes(9)));
-                    $newsletterModel->setConfirmCode(bin2hex(random_bytes(32)));
-                    $newsletterModel->setEmail($this->getRequest()->getPost('email'));
-                    $newsletterMapper->saveEmail($newsletterModel);
+                    $selector = bin2hex(random_bytes(9));
+                    $confirmedCode = bin2hex(random_bytes(32));
+                    $date = new Date();
+
+                    if ($this->getConfig()->get('newsletter_doubleOptIn')) {
+                        // Double-Opt-In is enabled.
+                        $emailsMapper = new EmailsMapper();
+
+                        $siteTitle = $this->getLayout()->escape($this->getConfig()->get('page_title'));
+                        $confirmCode = '<a href="' . BASE_URL . '/index.php/newsletter/index/doubleoptin/selector/' . $selector . '/code/' . $confirmedCode . '" class="btn btn-primary btn-sm">' . $this->getTranslator()->trans('confirmMailButtonText') . '</a>';
+                        $mailContent = $emailsMapper->getEmail('newsletter', 'newsletter_doubleOptIn', $this->getTranslator()->getLocale());
+                        $layout = '';
+                        if (!empty($_SESSION['layout'])) {
+                            $layout = $_SESSION['layout'];
+                        }
+
+                        if ($layout == $this->getConfig()->get('default_layout') && file_exists(APPLICATION_PATH . '/layouts/' . $this->getConfig()->get('default_layout') . '/views/modules/newsletter/layouts/mail/doubleOptIn.php')) {
+                            $messageTemplate = file_get_contents(APPLICATION_PATH . '/layouts/' . $this->getConfig()->get('default_layout') . '/views/modules/newsletter/layouts/mail/doubleOptIn.php');
+                        } else {
+                            $messageTemplate = file_get_contents(APPLICATION_PATH . '/modules/newsletter/layouts/mail/doubleOptIn.php');
+                        }
+
+                        $messageReplace = [
+                            '{content}' => $this->getLayout()->purify($mailContent->getText()),
+                            '{sitetitle}' => $siteTitle,
+                            '{date}' => $date->format('l, d. F Y', true),
+                            '{confirm}' => $confirmCode,
+                            '{footer}' => $this->getTranslator()->trans('noReplyMailFooter')
+                        ];
+                        $message = str_replace(array_keys($messageReplace), array_values($messageReplace), $messageTemplate);
+
+                        $mail = new Mail();
+                        $mail->setFromName($siteTitle)
+                            ->setFromEmail($this->getConfig()->get('standardMail'))
+                            ->setToEmail($this->getRequest()->getPost('email'))
+                            ->setSubject($this->getTranslator()->trans('automaticEmail'))
+                            ->setMessage($message)
+                            ->send();
+                    }
+
+                    $subscriberModel = new SubscriberModel();
+                    $subscriberModel->setSelector($selector);
+                    $subscriberModel->setConfirmCode($confirmedCode);
+                    $subscriberModel->setEmail($this->getRequest()->getPost('email'));
+                    $subscriberModel->setDoubleOptInDate($date);
+                    $subscriberModel->setDoubleOptInConfirmed(false);
+                    $subscriberMapper->saveEmail($subscriberModel);
                 }
                 $this->getView()->set('success', 'true');
             } else {

--- a/application/modules/newsletter/boxes/views/newsletter.php
+++ b/application/modules/newsletter/boxes/views/newsletter.php
@@ -1,8 +1,8 @@
 <?php if ($this->get('success') !== '') : ?>
     <?php if ($this->get('success') === 'false') :?>
-        <?='<div class="alert alert-danger">'.$this->getTrans('subscribeFailed').'</div>' ?>
+        <?='<div class="alert alert-danger">' . $this->getTrans('subscribeFailed') . '</div>' ?>
     <?php else : ?>
-        <?='<div class="alert alert-success">'.$this->getTrans('subscribeSuccess').'</div>' ?>
+        <?='<div class="alert alert-success">' . $this->getTrans('subscribeSuccess') . '</div>' ?>
     <?php endif ?>
 <?php endif; ?>
 
@@ -11,7 +11,7 @@
     <div class="form-group <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
         <div class="col-lg-12">
             <div class="input-group">
-                <span class="input-group-addon" id="basic-addon1"><i class="fa fa-envelope"></i></span>
+                <span class="input-group-addon" id="basic-addon1"><i class="fa-solid fa-envelope"></i></span>
                 <input type="email"
                        class="form-control"
                        id="email"

--- a/application/modules/newsletter/boxes/views/newsletter.php
+++ b/application/modules/newsletter/boxes/views/newsletter.php
@@ -2,7 +2,7 @@
     <?php if ($this->get('success') === 'false') :?>
         <?='<div class="alert alert-danger">' . $this->getTrans('subscribeFailed') . '</div>' ?>
     <?php else : ?>
-        <?='<div class="alert alert-success">' . $this->getTrans('subscribeSuccess') . '</div>' ?>
+        <?='<div class="alert alert-success">' . $this->getTrans('subscribeSuccess') . (($this->get('doubleOptIn')) ? ' ' . $this->getTrans('doubleOptInConfirm') : '') . '</div>' ?>
     <?php endif ?>
 <?php endif; ?>
 

--- a/application/modules/newsletter/config/config.php
+++ b/application/modules/newsletter/config/config.php
@@ -43,6 +43,8 @@ class Config extends Install
 
     public function install()
     {
+        $databaseConfig = new Database($this->db());
+        $databaseConfig->set('newsletter_doubleOptIn', '1');
         $this->db()->queryMulti($this->getInstallSql());
     }
 

--- a/application/modules/newsletter/config/config.php
+++ b/application/modules/newsletter/config/config.php
@@ -6,6 +6,7 @@
 
 namespace Modules\Newsletter\Config;
 
+use Ilch\Config\Database;
 use Ilch\Config\Install;
 
 class Config extends Install
@@ -49,7 +50,11 @@ class Config extends Install
     {
         $this->db()->drop('[prefix]_newsletter');
         $this->db()->drop('[prefix]_newsletter_mails');
-        $this->db()->queryMulti("DELETE FROM `[prefix]_user_menu_settings_links` WHERE `key` = 'newsletter/index/settings'");
+        $this->db()->queryMulti("DELETE FROM `[prefix]_user_menu_settings_links` WHERE `key` = 'newsletter/index/settings';
+            DELETE FROM `[prefix]_emails` WHERE `moduleKey` = 'newsletter';");
+
+        $databaseConfig = new Database($this->db());
+        $databaseConfig->delete('newsletter_doubleOptIn');
     }
 
     public function getInstallSql(): string

--- a/application/modules/newsletter/controllers/Index.php
+++ b/application/modules/newsletter/controllers/Index.php
@@ -39,7 +39,7 @@ class Index extends Frontend
                     $subscriberModel->setSelector(bin2hex(random_bytes(9)));
                     $subscriberModel->setConfirmCode(bin2hex(random_bytes(32)));
                     $subscriberModel->setEmail($this->getRequest()->getPost('email'));
-                    $subscriberMapper->saveEmail($subscriberModel);
+                    $subscriberMapper->saveSubscriber($subscriberModel);
                 }
 
                 $this->addMessage('subscribeSuccess');
@@ -94,7 +94,7 @@ class Index extends Frontend
                     $subscriberModel->setNewsletter(1);
                     $subscriberModel->setDoubleOptInDate($subscriber->getDoubleOptInDate());
                     $subscriberModel->setDoubleOptInConfirmed(true);
-                    $subscriberMapper->saveEmail($subscriberModel);
+                    $subscriberMapper->saveSubscriber($subscriberModel);
 
                     $this->addMessage('doubleOptInSuccess');
                 }
@@ -118,7 +118,7 @@ class Index extends Frontend
             if (!empty($subscriber) && hash_equals($subscriber->getConfirmCode(), $confirmCode)) {
                 $countEmail = $subscriberMapper->countEmails($subscriber->getEmail());
                 if ($countEmail == 1) {
-                    $subscriberMapper->deleteEmail($subscriber->getEmail());
+                    $subscriberMapper->deleteSubscriberByEmail($subscriber->getEmail());
 
                     $this->addMessage('unsubscribeSuccess');
                 }
@@ -151,7 +151,7 @@ class Index extends Frontend
                 $subscriberModel->setConfirmCode(bin2hex(random_bytes(32)));
                 $subscriberModel->setId($this->getUser()->getId());
                 $subscriberModel->setNewsletter($this->getRequest()->getPost('acceptNewsletter'));
-                $subscriberMapper->saveUserEmail($subscriberModel);
+                $subscriberMapper->saveUserAsSubscriber($subscriberModel);
 
                 $this->redirect(['action' => 'settings']);
             } else {

--- a/application/modules/newsletter/controllers/admin/Index.php
+++ b/application/modules/newsletter/controllers/admin/Index.php
@@ -158,7 +158,7 @@ class Index extends Admin
                     $messageTemplate = file_get_contents(APPLICATION_PATH . '/modules/newsletter/layouts/mail/newsletter.php');
                 }
 
-                $emails = $subscriberMapper->getMail();
+                $emails = $subscriberMapper->getSubscribers();
                 foreach ($emails as $email) {
                     if (!$email->getDoubleOptInConfirmed()) {
                         continue;
@@ -197,6 +197,6 @@ class Index extends Admin
             }
         }
 
-        $this->getView()->set('emails', $subscriberMapper->getMail());
+        $this->getView()->set('emails', $subscriberMapper->getSubscribers());
     }
 }

--- a/application/modules/newsletter/controllers/admin/Index.php
+++ b/application/modules/newsletter/controllers/admin/Index.php
@@ -6,12 +6,16 @@
 
 namespace Modules\Newsletter\Controllers\Admin;
 
+use Ilch\Controller\Admin;
+use Ilch\Date;
+use Ilch\Mail;
 use Modules\Newsletter\Mappers\Newsletter as NewsletterMapper;
+use Modules\Newsletter\Mappers\Subscriber as SubscriberMapper;
 use Modules\Newsletter\Models\Newsletter as NewsletterModel;
 use Modules\User\Mappers\User as UserMapper;
 use Ilch\Validation;
 
-class Index extends \Ilch\Controller\Admin
+class Index extends Admin
 {
     public function init()
     {
@@ -19,20 +23,26 @@ class Index extends \Ilch\Controller\Admin
             [
                 'name' => 'manage',
                 'active' => false,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index']),
                 [
                     'name' => 'add',
                     'active' => false,
-                    'icon' => 'fa fa-plus-circle',
+                    'icon' => 'fa-solid fa-circle-plus',
                     'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'treat'])
                 ]
             ],
             [
                 'name' => 'receiver',
                 'active' => false,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'receiver', 'action' => 'index'])
+            ],
+            [
+                'name' => 'settings',
+                'active' => false,
+                'icon' => 'fa-solid fa-gears',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
             ]
         ];
 
@@ -51,11 +61,15 @@ class Index extends \Ilch\Controller\Admin
     public function indexAction()
     {
         $newsletterMapper = new NewsletterMapper();
+        $subscriberMapper = new SubscriberMapper();
         $userMapper = new UserMapper();
 
         $this->getLayout()->getAdminHmenu()
                 ->add($this->getTranslator()->trans('menuNewsletter'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('manage'), ['action' => 'index']);
+
+        // Another occasion to delete possible old unconfirmed entries of subscribers.
+        $subscriberMapper->deleteOldUnconfirmedDoubleOptIn();
 
         if ($this->getRequest()->getPost('check_entries') && $this->getRequest()->getPost('action') === 'delete') {
             foreach ($this->getRequest()->getPost('check_entries') as $newsletterId) {
@@ -91,7 +105,7 @@ class Index extends \Ilch\Controller\Admin
                 ->add($this->getTranslator()->trans('menuNewsletter'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('show'), ['action' => 'show']);
 
-        if ($this->getRequest()->isPost('delete')) {
+        if ($this->getRequest()->isPost()) {
             $newsletterMapper->delete($this->getRequest()->getParam('id'));
 
             $this->addMessage('deleteSuccess');
@@ -106,7 +120,8 @@ class Index extends \Ilch\Controller\Admin
     public function treatAction()
     {
         $newsletterMapper = new NewsletterMapper();
-        $date = new \Ilch\Date();
+        $subscriberMapper = new SubscriberMapper();
+        $date = new Date();
 
         $this->getLayout()->getAdminHmenu()
                 ->add($this->getTranslator()->trans('menuNewsletter'), ['action' => 'index'])
@@ -137,14 +152,18 @@ class Index extends \Ilch\Controller\Admin
                     $layout = $_SESSION['layout'];
                 }
 
-                if ($layout == $this->getConfig()->get('default_layout') && file_exists(APPLICATION_PATH.'/layouts/'.$this->getConfig()->get('default_layout').'/views/modules/newsletter/layouts/mail/newsletter.php')) {
-                    $messageTemplate = file_get_contents(APPLICATION_PATH.'/layouts/'.$this->getConfig()->get('default_layout').'/views/modules/newsletter/layouts/mail/newsletter.php');
+                if ($layout == $this->getConfig()->get('default_layout') && file_exists(APPLICATION_PATH . '/layouts/' . $this->getConfig()->get('default_layout') . '/views/modules/newsletter/layouts/mail/newsletter.php')) {
+                    $messageTemplate = file_get_contents(APPLICATION_PATH . '/layouts/' . $this->getConfig()->get('default_layout') . '/views/modules/newsletter/layouts/mail/newsletter.php');
                 } else {
-                    $messageTemplate = file_get_contents(APPLICATION_PATH.'/modules/newsletter/layouts/mail/newsletter.php');
+                    $messageTemplate = file_get_contents(APPLICATION_PATH . '/modules/newsletter/layouts/mail/newsletter.php');
                 }
 
-                $emails = $newsletterMapper->getMail();
+                $emails = $subscriberMapper->getMail();
                 foreach ($emails as $email) {
+                    if (!$email->getDoubleOptInConfirmed()) {
+                        continue;
+                    }
+
                     $messageReplace = [
                         '{subject}' => $this->getLayout()->escape($post['subject']),
                         '{content}' => $this->getLayout()->purify($post['text']),
@@ -156,7 +175,7 @@ class Index extends \Ilch\Controller\Admin
                     ];
                     $message = str_replace(array_keys($messageReplace), array_values($messageReplace), $messageTemplate);
 
-                    $mail = new \Ilch\Mail();
+                    $mail = new Mail();
                     $mail->setFromName($this->getConfig()->get('page_title'))
                         ->setFromEmail($this->getConfig()->get('standardMail'))
                         ->setToName($email->getEmail())
@@ -178,6 +197,6 @@ class Index extends \Ilch\Controller\Admin
             }
         }
 
-        $this->getView()->set('emails', $newsletterMapper->getMail());
+        $this->getView()->set('emails', $subscriberMapper->getMail());
     }
 }

--- a/application/modules/newsletter/controllers/admin/Receiver.php
+++ b/application/modules/newsletter/controllers/admin/Receiver.php
@@ -54,20 +54,20 @@ class Receiver extends Admin
 
             if ($this->getRequest()->getPost('check_entries') && $this->getRequest()->getPost('action') === 'delete') {
                 foreach ($this->getRequest()->getPost('check_entries') as $email) {
-                    $subscriberMapper->deleteEmail($email);
+                    $subscriberMapper->deleteSubscriberByEmail($email);
                 }
             }
 
             foreach ($this->getRequest()->getPost('check_users') as $userEmail) {
                 if ($userEmail != '') {
                     $subscriberModel->setEmail($userEmail);
-                    $subscriberMapper->saveEmail($subscriberModel);
+                    $subscriberMapper->saveSubscriber($subscriberModel);
                 }
             }
             $this->addMessage('saveSuccess');
         }
 
-        $this->getView()->set('emails', $subscriberMapper->getMail());
+        $this->getView()->set('emails', $subscriberMapper->getSubscribers());
         $this->getView()->set('userList', $subscriberMapper->getSendMailUser());
     }
 

--- a/application/modules/newsletter/controllers/admin/Receiver.php
+++ b/application/modules/newsletter/controllers/admin/Receiver.php
@@ -6,10 +6,11 @@
 
 namespace Modules\Newsletter\Controllers\Admin;
 
-use Modules\Newsletter\Mappers\Newsletter as NewsletterMapper;
-use Modules\Newsletter\Models\Newsletter as NewsletterModel;
+use Ilch\Controller\Admin;
+use Modules\Newsletter\Mappers\Subscriber as SubscriberMapper;
+use Modules\Newsletter\Models\Subscriber as SubscriberModel;
 
-class Receiver extends \Ilch\Controller\Admin
+class Receiver extends Admin
 {
     public function init()
     {
@@ -17,14 +18,20 @@ class Receiver extends \Ilch\Controller\Admin
             [
                 'name' => 'manage',
                 'active' => false,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
             ],
             [
                 'name' => 'receiver',
                 'active' => true,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'receiver', 'action' => 'index'])
+            ],
+            [
+                'name' => 'settings',
+                'active' => false,
+                'icon' => 'fa-solid fa-gears',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
             ]
         ];
 
@@ -36,40 +43,40 @@ class Receiver extends \Ilch\Controller\Admin
 
     public function indexAction()
     {
-        $newsletterMapper = new NewsletterMapper();
+        $subscriberMapper = new SubscriberMapper();
 
         $this->getLayout()->getAdminHmenu()
                 ->add($this->getTranslator()->trans('menuNewsletter'), ['action' => 'index'])
                 ->add($this->getTranslator()->trans('receiver'), ['action' => 'index']);
 
         if ($this->getRequest()->isPost()) {
-            $newsletterModel = new NewsletterModel();
+            $subscriberModel = new SubscriberModel();
 
             if ($this->getRequest()->getPost('check_entries') && $this->getRequest()->getPost('action') === 'delete') {
                 foreach ($this->getRequest()->getPost('check_entries') as $email) {
-                    $newsletterMapper->deleteEmail($email);
+                    $subscriberMapper->deleteEmail($email);
                 }
             }
 
             foreach ($this->getRequest()->getPost('check_users') as $userEmail) {
                 if ($userEmail != '') {
-                    $newsletterModel->setEmail($userEmail);
-                    $newsletterMapper->saveEmail($newsletterModel);
+                    $subscriberModel->setEmail($userEmail);
+                    $subscriberMapper->saveEmail($subscriberModel);
                 }
             }
             $this->addMessage('saveSuccess');
         }
 
-        $this->getView()->set('emails', $newsletterMapper->getMail());
-        $this->getView()->set('userList', $newsletterMapper->getSendMailUser());
+        $this->getView()->set('emails', $subscriberMapper->getMail());
+        $this->getView()->set('userList', $subscriberMapper->getSendMailUser());
     }
 
     public function deleteAction()
     {
         if ($this->getRequest()->isSecure()) {
-            $newsletterMapper = new NewsletterMapper();
+            $subscriberMapper = new SubscriberMapper();
 
-            $newsletterMapper->deleteSubscriberBySelector($this->getRequest()->getParam('selector'));
+            $subscriberMapper->deleteSubscriberBySelector($this->getRequest()->getParam('selector'));
 
             $this->addMessage('deleteSuccess');
         }

--- a/application/modules/newsletter/controllers/admin/Settings.php
+++ b/application/modules/newsletter/controllers/admin/Settings.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Newsletter\Controllers\Admin;
+
+use Ilch\Controller\Admin;
+
+class Settings extends Admin
+{
+    public function init()
+    {
+        $items = [
+            [
+                'name' => 'manage',
+                'active' => false,
+                'icon' => 'fa-solid fa-table-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index']),
+                [
+                    'name' => 'add',
+                    'active' => false,
+                    'icon' => 'fa-solid fa-circle-plus',
+                    'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'treat'])
+                ]
+            ],
+            [
+                'name' => 'receiver',
+                'active' => false,
+                'icon' => 'fa-solid fa-table-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'receiver', 'action' => 'index'])
+            ],
+            [
+                'name' => 'settings',
+                'active' => true,
+                'icon' => 'fa-solid fa-gears',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
+            ]
+        ];
+
+        $this->getLayout()->addMenu(
+            'menuNewsletter',
+            $items
+        );
+    }
+
+    public function indexAction()
+    {
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('forum'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('settings'), ['action' => 'index']);
+
+        if ($this->getRequest()->isPost()) {
+            $this->getConfig()->set('newsletter_doubleOptIn', $this->getRequest()->getPost('doubleOptIn'));
+            $this->addMessage('saveSuccess');
+        }
+
+        $this->getView()->set('doubleOptIn', $this->getConfig()->get('newsletter_doubleOptIn'));
+    }
+}

--- a/application/modules/newsletter/layouts/mail/doubleOptIn.php
+++ b/application/modules/newsletter/layouts/mail/doubleOptIn.php
@@ -1,22 +1,10 @@
-<?php
-
-use Ilch\Registry;
-use Ilch\Translator;
-
-$config = Registry::get('config');
-$subscriberMapper = new Modules\Newsletter\Mappers\Subscriber();
-$subscriber = $subscriberMapper->getSubscriberByEMail($this->getRequest()->getParam('email'));
-$translator = new Translator();
-$translator->load(APPLICATION_PATH . '/modules/newsletter/translations/');
-?>
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <meta name="viewport" content="width=device-width" />
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title><?=$config->get('page_title') ?></title>
-        <style>
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>{sitetitle}</title>
+    <style>
         /* -------------------------------------
             GLOBAL
         ------------------------------------- */
@@ -37,7 +25,6 @@ $translator->load(APPLICATION_PATH . '/modules/newsletter/translations/');
             -webkit-text-size-adjust: none;
             width: 100%!important;
             height: 100%;
-            background-color: #f6f6f6;
         }
 
         /* -------------------------------------
@@ -103,11 +90,9 @@ $translator->load(APPLICATION_PATH . '/modules/newsletter/translations/');
         table.body-wrap {
             width: 100%;
             padding: 20px;
-            background-color: #f6f6f6;
         }
 
         table.body-wrap .container {
-            background-color: #FFF;
             border: 1px solid #f0f0f0;
         }
 
@@ -190,45 +175,46 @@ $translator->load(APPLICATION_PATH . '/modules/newsletter/translations/');
         .content table {
             width: 100%;
         }
-        </style>
-    </head>
+    </style>
+</head>
 
-    <body>
-        <!-- body -->
-        <table class="body-wrap">
-            <tr>
-                <td></td>
-                <td class="container">
-                    <!-- content -->
-                    <div class="content">
-                        <table>
-                            <tr>
-                                <td>
-                                    <?=$this->getContent() ?>
-                                </td>
-                            </tr>
-                        </table>
-                    </div>
-                    <!-- /content -->
-                </td>
-                <td></td>
-            </tr>
-        </table>
-        <!-- /body -->
+<body bgcolor="#f6f6f6">
+<!-- body -->
+<table class="body-wrap" bgcolor="#f6f6f6">
+    <tr>
+        <td></td>
+        <td class="container" bgcolor="#FFFFFF">
+            <!-- content -->
+            <div class="content">
+                <table>
+                    <tr>
+                        <td>
+                            <p class="small text-muted">{date}</p>
+                            <p>&nbsp;</p>
+                            {content}
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <!-- /content -->
+        </td>
+        <td></td>
+    </tr>
+</table>
+<!-- /body -->
 
-        <!-- footer -->
-        <table class="footer-wrap">
-            <tr>
-                <td></td>
-                <td class="container">
-                    <div class="content" align="center">
-                        <p><?=$translator->trans('noReplyMailFooter') ?></p>
-                        <p><?=$translator->trans('mailUnsubscribe', $subscriber->getSelector(), $subscriber->getConfirmCode()) ?></p>
-                    </div>
-                </td>
-                <td></td>
-            </tr>
-        </table>
-        <!-- /footer -->
-    </body>
+<!-- footer -->
+<table class="footer-wrap">
+    <tr>
+        <td></td>
+        <td class="container">
+            <div class="content" align="center">
+                <p>{footer}</p>
+            </div>
+        </td>
+        <td></td>
+    </tr>
+</table>
+<!-- /footer -->
+</body>
 </html>

--- a/application/modules/newsletter/mappers/Subscriber.php
+++ b/application/modules/newsletter/mappers/Subscriber.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Newsletter\Mappers;
+
+use Ilch\Database\Mysql\Result;
+use Ilch\Mapper;
+use Modules\Newsletter\Models\Newsletter as NewsletterModel;
+use Modules\Newsletter\Models\Subscriber as SubscriberModel;
+
+class Subscriber extends Mapper
+{
+    /**
+     * Gets the Newsletter entries.
+     *
+     * @return NewsletterModel[]|array
+     */
+    public function getMail(): ?array
+    {
+        $entryArray = $this->db()->select('*')
+                ->from('newsletter_mails')
+                ->execute()
+                ->fetchRows();
+
+        if (empty($entryArray)) {
+            return null;
+        }
+
+        $entry = [];
+
+        foreach ($entryArray as $entries) {
+            $entryModel = new SubscriberModel();
+            $entryModel->setId($entries['id']);
+            $entryModel->setEmail($entries['email']);
+            $entryModel->setSelector($entries['selector']);
+            $entryModel->setConfirmCode($entries['confirmCode']);
+            $entryModel->setDoubleOptInDate($entries['doubleOptInDate']);
+            $entryModel->setDoubleOptInConfirmed($entries['doubleOptInConfirmed']);
+            $entry[] = $entryModel;
+        }
+
+        return $entry;
+    }
+
+    /**
+     * Gets the Newsletter subscriber by the email.
+     *
+     * @param string $email
+     * @return SubscriberModel|null
+     */
+    public function getSubscriberByEMail(string $email): ?SubscriberModel
+    {
+        $entryArray = $this->db()->select('*')
+            ->from('newsletter_mails')
+            ->where(['email' => $email])
+            ->execute()
+            ->fetchAssoc();
+
+        if (empty($entryArray)) {
+            return null;
+        }
+
+        $entryModel = new SubscriberModel();
+        $entryModel->setId($entryArray['id']);
+        $entryModel->setEmail($entryArray['email']);
+        $entryModel->setSelector($entryArray['selector']);
+        $entryModel->setConfirmCode($entryArray['confirmCode']);
+        $entryModel->setDoubleOptInDate($entryArray['doubleOptInDate']);
+        $entryModel->setDoubleOptInConfirmed($entryArray['doubleOptInConfirmed']);
+
+        return $entryModel;
+    }
+
+    /**
+     * Gets the Newsletter subscriber by the selector.
+     *
+     * @param string $selector
+     * @return SubscriberModel|null
+     */
+    public function getSubscriberBySelector(string $selector): ?SubscriberModel
+    {
+        $entryArray = $this->db()->select('*')
+                ->from('newsletter_mails')
+                ->where(['selector' => $selector])
+                ->execute()
+                ->fetchAssoc();
+
+        if (empty($entryArray)) {
+            return null;
+        }
+
+        $entryModel = new SubscriberModel();
+        $entryModel->setId($entryArray['id']);
+        $entryModel->setEmail($entryArray['email']);
+        $entryModel->setConfirmCode($entryArray['confirmCode']);
+        $entryModel->setDoubleOptInDate($entryArray['doubleOptInDate']);
+        $entryModel->setDoubleOptInConfirmed($entryArray['doubleOptInConfirmed']);
+
+        return $entryModel;
+    }
+
+    /**
+     * Gets the Newsletter mail entries.
+     *
+     * @param string $email
+     * @return int
+     */
+    public function countEmails(string $email): int
+    {
+        return $this->db()->select('COUNT(*)')
+                ->from('newsletter_mails')
+                ->where(['email' => $email])
+                ->execute()
+                ->fetchCell();
+    }
+
+    /**
+     * Inserts newsletter mail model.
+     *
+     * @param SubscriberModel $subscriber
+     * @return int
+     */
+    public function saveEmail(SubscriberModel $subscriber): int
+    {
+        $values = [
+            'email' => $subscriber->getEmail(),
+            'selector' => $subscriber->getSelector(),
+            'confirmCode' => $subscriber->getConfirmCode(),
+            'doubleOptInDate' => $subscriber->getDoubleOptInDate(),
+            'doubleOptInConfirmed' => $subscriber->getDoubleOptInConfirmed(),
+        ];
+
+        if ($subscriber->getId()) {
+            return $this->db()->update('newsletter_mails')
+                ->values($values)
+                ->where(['id' => $subscriber->getId()])
+                ->execute();
+        } else {
+            return $this->db()->insert('newsletter_mails')
+                ->values($values)
+                ->execute();
+        }
+    }
+
+    /**
+     * Deletes newsletter email with given email.
+     *
+     * @param string $email
+     */
+    public function deleteEmail(string $email)
+    {
+        $this->db()->delete('newsletter_mails')
+                ->where(['email' => $email])
+                ->execute();
+    }
+
+    /**
+     * Deletes newsletter email with given selector.
+     *
+     * @param string $selector
+     */
+    public function deleteSubscriberBySelector(string $selector)
+    {
+        $this->db()->delete('newsletter_mails')
+                ->where(['selector' => $selector])
+                ->execute();
+    }
+
+    /**
+     * Delete unconfirmed double opt-in entries that are older than 24 hours.
+     *
+     * @return Result|int
+     */
+    public function deleteOldUnconfirmedDoubleOptIn()
+    {
+        return $this->db()->delete('newsletter_mails')
+            ->where(['doubleOptInDate <' => date('Y-m-d H:i:s', strtotime('-24 hours')), 'doubleOptInConfirmed' => 0])
+            ->execute();
+    }
+
+    /**
+     * Gets the Newsletter entries.
+     *
+     * @return NewsletterModel[]|array
+     */
+    public function getSendMailUser(): array
+    {
+        return $this->db()->select()
+                ->fields(['nm.email', 'nm.selector'])
+                ->from(['nm' => 'newsletter_mails'])
+                ->join(['u' => 'users'], 'u.email = nm.email', 'LEFT', ['name' => 'u.name'])
+                ->execute()
+                ->fetchRows();
+    }
+
+    /**
+     * Insert Mail to Newsletter.
+     *
+     * @param SubscriberModel $subscriber
+     * @return void
+     */
+    public function saveUserEmail(SubscriberModel $subscriber)
+    {
+        $userRow = $this->db()->select('email')
+            ->from('users')
+            ->where(['id' => $subscriber->getId()])
+            ->execute()
+            ->fetchRows();
+        $userMail = $userRow[0]['email'];
+
+        $newsletterMail = $this->countEmails($userMail);
+
+        if ($newsletterMail == '0') {
+            $this->db()->insert('newsletter_mails')
+                ->values([
+                    'email' => $userMail,
+                    'selector' => $subscriber->getSelector(),
+                    'confirmCode' => $subscriber->getConfirmCode(),
+                    'doubleOptInDate' => $subscriber->getDoubleOptInDate(),
+                    'doubleOptInConfirmed' => $subscriber->getDoubleOptInConfirmed(),
+                ])
+                ->execute();
+        } else {
+            $this->db()->delete('newsletter_mails')
+                ->where(['email' => $userMail])
+                ->execute();
+        }
+    }
+}

--- a/application/modules/newsletter/models/Newsletter.php
+++ b/application/modules/newsletter/models/Newsletter.php
@@ -6,7 +6,9 @@
 
 namespace Modules\Newsletter\Models;
 
-class Newsletter extends \Ilch\Model
+use Ilch\Model;
+
+class Newsletter extends Model
 {
     /**
      * The id of the newsletter.
@@ -18,7 +20,7 @@ class Newsletter extends \Ilch\Model
     /**
      * The user of the newsletter.
      *
-     * @var integer
+     * @var int
      */
     protected $userId;
 
@@ -44,39 +46,11 @@ class Newsletter extends \Ilch\Model
     protected $text;
 
     /**
-     * The email of the newsletter.
-     *
-     * @var string
-     */
-    protected $email;
-
-    /**
-     * The selector of the subscription.
-     *
-     * @var string
-     */
-    protected $selector;
-
-    /**
-     * The confirmCode of the subscription.
-     *
-     * @var string
-     */
-    protected $confirmCode;
-
-    /**
-     * Newsletter user option
-     *
-     * @var string
-     */
-    protected $opt_newsletter;
-
-    /**
      * Gets the id of the newsletter.
      *
-     * @return int
+     * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -85,11 +59,11 @@ class Newsletter extends \Ilch\Model
      * Sets the id of the newsletter.
      *
      * @param int $id
-     * @return this
+     * @return Newsletter
      */
-    public function setId($id)
+    public function setId(int $id): Newsletter
     {
-        $this->id = (int)$id;
+        $this->id = $id;
 
         return $this;
     }
@@ -97,9 +71,9 @@ class Newsletter extends \Ilch\Model
     /**
      * Gets the user of the newsletter.
      *
-     * @return integer
+     * @return int
      */
-    public function getUserId()
+    public function getUserId(): int
     {
         return $this->userId;
     }
@@ -107,12 +81,12 @@ class Newsletter extends \Ilch\Model
     /**
      * Sets the user of the newsletter.
      *
-     * @param integer $userId
-     * @return this
+     * @param int $userId
+     * @return Newsletter
      */
-    public function setUserId($userId)
+    public function setUserId(int $userId): Newsletter
     {
-        $this->userId = (int)$userId;
+        $this->userId = $userId;
 
         return $this;
     }
@@ -120,9 +94,9 @@ class Newsletter extends \Ilch\Model
     /**
      * Gets the date of the newsletter.
      *
-     * @return DateTime
+     * @return string
      */
-    public function getDateCreated()
+    public function getDateCreated(): string
     {
         return $this->dateCreated;
     }
@@ -130,12 +104,12 @@ class Newsletter extends \Ilch\Model
     /**
      * Sets the date of the newsletter.
      *
-     * @param DateTime $date
-     * @return this
+     * @param string $dateCreated
+     * @return Newsletter
      */
-    public function setDateCreated($dateCreated)
+    public function setDateCreated(string $dateCreated): Newsletter
     {
-        $this->dateCreated = (string)$dateCreated;
+        $this->dateCreated = $dateCreated;
 
         return $this;
     }
@@ -145,7 +119,7 @@ class Newsletter extends \Ilch\Model
      *
      * @return string
      */
-    public function getSubject()
+    public function getSubject(): string
     {
         return $this->subject;
     }
@@ -154,11 +128,11 @@ class Newsletter extends \Ilch\Model
      * Sets the subject of the newsletter.
      *
      * @param string $subject
-     * @return this
+     * @return Newsletter
      */
-    public function setSubject($subject)
+    public function setSubject(string $subject): Newsletter
     {
-        $this->subject = (string)$subject;
+        $this->subject = $subject;
 
         return $this;
     }
@@ -168,7 +142,7 @@ class Newsletter extends \Ilch\Model
      *
      * @return string
      */
-    public function getText()
+    public function getText(): string
     {
         return $this->text;
     }
@@ -177,103 +151,11 @@ class Newsletter extends \Ilch\Model
      * Sets the text of the newsletter.
      *
      * @param string $text
-     * @return this
+     * @return Newsletter
      */
-    public function setText($text)
+    public function setText(string $text): Newsletter
     {
-        $this->text = (string)$text;
-
-        return $this;
-    }
-
-    /**
-     * Gets the email of the newsletter.
-     *
-     * @return string
-     */
-    public function getEmail()
-    {
-        return $this->email;
-    }
-
-    /**
-     * Sets the email of the newsletter.
-     *
-     * @param string $email
-     * @return this
-     */
-    public function setEmail($email)
-    {
-        $this->email = (string)$email;
-
-        return $this;
-    }
-
-    /**
-     * Gets the selector of the subscription.
-     *
-     * @return string
-     */
-    public function getSelector()
-    {
-        return $this->selector;
-    }
-
-    /**
-     * Sets the selector of the subscription.
-     *
-     * @param string $selector
-     * @return this
-     */
-    public function setSelector($selector)
-    {
-        $this->selector = (string)$selector;
-
-        return $this;
-    }
-
-    /**
-     * Gets the confirmCode of the subscription.
-     *
-     * @return string
-     */
-    public function getConfirmCode()
-    {
-        return $this->confirmCode;
-    }
-
-    /**
-     * Sets the confirmCode of the subscription.
-     *
-     * @param string $confirmCode
-     * @return this
-     */
-    public function setConfirmCode($confirmCode)
-    {
-        $this->confirmCode = (string)$confirmCode;
-
-        return $this;
-    }
-
-    /**
-     * Returns the opt_newsletter of the user.
-     *
-     * @return int
-     */
-    public function getNewsletter()
-    {
-        return $this->opt_newsletter;
-    }
-
-    /**
-     * Saves the opt_newsletter of the user.
-     *
-     * @param int $opt_newsletter
-     * @return User
-     */
-    public function setNewsletter($opt_newsletter)
-    {
-        $this->opt_newsletter = (string)$opt_newsletter;
+        $this->text = $text;
 
         return $this;
     }

--- a/application/modules/newsletter/models/Subscriber.php
+++ b/application/modules/newsletter/models/Subscriber.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Newsletter\Models;
+
+use Ilch\Model;
+
+class Subscriber extends Model
+{
+    /**
+     * The id of the subscriber.
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * The email of the subscriber.
+     *
+     * @var string
+     */
+    protected $email;
+
+    /**
+     * The selector of the subscription.
+     *
+     * @var string
+     */
+    protected $selector;
+
+    /**
+     * The confirmCode of the subscription.
+     *
+     * @var string
+     */
+    protected $confirmCode;
+
+    /**
+     * The date of the registration for the newsletter.
+     * Is used to find old unconfirmed double opt-in entries.
+     *
+     * @var string
+     */
+    protected $doubleOptInDate;
+
+    /**
+     * Status of the double opt-in for the newsletter.
+     *
+     * @var bool
+     */
+    protected $doubleOptInConfirmed;
+
+    /**
+     * Newsletter user option
+     *
+     * @var bool
+     */
+    protected $opt_newsletter;
+
+    /**
+     * Gets the id of the newsletter.
+     *
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Sets the id of the subscriber.
+     *
+     * @param int $id
+     * @return Subscriber
+     */
+    public function setId(int $id): Subscriber
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * Gets the email of the subscriber.
+     *
+     * @return string
+     */
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    /**
+     * Sets the email of the subscriber.
+     *
+     * @param string $email
+     * @return Subscriber
+     */
+    public function setEmail(string $email): Subscriber
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    /**
+     * Gets the selector of the subscription.
+     *
+     * @return string
+     */
+    public function getSelector(): string
+    {
+        return $this->selector;
+    }
+
+    /**
+     * Sets the selector of the subscription.
+     *
+     * @param string $selector
+     * @return Subscriber
+     */
+    public function setSelector(string $selector): Subscriber
+    {
+        $this->selector = $selector;
+        return $this;
+    }
+
+    /**
+     * Gets the confirmCode of the subscription.
+     *
+     * @return string
+     */
+    public function getConfirmCode(): string
+    {
+        return $this->confirmCode;
+    }
+
+    /**
+     * Sets the confirmCode of the subscription.
+     *
+     * @param string $confirmCode
+     * @return Subscriber
+     */
+    public function setConfirmCode(string $confirmCode): Subscriber
+    {
+        $this->confirmCode = $confirmCode;
+        return $this;
+    }
+
+    /**
+     * Get the date of the registration for the newsletter.
+     * Is used to find old unconfirmed double opt-in entries.
+     *
+     * @return string
+     */
+    public function getDoubleOptInDate(): string
+    {
+        return $this->doubleOptInDate;
+    }
+
+    /**
+     * Set the date of the registration for the newsletter.
+     * Is used to find old unconfirmed double opt-in entries.
+     *
+     * @param string $doubleOptInDate
+     * @return Subscriber
+     */
+    public function setDoubleOptInDate(string $doubleOptInDate): Subscriber
+    {
+        $this->doubleOptInDate = $doubleOptInDate;
+        return $this;
+    }
+
+    /**
+     * Get the status of the double opt-in for the newsletter.
+     *
+     * @return bool
+     */
+    public function getDoubleOptInConfirmed(): bool
+    {
+        return $this->doubleOptInConfirmed;
+    }
+
+    /**
+     * Set the status of the double opt-in for the newsletter.
+     *
+     * @param bool $doubleOptInConfirmed
+     * @return Subscriber
+     */
+    public function setDoubleOptInConfirmed(bool $doubleOptInConfirmed): Subscriber
+    {
+        $this->doubleOptInConfirmed = $doubleOptInConfirmed;
+        return $this;
+    }
+
+    /**
+     * Returns the opt_newsletter of the user.
+     *
+     * @return bool
+     */
+    public function getNewsletter(): bool
+    {
+        return $this->opt_newsletter;
+    }
+
+    /**
+     * Saves the opt_newsletter of the user.
+     *
+     * @param bool $opt_newsletter
+     * @return Subscriber
+     */
+    public function setNewsletter(bool $opt_newsletter): Subscriber
+    {
+        $this->opt_newsletter = $opt_newsletter;
+        return $this;
+    }
+}

--- a/application/modules/newsletter/translations/de.php
+++ b/application/modules/newsletter/translations/de.php
@@ -19,6 +19,7 @@ return [
     'email' => 'E-Mail',
     'noEmails' => 'Keine E-Mail Adressen vorhanden',
     'subscribeSuccess' => 'E-Mail wurde erfolgreich eingetragen.',
+    'doubleOptInConfirm' => 'Bitte bestätigen Sie die Registrierung in der an Ihnen versandten E-Mail.',
     'unsubscribeSuccess' => 'E-Mail wurde erfolgreich ausgetragen.',
     'subscribeFailed' => 'Eintragen fehlgeschlagen.',
     'noReplyMailFooter' => 'Bitte antworten Sie nicht auf diese E-Mail. Dieses Postfach wird nicht überwacht, deshalb werden Sie keine Antwort erhalten.',

--- a/application/modules/newsletter/translations/de.php
+++ b/application/modules/newsletter/translations/de.php
@@ -22,9 +22,10 @@ return [
     'unsubscribeSuccess' => 'E-Mail wurde erfolgreich ausgetragen.',
     'subscribeFailed' => 'Eintragen fehlgeschlagen.',
     'noReplyMailFooter' => 'Bitte antworten Sie nicht auf diese E-Mail. Dieses Postfach wird nicht überwacht, deshalb werden Sie keine Antwort erhalten.',
-    'mailUnreadable' => 'Falls Sie keine HTML E-Mail lesen können klicken Sie <a href="'.BASE_URL.'/index.php/newsletter/index/show/id/%s/email/%s">hier</a>.',
-    'mailUnsubscribe' => 'Wenn Sie keine Newsletter von uns erhalten wollen, können Sie diese jederzeit <a href="'.BASE_URL.'/index.php/newsletter/index/unsubscribe/selector/%s/code/%s">hier</a> abmelden.',
+    'mailUnreadable' => 'Falls Sie keine HTML E-Mail lesen können klicken Sie <a href="' . BASE_URL . '/index.php/newsletter/index/show/id/%s/email/%s">hier</a>.',
+    'mailUnsubscribe' => 'Wenn Sie keine Newsletter von uns erhalten wollen, können Sie diese jederzeit <a href="' . BASE_URL . '/index.php/newsletter/index/unsubscribe/selector/%s/code/%s">hier</a> abmelden.',
     'incompleteUnsubscribeUrl' => 'Die Adresse zum Austragen aus dem Newsletter ist ungültig.',
+    'incompleteDoubleOptInUrl' => 'Die Adresse zur Bestätigung der Registrierung für den Newsletter ist ungültig.',
 
     'userName' => 'Benutzername',
     'userEmail' => 'E-Mail Adresse',
@@ -33,6 +34,9 @@ return [
     'groupName' => 'Gruppenname',
     'groupAssignedUsers' => 'Anzahl "Zugeordnete Benutzer"',
     'receiver' => 'Empfänger',
+    'doubleOptIn' => 'Double-Opt-In',
+    'doubleOptInInfo' => 'Beim „Double-Opt-in“ (auch „Closed-Loop-Opt-in“ genannt) wird der Eintrag der Abonnentenliste durch einen zweiten Schritt bestätigt: Hierzu wird eine E-Mail mit Bitte um Bestätigung an die eingetragene E-Mail Adresse gesendet.',
+    'doubleOptInSuccess' => 'Sie haben die Registrierung für den Newsletter erfolgreich bestätigt.',
 
     'menuPanel' => 'User Panel',
     'menuSettings' => 'Einstellungen',

--- a/application/modules/newsletter/translations/en.php
+++ b/application/modules/newsletter/translations/en.php
@@ -22,9 +22,10 @@ return [
     'unsubscribeSuccess' => 'E-Mail has been successfully removed.',
     'subscribeFailed' => 'Subscribing failed.',
     'noReplyMailFooter' => 'Please do not reply to this email. This mailbox is not monitored, so you will not receive a response.',
-    'mailUnreadable' => 'If you can not read HTML E-Mail click <a href="'.BASE_URL.'/index.php/newsletter/index/show/id/%s/email/%s">here</a>.',
-    'mailUnsubscribe' => 'If you do not wish to receive newsletters from us, you can cancel these at any time <a href="'.BASE_URL.'/index.php/newsletter/index/unsubscribe/selector/%s/code/%s">here</a>.',
+    'mailUnreadable' => 'If you can not read HTML E-Mail click <a href="' . BASE_URL . '/index.php/newsletter/index/show/id/%s/email/%s">here</a>.',
+    'mailUnsubscribe' => 'If you do not wish to receive newsletters from us, you can cancel these at any time <a href="' . BASE_URL . '/index.php/newsletter/index/unsubscribe/selector/%s/code/%s">here</a>.',
     'incompleteUnsubscribeUrl' => 'The url to unsubscribe from the newsletter is invalid.',
+    'incompleteDoubleOptInUrl' => 'The url to confirm the subscription to the newsletter is invalid.',
 
     'userName' => 'Username',
     'userEmail' => 'Email address',
@@ -33,6 +34,9 @@ return [
     'groupName' => 'Groupname',
     'groupAssignedUsers' => 'Number "Assigned users"',
     'receiver' => 'Receiver',
+    'doubleOptIn' => 'Double-Opt-In',
+    'doubleOptInInfo' => 'A new subscriber asks to be subscribed to the mailing list, but unlike unconfirmed or single opt-in, a confirmation email is sent to verify it was really them.',
+    'doubleOptInSuccess' => 'You have successfully confirmed the subscription to this newsletter.',
 
     'menuPanel' => 'User Panel',
     'menuSettings' => 'Settings',

--- a/application/modules/newsletter/translations/en.php
+++ b/application/modules/newsletter/translations/en.php
@@ -19,6 +19,7 @@ return [
     'email' => 'E-Mail',
     'noEmails' => 'No e-mail addresses available',
     'subscribeSuccess' => 'E-Mail has been successfully added.',
+    'doubleOptInConfirm' => 'Please confirm your subscription in the email that got sent to you.',
     'unsubscribeSuccess' => 'E-Mail has been successfully removed.',
     'subscribeFailed' => 'Subscribing failed.',
     'noReplyMailFooter' => 'Please do not reply to this email. This mailbox is not monitored, so you will not receive a response.',

--- a/application/modules/newsletter/views/admin/index/index.php
+++ b/application/modules/newsletter/views/admin/index/index.php
@@ -1,4 +1,7 @@
-<?php $userMapper = $this->get('userMapper'); ?>
+<?php
+use Ilch\Date;
+
+$userMapper = $this->get('userMapper'); ?>
 
 <h1><?=$this->getTrans('manage') ?></h1>
 <?php if ($this->get('entries') != ''): ?>
@@ -25,13 +28,13 @@
                 <tbody>
                     <?php foreach ($this->get('entries') as $entry): ?>
                         <?php $user = $userMapper->getUserById($entry->getUserId()) ?>
-                        <?php $date = new \Ilch\Date($entry->getDateCreated()) ?>
+                        <?php $date = new Date($entry->getDateCreated()) ?>
                         <tr>
                             <td><?=$this->getDeleteCheckbox('check_entries', $entry->getId()) ?></td>
                             <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $entry->getId()]) ?></td>
                             <td><?=$date->format('d.m.Y H:i', true) ?></td>
-                            <td><a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>" target="_blank"><?=$this->escape($user->getName()) ?></a></td>
-                            <td><a href="<?=$this->getUrl('admin/newsletter/index/show/id/'.$entry->getId()) ?>"><?=$this->escape($entry->getSubject()) ?></a></td>
+                            <td><a href="<?=$this->getUrl('user/profil/index/user/' . $user->getId()) ?>" target="_blank"><?=$this->escape($user->getName()) ?></a></td>
+                            <td><a href="<?=$this->getUrl('admin/newsletter/index/show/id/' . $entry->getId()) ?>"><?=$this->escape($entry->getSubject()) ?></a></td>
                         </tr>
                     <?php endforeach; ?>
                 </tbody>

--- a/application/modules/newsletter/views/admin/index/show.php
+++ b/application/modules/newsletter/views/admin/index/show.php
@@ -1,8 +1,11 @@
 <?php
+
+use Ilch\Date;
+
 $newsletter = $this->get('newsletter');
 $userMapper = $this->get('userMapper');
 $user = $userMapper->getUserById($newsletter->getUserId());
-$date = new \Ilch\Date($newsletter->getDateCreated());
+$date = new Date($newsletter->getDateCreated());
 ?>
 
 <h1><?=$this->getTrans('show') ?></h1>
@@ -19,7 +22,7 @@ $date = new \Ilch\Date($newsletter->getDateCreated());
             <div class="col-lg-2">
                 <?=$this->getTrans('from') ?>:
             </div>
-            <div class="col-lg-4"><a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>" target="_blank"><?=$this->escape($user->getName()) ?></a></div>
+            <div class="col-lg-4"><a href="<?=$this->getUrl('user/profil/index/user/' . $user->getId()) ?>" target="_blank"><?=$this->escape($user->getName()) ?></a></div>
         </div>
         <div class="form-group">
             <div class="col-lg-2">

--- a/application/modules/newsletter/views/admin/settings/index.php
+++ b/application/modules/newsletter/views/admin/settings/index.php
@@ -1,0 +1,25 @@
+<?php
+
+/** @var \Ilch\View $this */
+?>
+<h1><?=$this->getTrans('settings') ?></h1>
+<form class="form-horizontal" method="POST">
+    <?=$this->getTokenField() ?>
+    <p><?=$this->getTrans('doubleOptInInfo') ?></p>
+    <div class="form-group">
+        <div class="col-lg-2 control-label">
+            <?=$this->getTrans('doubleOptIn') ?>:
+        </div>
+        <div class="col-lg-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="doubleOptIn-on" name="doubleOptIn" value="1" <?=($this->get('doubleOptIn') == '1') ? 'checked="checked"' : '' ?> />
+                <label for="doubleOptIn-on" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('on') ?></label>
+                <input type="radio" class="flipswitch-input" id="doubleOptIn-off" name="doubleOptIn" value="0" <?=($this->get('doubleOptIn') != '1') ? 'checked="checked"' : '' ?> />
+                <label for="doubleOptIn-off" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('off') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+        </div>
+    </div>
+
+    <?=$this->getSaveBar() ?>
+</form>

--- a/application/modules/newsletter/views/index/index.php
+++ b/application/modules/newsletter/views/index/index.php
@@ -4,7 +4,7 @@
     <div class="form-group <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
         <div class="col-lg-4">
             <div class="input-group">
-                <span class="input-group-addon" id="basic-addon1"><i class="fa fa-envelope"></i></span>
+                <span class="input-group-addon" id="basic-addon1"><i class="fa-solid fa-envelope"></i></span>
                 <input type="email"
                        class="form-control"
                        id="email"

--- a/application/modules/newsletter/views/index/settings.php
+++ b/application/modules/newsletter/views/index/settings.php
@@ -4,7 +4,7 @@
 
 <div class="row">
     <div class="col-lg-12 profile">
-        <?php include APPLICATION_PATH.'/modules/user/views/panel/navi.php'; ?>
+        <?php include APPLICATION_PATH . '/modules/user/views/panel/navi.php'; ?>
 
         <div class="profile-content active">
             <h1><?=$this->getTrans('setting') ?></h1>

--- a/application/modules/newsletter/views/index/show.php
+++ b/application/modules/newsletter/views/index/show.php
@@ -1,6 +1,9 @@
 <?php
+
+use Ilch\Date;
+
 $newsletter = $this->get('newsletter');
-$date = new \Ilch\Date($newsletter->getDateCreated());
+$date = new Date($newsletter->getDateCreated());
 ?>
 
 <p class="small text-muted"><?=$date->format('l, d. F Y', true) ?></p>


### PR DESCRIPTION
# Description
- Added support for double opt in (enabled by default).
- Splitted up "newsletter" model and "newsletter" mapper by adding a "subscriber" model and mapper.
- Changed setter and getter of Newsletter (now in subscriber mapper) to Boolean.
- #635
- Code style changes

Fixes #514

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
