### PR TITLE
V2.1.59-Beta

### DIFF
--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -948,6 +948,10 @@ class Config extends \Ilch\Config\Install
                 $databaseConfig->set('page_title_moduledata_separator', ' | ');
                 $databaseConfig->set('page_title_moduledata_order', '0');
                 break;
+            case "2.1.57":
+                break;
+            case "2.1.58":
+                break;
         }
 
         return 'Update function executed.';

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@ header('Content-Type: text/html; charset=utf-8');
 $serverTimeZone = @date_default_timezone_get();
 date_default_timezone_set('UTC');
 
-define('VERSION', '2.1.58');
+define('VERSION', '2.1.59');
 define('SERVER_TIMEZONE', $serverTimeZone);
 define('DEFAULT_MODULE', 'page');
 define('DEFAULT_LAYOUT', 'index');


### PR DESCRIPTION
**Version 2.1.59**

Als eine der letzten offiziell unterstützten Versionen von Linux-Distributionen mit PHP 7.3 wird Debian 10 am 30. Juni 2024 den Support einstellen. Ab diesem Stichtag wird auch Ilch 2 kein PHP 7.3 mehr unterstützen. Wir empfehlen daher rechtzeitig auf neuere PHP-Versionen zu wechseln.  
  
Sollten Sie noch Inhalte im BBCode-Format haben, wird empfohlen diese bis vor Mitte des Jahres zu konvertieren. Ab diesem Zeitpunkt wird das BBCode-Konvertierung-Modul nicht mehr gepflegt.  
  
<a href="https://github.com/IlchCMS/Ilch-2.0/wiki/Hinweise-f%C3%BCr-Entwickler" target="_blank">Hinweise für Entwickler</a>  
**Ilch:**  
- Die erweiterten Layout-Einstellungen wurden um den Typen "textarea" erweitert.  
- Der Typ "text" der erweiterten Layout-Einstellungen erlaubt nun 255 Zeichen, anstatt wie bisher 40 Zeichen.

**BBCode-Konvertierung-Modul (1.0.7):**

- Unterstützung für die aktuelle Version von Ilch und dem Forum-Modul.

**Forum-Modul (1.34.7):**

- An mehreren Stellen wurde nicht der neueste Beitrag verlinkt, sondern der erste Beitrag.  
- In der Box wurde oft bei mehr als einer Seite die falsche Seitenzahl im Link eingebunden.

**Newsletter-Modul (1.7.1):**

- Fehler im User-Panel im Zusammenhang mit der "Double-Opt-in"-Funktion behoben.

**Shop-Modul (1.2.2):**

- Fehler im Bestellprozess behoben, wenn ein Produkt in der Zwischenzeit gelöscht wurde.  
- "Registrierungs"- und "Passwort vergessen"-Verlinkung auf der Login-Seite hinzugefügt.

**Wie halte ich Ilch auf den aktuellen Stand?**  
<a href="https://github.com/IlchCMS/Ilch-2.0/wiki/Doku-Benutzer-Ilch-aktuell-halten" target="_blank">Doku Benutzer Ilch aktuell halten</a>