### PR TITLE
BS5: Various smaller changes

### DIFF
--- a/application/modules/admin/layouts/index.php
+++ b/application/modules/admin/layouts/index.php
@@ -282,7 +282,7 @@ $accesses = $this->get('accesses');
                         <div class="input-group">
                             <input type="text" class="form-control" placeholder="<?=$this->getTrans('search') ?>">
                             <span class="input-group-btn">
-                                <button type="button" class="btn btn-default"><?=$this->getTrans('go') ?></button>
+                                <button type="button" class="btn btn-secondary"><?=$this->getTrans('go') ?></button>
                             </span>
                         </div>
                     </div>

--- a/application/modules/admin/layouts/index.php
+++ b/application/modules/admin/layouts/index.php
@@ -96,7 +96,7 @@ $accesses = $this->get('accesses');
                 <a class="float-start <?=($this->getRequest()->getModuleName() === 'admin' && $this->getRequest()->getControllerName() === 'index') ? 'active' : ''?> home" href="<?=$this->getUrl(['module' => 'admin', 'controller' => 'index', 'action' => 'index']) ?>">
                     <i class="fa-solid fa-house"></i>
                 </a>
-                <button class="float-end" type="button" class="float-end navbar-toggle" data-bs-toggle="collapse" data-bs-target="#rightbar">
+                <button class="float-end" type="button" class="float-end navbar-toggler" data-bs-toggle="collapse" data-bs-target="#rightbar">
                     <i class="fa-solid fa-table-cells"></i>
                 </button>
             </div>

--- a/application/modules/admin/layouts/maintenance.php
+++ b/application/modules/admin/layouts/maintenance.php
@@ -88,9 +88,8 @@ $date = new \Ilch\Date();
                     </div>
                 </div>
                 <b><?=$translator->trans('maintenanceStatus') ?></b>
-                <div class="progress progress-striped">
-                    <div class="progress-bar progress-bar-success active"
-                        role="progressbar"
+                <div class="progress" role="progressbar">
+                    <div class="progress-bar bg-success progress-bar-striped progress-bar-animated"
                         aria-valuenow="<?=$config->get('maintenance_status') ?>"
                         aria-valuemin="0"
                         aria-valuemax="100"

--- a/application/modules/admin/static/css/admin.css
+++ b/application/modules/admin/static/css/admin.css
@@ -261,7 +261,7 @@ aside nav ul .active > a {
     border-radius: 0;
     margin: 4px;
 }
-.navbar  .leftbar .navbar-toggle {
+.navbar  .leftbar .navbar-toggler {
     margin-right: 14px;
 }
 #toggleLeftMenu i {

--- a/application/modules/admin/static/css/admin.css
+++ b/application/modules/admin/static/css/admin.css
@@ -462,7 +462,7 @@ aside {
     bottom: 0;
     top: 40px;
 }
-.dropdown-menu .divider {
+.dropdown-menu .dropdown-divider {
     background-color: #ccc;
 }
 #main {

--- a/application/modules/admin/static/css/extsearch.css
+++ b/application/modules/admin/static/css/extsearch.css
@@ -26,7 +26,7 @@
     cursor: pointer;
 }
 
-#layouts .divider {
+#layouts .dropdown-divider {
     height: 1px;
     margin: 11px -15px;
     background-color: #ccc;

--- a/application/modules/admin/views/admin/infos/logs.php
+++ b/application/modules/admin/views/admin/infos/logs.php
@@ -99,7 +99,7 @@ $userCache = [];
 <div class="content_savebox">
     <form class="form-horizontal" method="POST">
         <?=$this->getTokenField() ?>
-        <button type="submit" name="clearLog" class="btn btn-default" value="1"><?=$this->getTrans('clearLog') ?></button>
+        <button type="submit" name="clearLog" class="btn btn-secondary" value="1"><?=$this->getTrans('clearLog') ?></button>
     </form>
 </div>
 

--- a/application/modules/admin/views/admin/layouts/show.php
+++ b/application/modules/admin/views/admin/layouts/show.php
@@ -38,11 +38,11 @@ foreach ($layouts as $layout): ?>
                     <?php if(count($layout->thumbs) > 1): ?>
                         <a class="left carousel-control" href="#layout-search-carousel" role="button" data-slide="prev">
                             <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                            <span class="sr-only">Previous</span>
+                            <span class="visually-hidden">Previous</span>
                         </a>
                         <a class="right carousel-control" href="#layout-search-carousel" role="button" data-slide="next">
                             <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                            <span class="sr-only">Next</span>
+                            <span class="visually-hidden">Next</span>
                         </a>
                     <?php endif; ?>
                 </div>

--- a/application/modules/admin/views/admin/modules/show.php
+++ b/application/modules/admin/views/admin/modules/show.php
@@ -89,11 +89,11 @@ foreach ($modules as $module): ?>
                     <?php if(count($module->thumbs) > 1): ?>
                         <a class="left carousel-control" href="#module-search-carousel" role="button" data-slide="prev">
                             <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                            <span class="sr-only">Previous</span>
+                            <span class="visually-hidden">Previous</span>
                         </a>
                         <a class="right carousel-control" href="#module-search-carousel" role="button" data-slide="next">
                             <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                            <span class="sr-only">Next</span>
+                            <span class="visually-hidden">Next</span>
                         </a>
                     <?php endif; ?>
                 </div>

--- a/application/modules/article/views/admin/cats/index.php
+++ b/application/modules/article/views/admin/cats/index.php
@@ -49,7 +49,7 @@
                 <li><a href="#" data-hiddenkey="delete" class="dropdown-item"><?=$this->getTrans('delete') ?></a></li>
             </ul>
         </div>
-        <button type="submit" class="save_button btn btn-default" name="saveCats" value="save">
+        <button type="submit" class="save_button btn btn-secondary" name="saveCats" value="save">
             <?=$this->getTrans('saveButton') ?>
         </button>
     </div>

--- a/application/modules/article/views/admin/index/treat.php
+++ b/application/modules/article/views/admin/index/treat.php
@@ -209,7 +209,7 @@ if ($this->get('article')) {
             <?=$this->getTrans('preview') ?>:
         </label>
         <div class="col-xl-4">
-            <a id="preview" class="btn btn-default"><?=$this->getTrans('show') ?></a>
+            <a id="preview" class="btn btn-secondary"><?=$this->getTrans('show') ?></a>
         </div>
     </div>
     <h1><?=$this->getTrans('seo') ?></h1>

--- a/application/modules/article/views/index/show.php
+++ b/application/modules/article/views/index/show.php
@@ -57,11 +57,11 @@
             $countOfVotes = count($votes) - 1;
             ?>
             <?php if ($this->getUser() && in_array($this->getUser()->getId(), $votes) == false) : ?>
-                <a class="btn btn-sm btn-default btn-hover-success" href="<?=$this->getUrl(['id' => $article->getId(), 'action' => 'vote', 'from' => 'show']) ?>" title="<?=$this->getTrans('iLike') ?>">
+                <a class="btn btn-sm btn-secondary btn-hover-success" href="<?=$this->getUrl(['id' => $article->getId(), 'action' => 'vote', 'from' => 'show']) ?>" title="<?=$this->getTrans('iLike') ?>">
                     <i class="fa fa-thumbs-up"></i> <?=$countOfVotes ?>
                 </a>
             <?php else: ?>
-                <button class="btn btn-sm btn-default btn-success">
+                <button class="btn btn-sm btn-secondary btn-success">
                     <i class="fa fa-thumbs-up"></i> <?=$countOfVotes ?>
                 </button>
             <?php endif; ?>

--- a/application/modules/bbcodeconvert/views/admin/index/convert.php
+++ b/application/modules/bbcodeconvert/views/admin/index/convert.php
@@ -29,7 +29,7 @@
 
 <p id="result"><?=($this->get('workDone')) ? $this->getTrans('workDone') : '' ?></p>
 <?php if (!$this->get('workDone')) : ?>
-    <button id="cancelConversion" class="btn btn-default" onclick="cancel(this)"><?=$this->getTrans('cancel') ?></button>
+    <button id="cancelConversion" class="btn btn-secondary" onclick="cancel(this)"><?=$this->getTrans('cancel') ?></button>
 <?php endif; ?>
 
 <script>

--- a/application/modules/birthday/views/index/index.php
+++ b/application/modules/birthday/views/index/index.php
@@ -19,7 +19,7 @@ $date = new \Ilch\Date();
                     <div class="row">
                         <div class="col-xl-2 confetti">
                             <a href="<?=$this->getUrl('user/profil/index/user/' . $birthdaylist->getId()) ?>">
-                                <img class="img-thumbnail center-block" style="margin-bottom: 0px;" src="<?=$this->getStaticUrl() . '../' . $this->escape($birthdaylist->getAvatar()) ?>" title="<?=$this->escape($birthdaylist->getName()) ?>" width="69" height="69">
+                                <img class="img-thumbnail mx-auto" style="margin-bottom: 0px;" src="<?=$this->getStaticUrl() . '../' . $this->escape($birthdaylist->getAvatar()) ?>" title="<?=$this->escape($birthdaylist->getName()) ?>" width="69" height="69">
                             </a>
                         </div>
                         <div class="col-xl-10">

--- a/application/modules/media/views/admin/index/index.php
+++ b/application/modules/media/views/admin/index/index.php
@@ -152,7 +152,7 @@
                     <div class="modal-body">
                         <ul class="list-unstyled">
                             <?php foreach ($this->get('catnames') as $name): ?>
-                                <li><button name="assignedCategory" class="btn btn-default list-group-item" type="submit" value="<?=$name->getId() ?>"><?=$this->escape($name->getCatName()) ?></button></li>
+                                <li><button name="assignedCategory" class="btn btn-secondary list-group-item" type="submit" value="<?=$name->getId() ?>"><?=$this->escape($name->getCatName()) ?></button></li>
                             <?php endforeach; ?>
                         </ul>
                     </div>

--- a/application/modules/shop/views/index/cart.php
+++ b/application/modules/shop/views/index/cart.php
@@ -124,7 +124,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                             <input type="hidden" name="code" value="<?=$this->escape($itemCode); ?>" />
                             <input type="hidden" name="name" value="<?=$this->escape($itemName); ?>" />
                             <input type="hidden" name="action" value="remove" />
-                            <button type="submit" class="btn btn-sm btn-default remove"><i class="fa-regular fa-trash-can"></i></button>
+                            <button type="submit" class="btn btn-sm btn-secondary remove"><i class="fa-regular fa-trash-can"></i></button>
                         </form>
                     </td>
                     <td data-label="<?=$this->getTrans('productName') ?>">

--- a/application/modules/shop/views/index/order.php
+++ b/application/modules/shop/views/index/order.php
@@ -503,7 +503,7 @@ if (!empty($_SESSION['shopping_cart'])) {
 } else { ?>
     <?=$this->getTrans('noProductInCart') ?>
     <div class="row space20"></div>
-    <a href="<?=$this->getUrl('shop/index') ?>#shopAnker" class="btn btn-default">
+    <a href="<?=$this->getUrl('shop/index') ?>#shopAnker" class="btn btn-secondary">
         <i class="fa-solid fa-backward"></i> <?=$this->getTrans('back') ?>
     </a>
 <?php } ?>

--- a/application/modules/shop/views/index/success.php
+++ b/application/modules/shop/views/index/success.php
@@ -13,6 +13,6 @@ unset($_SESSION['shopping_cart']); ?>
 </div>
 
 <div class="row space20"></div>
-<a href="<?=$this->getUrl('shop/index') ?>#shopAnker" class="btn btn-default">
+<a href="<?=$this->getUrl('shop/index') ?>#shopAnker" class="btn btn-secondary">
     <i class="fa-solid fa-backward"></i> <?=$this->getTrans('back') ?>
 </a>

--- a/application/modules/shoutbox/boxes/views/shoutbox.php
+++ b/application/modules/shoutbox/boxes/views/shoutbox.php
@@ -162,7 +162,7 @@ $config = \Ilch\Registry::get('config');
                         </div>
                         <?php if (count($this->get('shoutbox')) == $config->get('shoutbox_limit')) : ?>
                             <div class="float-end">
-                                <a href="<?=$this->getUrl('shoutbox/index/index/') ?>" class="btn btn-default"><?=$this->getTrans('archive') ?></a>
+                                <a href="<?=$this->getUrl('shoutbox/index/index/') ?>" class="btn btn-secondary"><?=$this->getTrans('archive') ?></a>
                             </div>
                         <?php endif; ?>
                     </div>

--- a/application/modules/teams/views/admin/index/index.php
+++ b/application/modules/teams/views/admin/index/index.php
@@ -61,7 +61,7 @@ $teams = $this->get('teams');
                     <li><a class="dropdoen-item" href="#" data-hiddenkey="delete"><?=$this->getTrans('delete') ?></a></li>
                 </ul>
             </div>
-            <button type="submit" class="save_button btn btn-default" name="saveTeams" value="save">
+            <button type="submit" class="save_button btn btn-secondary" name="saveTeams" value="save">
                 <?=$this->getTrans('saveButton') ?>
             </button>
         </div>

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -236,10 +236,8 @@ $iconArray = [
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="symbolDialogTitle"><?=$this->getTrans('chooseIcon') ?></h5>
-                <button type="button" class="btn" id="noIcon" data-bs-dismiss="modal"><?=$this->getTrans('noIcon') ?></button>
-                <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <div class="col-6"><button type="button" class="btn btn-outline-secondary" id="noIcon" data-bs-dismiss="modal"><?=$this->getTrans('noIcon') ?></button></div>
             </div>
             <div class="modal-body">
             </div>

--- a/application/modules/user/views/login/index.php
+++ b/application/modules/user/views/login/index.php
@@ -94,8 +94,8 @@
         </p>
     <?php endif; ?>
 <?php else: ?>
-    <div class="center-block"><p><h4 class="text-center"><?=$this->getTrans('alreadyLoggedIn') ?></h4></p></div>
-    <div class="row text-center">
+    <div class="mx-auto"><h4 class="text-center"><?=$this->getTrans('alreadyLoggedIn') ?></h4></div>
+    <div class="text-center">
         <a class="btn btn-outline-secondary" href="<?=$this->getUrl() ?>"><?=$this->getTrans('back') ?></a>
     </div>
 <?php endif; ?>

--- a/application/modules/user/views/panel/providers.php
+++ b/application/modules/user/views/panel/providers.php
@@ -29,7 +29,7 @@
                                 ]) ?>"
                             >
                                 <?=$this->getTokenField() ?>
-                                <button type="submit" class="btn btn-xs btn-default">
+                                <button type="submit" class="btn btn-sm btn-secondary">
                                     <i class="fa-solid fa-xmark fa-fw text-danger"></i> <?=$this->getTrans('providers.unlink') ?>
                                 </button>
                             </form>
@@ -39,7 +39,7 @@
                             <?=$this->getTrans('providers.notLinked') ?>
                         </li>
                         <li class="list-group-item">
-                            <a class="btn btn-xs btn-default" href="<?=$this->getUrl([
+                            <a class="btn btn-sm btn-secondary" href="<?=$this->getUrl([
                                 'module' => $provider->getModule(),
                                 'controller' => $provider->getAuthController(),
                                 'action' => $provider->getAuthAction()


### PR DESCRIPTION
# Description
- Renamed .close to .btn-close
- Renamed .sr-only to .visually-hidden
- Replaced center-block with mx-auto
- Replaced navbar-toggle with navbar-toggler
- bg-success and progress-bar-animated
- Renamed .divider to .dropdown-divider.
- Replaced btn-default with btn-secondary.
- Replaced btn-xs with btn-sm.

See
https://www.ilch.de/forum-showposts-58597-p5.html#408094
