### PR TITLE
Backup: Show "noBackups" message instead of garbled table

### DIFF
--- a/application/modules/admin/views/admin/backup/index.php
+++ b/application/modules/admin/views/admin/backup/index.php
@@ -1,6 +1,7 @@
 <h1><?=$this->getTrans('menuBackup') ?></h1>
 <form class="form-horizontal" method="POST">
     <?=$this->getTokenField() ?>
+    <?php if ($this->get('backups') != ''): ?>
     <div class="table-responsive">
         <table class="table table-hover table-striped">
             <colgroup>
@@ -22,24 +23,23 @@
                 </tr>
             </thead>
             <tbody>
-                <?php if ($this->get('backups') != ''): ?>
-                    <?php foreach ($this->get('backups') as $backup): ?>
-                        <tr>
-                            <td><?=$this->getDeleteCheckbox('id', $backup->getId()) ?></td>
-                            <td><a href="<?=$this->getUrl(['action' => 'download', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('download') ?>"><span class="fa-solid fa-download"></span></a></td>
-                            <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $backup->getId()]) ?></td>
-                            <td><?=$this->escape($backup->getDate()) ?></td>
-                            <td><?=formatBytes(filesize(ROOT_PATH . '/backups/' . $backup->getName())) ?></td>
-                            <td><?=$this->escape(preg_replace('/_[^_.]*\./', '.', $backup->getName())) ?></td>
-                        </tr>
-                    <?php endforeach; ?>
-                <?php else: ?>
-                    <tr>
-                        <td colspan="5"><?=$this->getTrans('noBackups') ?></td>
-                    </tr>
-                <?php endif; ?>
+            <?php foreach ($this->get('backups') as $backup): ?>
+                <tr>
+                    <td><?=$this->getDeleteCheckbox('id', $backup->getId()) ?></td>
+                    <td><a href="<?=$this->getUrl(['action' => 'download', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('download') ?>"><span class="fa-solid fa-download"></span></a></td>
+                    <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $backup->getId()]) ?></td>
+                    <td><?=$this->escape($backup->getDate()) ?></td>
+                    <td><?=formatBytes(filesize(ROOT_PATH . '/backups/' . $backup->getName())) ?></td>
+                    <td><?=$this->escape(preg_replace('/_[^_.]*\./', '.', $backup->getName())) ?></td>
+                </tr>
+            <?php endforeach; ?>
             </tbody>
         </table>
     </div>
+    <?php else: ?>
+        <tr>
+            <td colspan="5"><?=$this->getTrans('noBackups') ?></td>
+        </tr>
+    <?php endif; ?>
     <?=$this->getListBar(['delete' => 'delete']) ?>
 </form>


### PR DESCRIPTION
# Description
Show "noBackups" message instead of garbled table

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
