### PR TITLE
Forum: last id of post instead of first, wrong counts with getCountPostsByTopicIds

### DIFF
--- a/application/modules/forum/config/config.php
+++ b/application/modules/forum/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'forum',
-        'version' => '1.34.6',
+        'version' => '1.34.7',
         'icon_small' => 'fa-solid fa-list',
         'author' => 'Stantin Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/forum/mappers/Forum.php
+++ b/application/modules/forum/mappers/Forum.php
@@ -519,7 +519,7 @@ class Forum extends Mapper
      */
     public function getLastPostsByForumIds(array $forumId, int $userId = null): ?array
     {
-        $select = $this->db()->select(['p.id', 'p.topic_id', 'p.user_id', 'date_created' => 'MAX(p.date_created)', 'p.forum_id'])
+        $select = $this->db()->select(['postId' => 'MAX(p.id)', 'p.topic_id', 'p.user_id', 'date_created' => 'MAX(p.date_created)', 'p.forum_id'])
             ->from(['p' => 'forum_posts'])
             ->join(['t' => 'forum_topics'], 't.id = p.topic_id', 'LEFT', ['t.topic_title']);
 
@@ -542,7 +542,7 @@ class Forum extends Mapper
         foreach ($lastPostRows as $lastPostRow) {
             $postModel = new PostModel();
             $userMapper = new UserMapper();
-            $postModel->setId($lastPostRow['id']);
+            $postModel->setId($lastPostRow['postId']);
             $user = $userMapper->getUserById($lastPostRow['user_id']);
 
             if ($user) {
@@ -563,6 +563,7 @@ class Forum extends Mapper
 
         return $lastPosts;
     }
+
     /**
      * Get category by parent id.
      *

--- a/application/modules/forum/mappers/Forum.php
+++ b/application/modules/forum/mappers/Forum.php
@@ -757,7 +757,7 @@ class Forum extends Mapper
         $countOfPostsRows = $this->db()->select(['count' => 'COUNT(id)', 'topic_id'])
             ->from('forum_posts')
             ->where(['topic_id' => $topicIds], 'or')
-            ->group(['id'])
+            ->group(['topic_id'])
             ->execute()
             ->fetchList('count', 'topic_id');
 

--- a/application/modules/forum/mappers/Topic.php
+++ b/application/modules/forum/mappers/Topic.php
@@ -256,7 +256,7 @@ class Topic extends Mapper
             return null;
         }
 
-        $select = $this->db()->select(['p.id', 'p.topic_id', 'date_created' => 'MAX(p.date_created)', 'p.user_id', 'p.forum_id'])
+        $select = $this->db()->select(['postId' => 'MAX(p.id)', 'p.topic_id', 'date_created' => 'MAX(p.date_created)', 'p.user_id', 'p.forum_id'])
             ->from(['p' => 'forum_posts']);
         if ($userId) {
             $select->join(['tr' => 'forum_topics_read'], ['tr.user_id' => $userId, 'tr.topic_id = p.topic_id', 'tr.datetime >= p.date_created'], 'LEFT', ['topic_read' => 'tr.datetime'])
@@ -276,7 +276,7 @@ class Topic extends Mapper
         foreach ($lastPostsRows as $lastPostRow) {
             $postModel = new PostModel();
             $userMapper = new UserMapper();
-            $postModel->setId($lastPostRow['id']);
+            $postModel->setId($lastPostRow['postId']);
             $user = $userMapper->getUserById($lastPostRow['user_id']);
             if ($user) {
                 $postModel->setAutor($user);


### PR DESCRIPTION
# Description
- Get last id of post instead of first.
- Fix group with wrong column in getCountPostsByTopicIds. This caused the function to always return counts of 1.

Previously the first post of the topic was linked in various places instead of the newest one.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge