### PR TITLE
CKEditor 5: Media embed and HTML Purifier

### DIFF
--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -7,6 +7,7 @@
 
 namespace Ilch\Design;
 
+use Ilch\HTMLPurifier\EmbedUrlDef;
 use Ilch\Layout\Helper\GetMedia;
 use Ilch\Request;
 use Ilch\Router;
@@ -170,12 +171,27 @@ abstract class Base
         $this->purifierConfig->set('Filter.YouTube', true);
         $this->purifierConfig->set('HTML.SafeIframe', true);
         $this->purifierConfig->set('URI.AllowedSchemes', ['data' => true, 'src' => true, 'http' => true, 'https' => true]);
-        $this->purifierConfig->set('URI.SafeIframeRegexp', '%^https://(www.youtube.com/embed/|www.youtube-nocookie.com/embed/|player.vimeo.com/video/|)%');
+        $this->purifierConfig->set('URI.SafeIframeRegexp', '%^https://(www.youtube.com/embed/|www.youtube-nocookie.com/embed/|player.vimeo.com/video/|open.spotify.com/embed/|www.dailymotion.com/embed/video/)%');
         $this->purifierConfig->set('Attr.AllowedFrameTargets', '_blank, _self, _target, _parent');
         $this->purifierConfig->set('Attr.EnableID', true);
         $this->purifierConfig->set('AutoFormat.Linkify', true);
         $def = $this->purifierConfig->getHTMLDefinition(true);
         $def->addAttribute('iframe', 'allowfullscreen', 'Bool');
+        // Allow explicit attributes used and more for Media embed of CKEditor 5.
+        // https://github.com/ckeditor/ckeditor5/blob/v41.1.0/packages/ckeditor5-media-embed/src/mediaembedediting.ts
+        // https://ckeditor.com/docs/ckeditor5/latest/features/media-embed.html#including-previews-in-data
+        $def->addAttribute('iframe', 'allow', 'Enum#autoplay; encrypted-media');
+        $def->addAttribute('iframe', 'style', 'Enum#position: absolute; width: 100%; height: 100%; top: 0; left: 0;');
+        $def->addAttribute('div', 'style', 'Enum#position: relative; padding-bottom: 100%; height: 0; padding-bottom: 56.2493%;');
+        $def->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
+        $def->addElement('figcaption', 'Inline', 'Flow', 'Common');
+        $def->addAttribute('div', 'data-oembed-url', new EmbedUrlDef());
+        $def->addElement('oembed', 'Block', 'Inline', 'Common');
+        $def->addAttribute('oembed', 'url', new EmbedUrlDef());
+
+        // https://github.com/ezyang/htmlpurifier/issues/152#issuecomment-414192516
+        $def->addAttribute('a', 'download', 'URI');
+
         $def->addElement('video', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', array(
             'autoplay' => 'Bool',
             'src' => 'URI',

--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -167,7 +167,9 @@ abstract class Base
         }
         $this->baseUrl = $baseUrl;
 
+        // HTML Purifier configuration
         $this->purifierConfig = \HTMLPurifier_Config::createDefault();
+        // $this->purifierConfig->set('Cache.DefinitionImpl', null);
         $this->purifierConfig->set('Filter.YouTube', true);
         $this->purifierConfig->set('HTML.SafeIframe', true);
         $this->purifierConfig->set('URI.AllowedSchemes', ['data' => true, 'src' => true, 'http' => true, 'https' => true]);
@@ -175,21 +177,21 @@ abstract class Base
         $this->purifierConfig->set('Attr.AllowedFrameTargets', '_blank, _self, _target, _parent');
         $this->purifierConfig->set('Attr.EnableID', true);
         $this->purifierConfig->set('AutoFormat.Linkify', true);
+        // Had to be enabled to allow the output of the media embed plugin of CKEditor 5.
+        $this->purifierConfig->set('CSS.Trusted', true);
         $def = $this->purifierConfig->getHTMLDefinition(true);
         $def->addAttribute('iframe', 'allowfullscreen', 'Bool');
-        // Allow explicit attributes used and more for Media embed of CKEditor 5.
+        // Settings to allow (most of) the output of the media embed plugin of CKEditor 5.
         // https://github.com/ckeditor/ckeditor5/blob/v41.1.0/packages/ckeditor5-media-embed/src/mediaembedediting.ts
         // https://ckeditor.com/docs/ckeditor5/latest/features/media-embed.html#including-previews-in-data
-        $def->addAttribute('iframe', 'allow', 'Enum#autoplay; encrypted-media');
-        $def->addAttribute('iframe', 'style', 'Enum#position: absolute; width: 100%; height: 100%; top: 0; left: 0;');
-        $def->addAttribute('div', 'style', 'Enum#position: relative; padding-bottom: 100%; height: 0; padding-bottom: 56.2493%;');
-        $def->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
-        $def->addElement('figcaption', 'Inline', 'Flow', 'Common');
         $def->addAttribute('div', 'data-oembed-url', new EmbedUrlDef());
         $def->addElement('oembed', 'Block', 'Inline', 'Common');
         $def->addAttribute('oembed', 'url', new EmbedUrlDef());
 
-        // https://github.com/ezyang/htmlpurifier/issues/152#issuecomment-414192516
+        $def->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
+        $def->addElement('figcaption', 'Inline', 'Flow', 'Common');
+
+        // https://github.com/ezyang/htmlpurifier/issues/152
         $def->addAttribute('a', 'download', 'URI');
 
         $def->addElement('video', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', array(

--- a/application/libraries/Ilch/HTMLPurifier/EmbedUrlDef.php
+++ b/application/libraries/Ilch/HTMLPurifier/EmbedUrlDef.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Ilch\HTMLPurifier;
+
+use HTMLPurifier_AttrDef_URI;
+
+class EmbedUrlDef extends HTMLPurifier_AttrDef_URI
+{
+    public function validate($uri, $config, $context)
+    {
+        $regexp = $config->get('URI.SafeIframeRegexp');
+        if ($regexp !== null) {
+            if (!preg_match($regexp, $uri)) {
+                return false;
+            }
+        }
+
+        return parent::validate($uri, $config, $context);
+    }
+}

--- a/static/js/ilch.js
+++ b/static/js/ilch.js
@@ -71,6 +71,9 @@ $(document).ready(function(){
                         'tableCellProperties',
                         'tableProperties'
                     ]
+                },
+                mediaEmbed: {
+                    previewsInData: true
                 }
             };
         } else if(toolbar === 'ilch_html_frontend') {
@@ -141,6 +144,9 @@ $(document).ready(function(){
                         'tableCellProperties',
                         'tableProperties'
                     ]
+                },
+                mediaEmbed: {
+                    previewsInData: true
                 }
             };
         };


### PR DESCRIPTION
# Description
- Change configuration of media embed and HTML Purifier.

![grafik](https://github.com/IlchCMS/Ilch-2.0/assets/18415497/da22f2cb-bb2f-4c10-be79-082276a089b8)
![grafik](https://github.com/IlchCMS/Ilch-2.0/assets/18415497/4b9cc54f-736b-41e3-a08f-94e73b1290ab)

So sieht es aktuell im CKEditor 4.22.1 (Frontend) aus:
![grafik](https://github.com/IlchCMS/Ilch-2.0/assets/18415497/feb5cd52-26dd-4324-b364-2a23bc95100e)

Im Backend haben wir ja das "ilchmedia"-Plugin was noch paar mehr Funktionen hat.
![grafik](https://github.com/IlchCMS/Ilch-2.0/assets/18415497/1603c400-1079-4b34-b4b6-62827e0a14f7)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
