### PR TITLE
Bootstrap 5: Implement a more flexible alternative to getDialog

### DIFF
--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -9,6 +9,8 @@ namespace Ilch\Design;
 
 use Ilch\HTMLPurifier\EmbedUrlDef;
 use Ilch\Layout\Helper\GetMedia;
+use Ilch\Layout\Helper\GetModalDialog;
+use Ilch\Layout\Helper\ModalDialog\Model as ModalDialogModel;
 use Ilch\Request;
 use Ilch\Router;
 use Ilch\Translator;
@@ -771,6 +773,7 @@ abstract class Base
 
     /**
      * Gets the dialog.
+     * getModalDialog() offers more flexibilty by providing the ModalDialogModel for options.
      *
      * @param string $id
      * @param string $name
@@ -780,42 +783,23 @@ abstract class Base
      */
     public function getDialog(string $id, string $name, string $content, $submit = null): string
     {
-        $html = '<div class="modal fade" id="' . $id . '">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h4 class="modal-title" id="modalLabel">' . $name . '</h4>
-                        <button type="button"
-                                class="btn-close"
-                                data-bs-dismiss="modal"
-                                aria-label="Close">
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        ' . $content . '
-                    </div>
-                    <div class="modal-footer">';
-        if ($submit != null) {
-            $html .= '<button type="button"
-                                 class="btn btn-primary"
-                                 id="modalButton">' . $this->getTrans('ack') . '
-                            </button>
-                            <button type="button"
-                                    class="btn btn-outline-secondary"
-                                    data-bs-dismiss="modal">' . $this->getTrans('cancel') . '
-                            </button>';
-        } else {
-            $html .= '<button type="button"
-                                class="btn btn-primary"
-                                data-bs-dismiss="modal">
-                            ' . $this->getTrans('close') . '
-                            </button>';
-        }
-        $html .= '</div>
-                </div>
-            </div>
-        </div>';
+        $modalDialogModel = new ModalDialogModel();
+        $modalDialogModel->setId($id)
+            ->setTitle($name)
+            ->setContent($content);
+        return $this->getModalDialog($modalDialogModel);
+    }
 
-        return $html;
+    /**
+     * Gets a modal dialog.
+     *
+     * @see https://getbootstrap.com/docs/5.3/components/modal/
+     * @param ModalDialogModel $modalDialogModel Used to pass options (like size) and content (title, ...).
+     * @return GetModalDialog
+     * @since Ilch 2.2.0
+     */
+    public function getModalDialog(ModalDialogModel $modalDialogModel): GetModalDialog
+    {
+        return new GetModalDialog($modalDialogModel, $this);
     }
 }

--- a/application/libraries/Ilch/Layout/Helper/GetModalDialog.php
+++ b/application/libraries/Ilch/Layout/Helper/GetModalDialog.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Ilch\Layout\Helper;
+
+use Ilch\Design\Base;
+use Ilch\Layout\Helper\ModalDialog\Model as ModalDialogModel;
+
+/**
+ * Class for usage in conjunction with the ModalDialogModel in getModalDialog() to offer a more flexible way of getting a modal dialog.
+ *
+ * @since Ilch 2.2.0
+ */
+class GetModalDialog
+{
+    protected $model = null;
+    protected $base = null;
+
+    public function __construct(ModalDialogModel $model, Base $base)
+    {
+        $this->model = $model;
+        $this->base = $base;
+    }
+
+    public function __toString()
+    {
+        $html = '<div class="modal fade" id="' . $this->model->getId() . '"' . ($this->model->getClass() ? ' class="' . $this->model->getClass() . '"' : '') . '>
+            <div class="modal-dialog' . ($this->model->getInnerClass() ? ' ' . $this->model->getInnerClass() : '') . '">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4 class="modal-title" id="modalLabel">' . $this->model->getTitle() . '</h4>
+                        <button type="button"
+                                class="btn-close"
+                                data-bs-dismiss="modal"
+                                aria-label="Close">
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        ' . $this->model->getContent() . '
+                    </div>
+                    <div class="modal-footer">';
+        if ($this->model->isSubmit() != null) {
+            $html .= '<button type="button"
+                                 class="btn btn-primary"
+                                 id="modalButton">' . $this->base->getTrans('ack') . '
+                            </button>
+                            <button type="button"
+                                    class="btn btn-outline-secondary"
+                                    data-bs-dismiss="modal">' . $this->base->getTrans('cancel') . '
+                            </button>';
+        } else {
+            $html .= '<button type="button"
+                                class="btn btn-primary"
+                                data-bs-dismiss="modal">
+                            ' . $this->base->getTrans('close') . '
+                            </button>';
+        }
+        $html .= '</div>
+                </div>
+            </div>
+        </div>';
+
+        return $html;
+    }
+}

--- a/application/libraries/Ilch/Layout/Helper/ModalDialog/Model.php
+++ b/application/libraries/Ilch/Layout/Helper/ModalDialog/Model.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Ilch\Layout\Helper\ModalDialog;
+
+/**
+ * ModalDialog model to pass information to the GetModalDialog function to customize the dialog.
+ *
+ * @since Ilch 2.2.0
+ * @see https://getbootstrap.com/docs/5.3/components/modal/
+ */
+class Model
+{
+    /**
+     * CSS id
+     *
+     * @var string
+     */
+    protected $id = '';
+
+    /**
+     * The class of the outer div
+     *
+     * @var string
+     */
+    protected $class = '';
+
+    /**
+     * The class of the inner div
+     * @var string
+     */
+    protected $innerClass = '';
+
+    /**
+     * Title of the dialog.
+     *
+     * @var string
+     */
+    protected $title = '';
+
+    /**
+     * Content of the dialog.
+     *
+     * @var string
+     */
+    protected $content = '';
+
+    /**
+     * @var bool
+     */
+    protected $submit = false;
+
+    /**
+     * Get the id attribute.
+     *
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set the id attribute.
+     *
+     * @param string $id
+     * @return Model
+     */
+    public function setId(string $id): Model
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * Get the class of the outer div.
+     * This would be the div with the modal class.
+     *
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * Set the class of the outer div. Can be used to apply CSS to it.
+     * This would be the div with the modal class.
+     *
+     * @param string $class
+     * @return Model
+     */
+    public function setClass(string $class): Model
+    {
+        $this->class = $class;
+        return $this;
+    }
+
+    /**
+     * Get the class of the inner div.
+     * This would be the div with the modal-dialog class.
+     *
+     * @return string
+     */
+    public function getInnerClass(): string
+    {
+        return $this->innerClass;
+    }
+
+    /**
+     * Set the class of the inner div.
+     * This would be the div with the modal-dialog class.
+     *
+     * Can be used to add classes for the size (modal-sm, modal-lg, modal-xl),
+     * fullscreen modal (modal-fullscreen, modal-fullscreen-sm-down, ...), 
+     * scrollable modal (modal-dialog-scrollable), vertically centered and more.
+     *
+     * @see https://getbootstrap.com/docs/5.3/components/modal/
+     * @param string $innerClass
+     * @return Model
+     */
+    public function setInnerClass(string $innerClass): Model
+    {
+        $this->innerClass = $innerClass;
+        return $this;
+    }
+
+    /**
+     * Get the title of the modal dialog.
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set the title of the modal dialog.
+     *
+     * @param string $title
+     * @return Model
+     */
+    public function setTitle(string $title): Model
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    /**
+     * Get the content of the modal dialog.
+     *
+     * @return string
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * Set the content of the modal dialog.
+     *
+     * @param string $content
+     * @return Model
+     */
+    public function setContent(string $content): Model
+    {
+        $this->content = $content;
+        return $this;
+    }
+
+    /**
+     * Does add an submit button.
+     *
+     * @return bool
+     */
+    public function isSubmit(): bool
+    {
+        return $this->submit;
+    }
+
+    /**
+     * Set to true to add an submit button to the modal dialog.
+     * False for none.
+     *
+     * @param bool $submit
+     * @return Model
+     */
+    public function setSubmit(bool $submit): Model
+    {
+        $this->submit = $submit;
+        return $this;
+    }
+}


### PR DESCRIPTION
# Description
Implement a more flexible alternative to getDialog. It uses a ModalDialog model to pass information to the GetModalDialog function to customize the dialog. 
This can be used to add classes for the size (modal-sm, modal-lg, modal-xl), fullscreen modal (modal-fullscreen, modal-fullscreen-sm-down, ...), scrollable modal (modal-dialog-scrollable), vertically centered and more.
The ModalDialogModel is easier to extend if more features are needed in the future.
Currently it is not used as various issues with the modal dialogs with Bootstrap 5 could be sorted out, but this might be worth to add for the additional flexibility.

See the Bootstrap 5 documentation for the modal dialog:
https://getbootstrap.com/docs/5.3/components/modal/

Fixes #951

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
