### PR TITLE
Newsletter: Fix "Return value must be of type string, null returned"

### DIFF
--- a/application/modules/newsletter/config/config.php
+++ b/application/modules/newsletter/config/config.php
@@ -13,7 +13,7 @@ class Config extends Install
 {
     public $config = [
         'key' => 'newsletter',
-        'version' => '1.7.0',
+        'version' => '1.7.1',
         'icon_small' => 'fa-regular fa-newspaper',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/newsletter/controllers/Index.php
+++ b/application/modules/newsletter/controllers/Index.php
@@ -7,6 +7,7 @@
 namespace Modules\Newsletter\Controllers;
 
 use Ilch\Controller\Frontend;
+use Ilch\Date;
 use Modules\Newsletter\Mappers\Newsletter as NewsletterMapper;
 use Modules\Newsletter\Mappers\Subscriber as SubscriberMapper;
 use Modules\Newsletter\Models\Subscriber as SubscriberModel;
@@ -91,7 +92,7 @@ class Index extends Frontend
                     $subscriberModel->setSelector($selector);
                     $subscriberModel->setConfirmCode($confirmedCode);
                     $subscriberModel->setEmail($subscriber->getEmail());
-                    $subscriberModel->setNewsletter(1);
+                    $subscriberModel->setNewsletter(true);
                     $subscriberModel->setDoubleOptInDate($subscriber->getDoubleOptInDate());
                     $subscriberModel->setDoubleOptInConfirmed(true);
                     $subscriberMapper->saveSubscriber($subscriberModel);
@@ -150,6 +151,8 @@ class Index extends Frontend
                 $subscriberModel->setSelector(bin2hex(random_bytes(9)));
                 $subscriberModel->setConfirmCode(bin2hex(random_bytes(32)));
                 $subscriberModel->setId($this->getUser()->getId());
+                $subscriberModel->setDoubleOptInDate(new Date());
+                $subscriberModel->setDoubleOptInConfirmed(true);
                 $subscriberModel->setNewsletter($this->getRequest()->getPost('acceptNewsletter'));
                 $subscriberMapper->saveUserAsSubscriber($subscriberModel);
 


### PR DESCRIPTION
# Description
````
Fatal error: Uncaught TypeError: Modules\Newsletter\Models\Subscriber::getDoubleOptInDate(): Return value must be of type string, null returned in application\modules\newsletter\models\Subscriber.php:159

Stack trace:
#0 application\modules\newsletter\mappers\Subscriber.php(151): Modules\Newsletter\Models\Subscriber->getDoubleOptInDate()
#1 application\modules\newsletter\controllers\Index.php(154): Modules\Newsletter\Mappers\Subscriber->saveUserAsSubscriber(Object(Modules\Newsletter\Models\Subscriber))
#2 application\libraries\Ilch\Page.php(241): Modules\Newsletter\Controllers\Index->settingsAction()
#3 application\libraries\Ilch\Page.php(135): Ilch\Page->loadController()
#4 index.php(68): Ilch\Page->loadPage()
#5 {main} thrown in application\modules\newsletter\models\Subscriber.php on line 159
````

https://www.ilch.de/forum-showposts-58685.html

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
