### PR TITLE
BS5: Replace removed hidden class

### DIFF
--- a/application/modules/admin/views/admin/settings/index.php
+++ b/application/modules/admin/views/admin/settings/index.php
@@ -75,7 +75,7 @@
             </div>
         </div>
     </div>
-    <div id="contentLanguage" class="row mb-3 <?php if ($this->get('multilingualAcp') != '1') { echo 'hidden'; } ?>">
+    <div id="contentLanguage" class="row mb-3" <?=($this->get('multilingualAcp') != '1') ? 'hidden' : ''; } ?>>
         <label for="languageInput" class="col-xl-2 control-label">
             <?=$this->getTrans('contentLanguage') ?>:
         </label>
@@ -303,21 +303,21 @@
 <script>
 $('[name="multilingualAcp"]').click(function () {
     if ($(this).val() == "1") {
-        $('#contentLanguage').removeClass('hidden');
+        $('#contentLanguage').removeAttr('hidden');
     } else {
-        $('#contentLanguage').addClass('hidden');
+        $('#contentLanguage').attr('hidden', '');
     }
 });
 
 $('[name="captcha"]').change(function () {
     if ($(this).val() == "2" || $(this).val() == "3") {
-        $('#captcha_apikey').removeClass('hidden');
-        $('#captcha_seckey').removeClass('hidden');
-        $('#captcha_apikey_info').removeClass('hidden');
+        $('#captcha_apikey').removeAttr('hidden');
+        $('#captcha_seckey').removeAttr('hidden');
+        $('#captcha_apikey_info').removeAttr('hidden');
     } else {
-        $('#captcha_apikey').addClass('hidden');
-        $('#captcha_seckey').addClass('hidden');
-        $('#captcha_apikey_info').addClass('hidden');
+        $('#captcha_apikey').attr('hidden', '');
+        $('#captcha_seckey').attr('hidden', '');
+        $('#captcha_apikey_info').attr('hidden', '');
     }
 });
 $('[name="captcha"]').change();

--- a/application/modules/admin/views/admin/settings/mail.php
+++ b/application/modules/admin/views/admin/settings/mail.php
@@ -19,7 +19,7 @@
             </div>
         </div>
     </div>
-    <div id="smtpSettings" class="smtpSettings <?=($this->get('smtp_mode') !== '1') ? 'hidden' : '' ?>">
+    <div id="smtpSettings" class="smtpSettings" <?=($this->get('smtp_mode') !== '1') ? 'hidden' : '' ?>>
         <div class="row mb-3">
             <label for="smtp_server" class="col-xl-2 control-label">
                 <?=$this->getTrans('smtp_server') ?>:
@@ -110,10 +110,10 @@
 <script>
     $('[name="smtp_mode"]').click(function () {
         if ($(this).val() == "1") {
-            $('#smtpSettings').removeClass('hidden');
+            $('#smtpSettings').removeAttr('hidden');
             $('#smtpModeDescription').html("<?=$this->getTrans('smtpModeEnabledDescription') ?>");
         } else {
-            $('#smtpSettings').addClass('hidden');
+            $('#smtpSettings').attr('hidden', '');
             $('#smtpModeDescription').html("<?=$this->getTrans('smtpModeDisabledDescription') ?>");
         }
     });

--- a/application/modules/away/views/admin/settings/index.php
+++ b/application/modules/away/views/admin/settings/index.php
@@ -29,7 +29,7 @@
             </div>
         </div>
     </div>
-    <div id="notifyGroupsDiv" class="row mb-3 <?=$this->validation()->hasError('notifyGroups') ? 'has-error' : '' ?> <?=($this->get('userNotification') !== '1') ? 'hidden' : '' ?>">
+    <div id="notifyGroupsDiv" class="row mb-3 <?=$this->validation()->hasError('notifyGroups') ? 'has-error' : '' ?>" <?=($this->get('userNotification') !== '1') ? 'hidden' : '' ?>>
         <label for="notifyGroups" class="col-xl-2 control-label">
             <?=$this->getTrans('notifyGroups') ?>
         </label>
@@ -49,9 +49,9 @@
 
     $('[name="userNotification"]').click(function () {
         if ($(this).val() == "1") {
-            $('#notifyGroupsDiv').removeClass('hidden');
+            $('#notifyGroupsDiv').removeAttr('hidden');
         } else {
-            $('#notifyGroupsDiv').addClass('hidden');
+            $('#notifyGroupsDiv').attr('hidden', '');
         }
     });
 </script>

--- a/application/modules/partner/views/admin/settings/index.php
+++ b/application/modules/partner/views/admin/settings/index.php
@@ -24,7 +24,7 @@ if ($this->validation()->hasErrors()) {
             </div>
         </div>
     </div>
-    <div id="contentHeight" class="<?=(!$slider) ? 'hidden' : '' ?>">
+    <div id="contentHeight" <?=(!$slider) ? 'hidden' : '' ?>>
         <div class="row mb-3 <?=$this->validation()->hasError('boxSliderMode') ? 'has-error' : '' ?>">
             <label for="boxSliderMode" class="col-xl-2 control-label">
                 <?=$this->getTrans('boxSliderMode') ?>:
@@ -70,9 +70,9 @@ if ($this->validation()->hasErrors()) {
 <script>
 $('[name="slider"]').click(function () {
     if ($(this).val() == "1") {
-        $('#contentHeight').removeClass('hidden');
+        $('#contentHeight').removeAttr('hidden');
     } else {
-        $('#contentHeight').addClass('hidden');
+        $('#contentHeight').attr('hidden', '');
     }
 });
 </script>

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -79,7 +79,7 @@ $iconArray = [
     </div>
 
     <!-- icon selection -->
-    <div class="row mb-3 <?=($profileField->getType() == 2) ? '' : 'hidden' ?>" id="profileFieldIcons">
+    <div class="row mb-3" id="profileFieldIcons" <?=($profileField->getType() == 2) ? '' : 'hidden' ?>>
         <?php $icon = '';
         if ($profileField->getType() == 2) {
             $icon = ($profileField->getIcon() !== '') ? $profileField->getIcon() : $this->get('post')['symbol'];
@@ -124,7 +124,7 @@ $iconArray = [
     </div>
 
     <!-- icon addition -->
-    <div class="row mb-3 <?=($profileField->getType() == 2) ? '' : 'hidden' ?>" id="profileFieldAddition">
+    <div class="row mb-3" id="profileFieldAddition" <?=($profileField->getType() == 2) ? '' : 'hidden' ?>>
         <label for="profileFieldLinkAddition" class="col-xl-2 control-label">
             <?=$this->getTrans('profileFieldLinkAddition') ?>
         </label>
@@ -186,7 +186,7 @@ $iconArray = [
 
     <!-- multi options -->
     <?php $multiArr = [3, 4, 5]; ?>
-    <div class="profileFieldsMulti <?=(in_array($profileField->getType(), $multiArr)) ? '' : 'hidden' ?>">
+    <div class="profileFieldsMulti" <?=(in_array($profileField->getType(), $multiArr)) ? '' : 'hidden' ?>>
         <?php if ($profileField->getOptions()) : ?>
             <?php $options = json_decode($profileField->getOptions(), true); ?>
             <div class="mb-3">
@@ -258,16 +258,16 @@ $('[name="profileField[type]"]').click(function () {
     const keysArr = ['3', '4', '5'];
     const thisKey = $(this).val();
     if (thisKey == "2") {
-        $('#profileFieldIcons, #profileFieldAddition').removeClass('hidden');
+        $('#profileFieldIcons, #profileFieldAddition').removeAttr('hidden');
     } else {
-        $('#profileFieldIcons, #profileFieldAddition').addClass('hidden');
+        $('#profileFieldIcons, #profileFieldAddition').attr('hidden', '');
     }
     if (jQuery.inArray(thisKey, keysArr) !== -1) {
-        $('.profileFieldsSingle').addClass('hidden');
-        $('.profileFieldsMulti').removeClass('hidden');
+        $('.profileFieldsSingle').attr('hidden', '');
+        $('.profileFieldsMulti').removeAttr('hidden');
     } else {
-        $('.profileFieldsSingle').removeClass('hidden');
-        $('.profileFieldsMulti').addClass('hidden');
+        $('.profileFieldsSingle').removeAttr('hidden');
+        $('.profileFieldsMulti').attr('hidden', '');
     }
 });
 

--- a/application/modules/user/views/admin/settings/index.php
+++ b/application/modules/user/views/admin/settings/index.php
@@ -15,9 +15,7 @@
             </div>
         </div>
     </div>
-    <div id="registRules" <?php if ($this->get('regist_accept') != '1') {
-    echo 'class="hidden"';
-} ?>>
+    <div id="registRules" <?=($this->get('regist_accept') != '1') ? 'hidden' : ''; } ?>>
         <div class="row mb-3">
             <div class="col-xl-2 control-label">
                 <?=$this->getTrans('confirmRegistrationEmail') ?>:
@@ -33,7 +31,7 @@
             </div>
         </div>
     </div>
-    <div id="registSetfree" <?=($this->get('regist_accept') == '1' && $this->get('regist_confirm') == '1') ? 'class="hidden"' : '' ?>>
+    <div id="registSetfree" <?=($this->get('regist_accept') == '1' && $this->get('regist_confirm') == '1') ? 'hidden' : '' ?>>
         <div class="row mb-3">
             <div class="col-xl-2 control-label">
                 <?=$this->getTrans('setfreeRegistration') ?>:
@@ -207,22 +205,22 @@
 <script>
 $('[name="regist_accept"]').click(function () {
     if ($(this).val() == "1") {
-        $('#registSetfree').removeClass('hidden');
-        $('#registRules').removeClass('hidden');
-        $('#rulesForRegist').removeClass('hidden');
-        $('#registAccept').removeClass('hidden');
+        $('#registSetfree').removeAttr('hidden');
+        $('#registRules').removeAttr('hidden');
+        $('#rulesForRegist').removeAttr('hidden');
+        $('#registAccept').removeAttr('hidden');
     } else {
-        $('#registSetfree').addClass('hidden');
-        $('#registRules').addClass('hidden');
-        $('#rulesForRegist').addClass('hidden');
-        $('#registAccept').addClass('hidden');
+        $('#registSetfree').attr('hidden', '');
+        $('#registRules').attr('hidden', '');
+        $('#rulesForRegist').attr('hidden', '');
+        $('#registAccept').attr('hidden', '');
     }
 });
 $('[name="regist_confirm"]').click(function () {
     if ($(this).val() == "0") {
-        $('#registSetfree').removeClass('hidden');
+        $('#registSetfree').removeAttr('hidden');
     } else {
-        $('#registSetfree').addClass('hidden');
+        $('#registSetfree').attr('hidden', '');
     }
 });
 </script>


### PR DESCRIPTION
# Description
- Replaced the removed hidden class with the hidden attribute.

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden

`The .hidden and .show classes have been removed because they conflicted with jQuery’s $(...).hide() and $(...).show() methods. Instead, try toggling the [hidden] attribute or use inline styles like style="display: none;" and style="display: block;".`

https://getbootstrap.com/docs/4.1/migration/#responsive-utilities

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
