### PR TITLE
CKEditor 4: Set versionCheck to false

### DIFF
--- a/static/js/ckeditor/config_ilch_html.js
+++ b/static/js/ckeditor/config_ilch_html.js
@@ -17,6 +17,7 @@ CKEDITOR.editorConfig = function( config ) {
         config.extraPlugins = "justify,font,colorbutton,colordialog,codesnippet,tableresize,emojione,ilchmedia";
     }
 
+    config.versionCheck = false;
     config.protectedSource.push(/<i[^>]*><\/i>/g);
     config.protectedSource.push(/<\?[\s\S]*?\?>/g);
     config.toolbar = 'ilch_html';

--- a/static/js/ckeditor/config_ilch_html_frontend.js
+++ b/static/js/ckeditor/config_ilch_html_frontend.js
@@ -11,6 +11,7 @@ CKEDITOR.plugins.addExternal('ilchyoutubehtml', basePath+'application/modules/me
 
 CKEDITOR.editorConfig = function( config ) {
     config.extraPlugins = "justify,font,colorbutton,colordialog,codesnippet,tableresize,emojione,ilchyoutubehtml";
+    config.versionCheck = false;
     config.protectedSource.push(/<i[^>]*><\/i>/g);
     config.protectedSource.push(/<\?[\s\S]*?\?>/g);
     config.toolbarGroups = [


### PR DESCRIPTION
# Description
Disables the version check of CKEditor 4.22.1 to prevent the "not secure" warning from popping up on every load of the CKEditor.
This is obviously not a long term solution. The switch to CKEditor 5 (together with Bootstrap 5) is currently in progress and planned to be done asap, but still requires some time. With the current configuration of CKEditor 4 and what we distribute of the CKEditor 4.22.1 as part of Ilch we are likely not directly affected by the security issues fixed with CKEditor 4.24.0 LTS.

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
