### PR TITLE
Bootstrap 5: Replace .control-label with .col-form-label

### DIFF
--- a/application/libraries/Captcha/DefaultCaptcha.php
+++ b/application/libraries/Captcha/DefaultCaptcha.php
@@ -60,7 +60,7 @@ class DefaultCaptcha
     public function getCaptcha(View $view): string
     {
         return '<div class="form-group row mb-15 ' . ($view->validation()->hasError('captcha') ? 'has-error' : '') . '">
-            <label class="col-xl-2 control-label">
+            <label class="col-xl-2 col-form-label">
                 ' . $view->getTrans('captcha') . '
             </label>
             <div class="col-xl-8">

--- a/application/modules/admin/layouts/login.php
+++ b/application/modules/admin/layouts/login.php
@@ -61,7 +61,7 @@ $languages = (!empty($this->get('languages'))) ? $this->get('languages') : [];
                                 </div>
                             </div>
                             <div class="row mb-3" style="padding: 0px 13px;">
-                                <label for="language" class="control-label p-0"><?=$this->getTrans('language') ?></label>
+                                <label for="language" class="col-form-label p-0"><?=$this->getTrans('language') ?></label>
                                 <select class="form-select" name="language" id="language">
                                     <option value="">Standard</option>
                                     <?php foreach ($languages as $key => $value): ?>

--- a/application/modules/admin/static/css/admin.css
+++ b/application/modules/admin/static/css/admin.css
@@ -432,7 +432,7 @@ ul > .heading {
     margin-left: -15px;
 }
 
-.form-group .control-label {
+.form-group {
     text-align: left;
 }
 

--- a/application/modules/admin/static/css/main.css
+++ b/application/modules/admin/static/css/main.css
@@ -6,7 +6,7 @@ body {
 .control-group {
     margin-bottom: 10px;
 }
-.control-group .control-label {
+.control-group {
     text-align: left;
 }
 .mobile {

--- a/application/modules/admin/views/admin/backup/create.php
+++ b/application/modules/admin/views/admin/backup/create.php
@@ -7,7 +7,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3">
-        <label for="compress" class="col-xl-2 control-label">
+        <label for="compress" class="col-xl-2 col-form-label">
             <?=$this->getTrans('compress') ?>:
         </label>
         <div class="col-xl-2">
@@ -18,7 +18,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('skipComments') ?>:
         </div>
         <div class="col-xl-2">
@@ -32,7 +32,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('addDatabases') ?>:
         </div>
         <div class="col-xl-2">
@@ -46,7 +46,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('dropTable') ?>:
         </div>
         <div class="col-xl-2">

--- a/application/modules/admin/views/admin/boxes/treat.php
+++ b/application/modules/admin/views/admin/boxes/treat.php
@@ -8,7 +8,7 @@ $entrie = $this->get('box');
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('boxTitle') ? 'has-error' : '' ?>">
-        <label for="boxTitle" class="col-xl-2 control-label">
+        <label for="boxTitle" class="col-xl-2 col-form-label">
             <?=$this->getTrans('boxTitle') ?>:
         </label>
         <div class="col-xl-4">
@@ -20,7 +20,7 @@ $entrie = $this->get('box');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('boxContent') ? 'has-error' : '' ?>">
-        <label for="boxContent" class="col-xl-2 control-label">
+        <label for="boxContent" class="col-xl-2 col-form-label">
             <?=$this->getTrans('boxContent') ?>:
         </label>
         <div class="col-xl-8">
@@ -32,7 +32,7 @@ $entrie = $this->get('box');
     </div>
     <?php if ($this->get('multilingual') && $this->getRequest()->getParam('locale')): ?>
         <div class="row mb-3">
-            <label for="boxLanguage" class="col-xl-2 control-label">
+            <label for="boxLanguage" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('boxLanguage') ?>:
             </label>
             <div class="col-xl-2">

--- a/application/modules/admin/views/admin/emails/treat.php
+++ b/application/modules/admin/views/admin/emails/treat.php
@@ -24,7 +24,7 @@ $module = $moduleMapper->getModulesByKey($this->getRequest()->getParam('key'), $
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('desc') ? 'has-error' : '' ?>">
-        <label for="desc" class="col-xl-2 control-label">
+        <label for="desc" class="col-xl-2 col-form-label">
             <?=$this->getTrans('emailDesc') ?>
         </label>
         <div class="col-xl-3">
@@ -36,7 +36,7 @@ $module = $moduleMapper->getModulesByKey($this->getRequest()->getParam('key'), $
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-        <label for="text" class="col-xl-2 control-label">
+        <label for="text" class="col-xl-2 col-form-label">
             <?=$this->getTrans('emailText') ?>
         </label>
         <div class="col-xl-10">

--- a/application/modules/admin/views/admin/infos/logs.php
+++ b/application/modules/admin/views/admin/infos/logs.php
@@ -14,7 +14,7 @@ $userCache = [];
         <?=$this->getTokenField() ?>
         <div class="panel-body">
             <div class="row mb-3">
-                <label for="startDate" class="col-xl-2 control-label">
+                <label for="startDate" class="col-xl-2 col-form-label">
                     <?=$this->getTrans('startDate') ?>:
                 </label>
                 <div id="startDate" class="col-xl-4 input-group ilch-date date form_datetime">
@@ -30,7 +30,7 @@ $userCache = [];
                 </div>
             </div>
             <div class="row mb-3">
-                <label for="endDate" class="col-xl-2 control-label">
+                <label for="endDate" class="col-xl-2 col-form-label">
                     <?=$this->getTrans('endDate') ?>:
                 </label>
                 <div id="endDate" class="col-xl-4 input-group ilch-date date form_datetime">

--- a/application/modules/admin/views/admin/layouts/advSettingsShow.php
+++ b/application/modules/admin/views/admin/layouts/advSettingsShow.php
@@ -96,7 +96,7 @@ function getInput(string $name, array $value, array $settingsValues, \Ilch\View 
             <h2><?=$this->getOtherLayoutTrans($this->get('layoutKey'), $key) ?></h2>
         <?php else : ?>
             <div class="row mb-3">
-                <label for="<?=$key ?>" class="col-xl-2 control-label">
+                <label for="<?=$key ?>" class="col-xl-2 col-form-label">
                     <?=$this->getOtherLayoutTrans($this->get('layoutKey'), $key) ?>:
                 </label>
                 <div class="col-xl-10">

--- a/application/modules/admin/views/admin/layouts/settings.php
+++ b/application/modules/admin/views/admin/layouts/settings.php
@@ -6,7 +6,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('favicon') ? 'has-error' : '' ?>">
-        <label for="selectedImage_1" class="col-xl-2 control-label">
+        <label for="selectedImage_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('favicon') ?>:
         </label>
         <div class="col-xl-4">
@@ -32,7 +32,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('appleIcon') ? 'has-error' : '' ?>">
-        <label for="selectedImage_2" class="col-xl-2 control-label">
+        <label for="selectedImage_2" class="col-xl-2 col-form-label">
             <?=$this->getTrans('appleIcon') ?>:
         </label>
         <div class="col-xl-4">
@@ -58,7 +58,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('pageTitle') ? 'has-error' : '' ?>">
-        <label for="pageTitle" class="col-xl-2 control-label">
+        <label for="pageTitle" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pageTitle') ?>:
         </label>
         <div class="col-xl-4">
@@ -70,7 +70,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('pageTitleOrder') ? 'has-error' : '' ?>">
-        <label for="pageTitleOrder" class="col-xl-2 control-label">
+        <label for="pageTitleOrder" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pageTitleOrder') ?>:<br>
             <h6><?=$this->getTrans('pageTitleOrderInfo') ?></h6>
         </label>
@@ -83,7 +83,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('pageTitleModuledataSeparator') ? 'has-error' : '' ?>">
-        <label for="pageTitleModuledataSeparator" class="col-xl-2 control-label">
+        <label for="pageTitleModuledataSeparator" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pageTitleModuledataSeparator') ?>:
         </label>
         <div class="col-xl-4">
@@ -95,7 +95,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('pageTitleModuledataOrder') ? 'has-error' : '' ?>">
-        <label for="pageTitleModuledataOrder" class="col-xl-2 control-label">
+        <label for="pageTitleModuledataOrder" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pageTitleModuledataOrder') ?>:
         </label>
         <div class="col-xl-4">
@@ -109,7 +109,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('keywords') ? 'has-error' : '' ?>">
-        <label for="keywords" class="col-xl-2 control-label">
+        <label for="keywords" class="col-xl-2 col-form-label">
             <?=$this->getTrans('seoKeywords') ?>:
         </label>
         <div class="col-xl-4">
@@ -119,7 +119,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('description') ? 'has-error' : '' ?>">
-        <label for="description" class="col-xl-2 control-label">
+        <label for="description" class="col-xl-2 col-form-label">
             <?=$this->getTrans('seoDescription') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/admin/views/admin/menu/index.php
+++ b/application/modules/admin/views/admin/menu/index.php
@@ -116,7 +116,7 @@ function buildMenu($parentId, $menuData, View $view) {
         <div class="col-md-5 col-xl-5 changeBox">
             <input type="hidden" id="id" value="" />
             <div class="row mb-3">
-                <label for="title" class="col-lg-4 control-label">
+                <label for="title" class="col-lg-4 col-form-label">
                     <?=$this->getTrans('itemTitle') ?>
                 </label>
                 <div class="col-xl-8">
@@ -124,7 +124,7 @@ function buildMenu($parentId, $menuData, View $view) {
                 </div>
             </div>
             <div class="row mb-3">
-                <label for="type" class="col-xl-4 control-label">
+                <label for="type" class="col-xl-4 col-form-label">
                     <?=$this->getTrans('itemType') ?>
                 </label>
                 <div class="col-xl-8">
@@ -141,7 +141,7 @@ function buildMenu($parentId, $menuData, View $view) {
             </div>
             <div class="dyn"></div>
             <div class="row mb-3">
-                <label for="access" class="col-xl-4 control-label">
+                <label for="access" class="col-xl-4 col-form-label">
                     <?=$this->getTrans('notVisible') ?>
                 </label>
                 <div class="col-xl-8">
@@ -153,7 +153,7 @@ function buildMenu($parentId, $menuData, View $view) {
                 </div>
             </div>
             <div class="row">
-                <label for="access" class="col-xl-4 control-label"></label>
+                <label for="access" class="col-xl-4 col-form-label"></label>
                 <div class="actions col-xl-8 text-end">
                     <input type="button" class="btn btn-light btn-sm" id="menuItemAdd" value="<?=$this->getTrans('menuItemAdd') ?>">
                 </div>
@@ -370,24 +370,24 @@ $(document).ready
                 return;
             }
 
-            let menuHtml = '<div class="row mb-3"><label for="menukey" class="col-xl-4 control-label"><?=$this->getTrans('labelMenu') ?></label>\n\
+            let menuHtml = '<div class="row mb-3"><label for="menukey" class="col-xl-4 col-form-label"><?=$this->getTrans('labelMenu') ?></label>\n\
                             <div class="col-xl-8"><select class="form-select" id="menukey">'+options+'</select></div></div>';
 
             if ($(this).val() == '0') {
                 $('.dyn').html('');
             } else if ($(this).val() == '1') {
-                $('.dyn').html('<div class="row mb-3"><label for="href" class="col-xl-4 control-label"><?=$this->getTrans('address') ?></label>\n\
+                $('.dyn').html('<div class="row mb-3"><label for="href" class="col-xl-4 col-form-label"><?=$this->getTrans('address') ?></label>\n\
                                 <div class="col-xl-8"><input type="text" class="form-control" id="href" value="http://" /></div></div>\n\
-                                <div class="row mb-3"><label for="target" class="col-xl-4 control-label"><?=$this->getTrans('target') ?></label>\n\
+                                <div class="row mb-3"><label for="target" class="col-xl-4 col-form-label"><?=$this->getTrans('target') ?></label>\n\
                                 <div class="col-xl-8"><select class="form-select" id="target"><?php foreach ($targets as $target => $translation) { echo '<option value="'.$target.'">'.$this->getTrans($translation).'</option>';} ?></select></div></div>'+menuHtml);
             } else if ($(this).val() == '2') {
-                 $('.dyn').html('<div class="row mb-3"><label for="siteid" class="col-xl-4 control-label"><?=$this->getTrans('page') ?></label>\n\
+                 $('.dyn').html('<div class="row mb-3"><label for="siteid" class="col-xl-4 col-form-label"><?=$this->getTrans('page') ?></label>\n\
                                 <div class="col-xl-8"><?php if (!empty($pages)) { echo '<select class="form-select" id="siteid">'; foreach ($pages as $page) { echo '<option value="'.$page->getId().'">'.$this->escape($page->getTitle()).'</option>';} echo '</select>'; } else { echo $this->getTrans('missingSite'); } ?></div></div>'+menuHtml);
             } else if ($(this).val() == '3') {
-                $('.dyn').html('<div class="row mb-3"><label for="modulekey" class="col-xl-4 control-label"><?=$this->getTrans('module') ?></label>\n\
+                $('.dyn').html('<div class="row mb-3"><label for="modulekey" class="col-xl-4 col-form-label"><?=$this->getTrans('module') ?></label>\n\
                                 <div class="col-lg-8"><?php if (!empty($modules)) { echo '<select class="form-select" id="modulekey">'; foreach ($modules as $module) { if ($module->getHideMenu() != true) { $content = $module->getContentForLocale($this->getTranslator()->getLocale()); echo '<option value="'.$module->getKey().'">'.$content['name'].'</option>';}} echo '</select>'; } else { echo $this->getTrans('missingModule'); } ?></div></div>'+menuHtml);
             } else if ($(this).val() == '4') {
-                $('.dyn').html('<div class="row mb-3"><label for="boxkey" class="col-xl-4 control-label"><?=$this->getTrans('box') ?></label>\n\
+                $('.dyn').html('<div class="row mb-3"><label for="boxkey" class="col-xl-4 col-form-label"><?=$this->getTrans('box') ?></label>\n\
                                 <div class="col-xl-8"><?='<select class="form-select" id="boxkey">';
                     foreach ($boxes as $box) { echo '<option value="'.$box->getModule().'_'.$box->getKey().'">'.$box->getName().'</option>'; } foreach ($selfBoxes as $box) { echo '<option value="'.$box->getId().'">self_'.$this->escape($box->getTitle()).'</option>';} echo '</select>'; ?></div></div>');
             }

--- a/application/modules/admin/views/admin/page/treat.php
+++ b/application/modules/admin/views/admin/page/treat.php
@@ -8,7 +8,7 @@ $entrie = $this->get('page');
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('pageTitle') ? 'has-error' : '' ?>">
-        <label for="pageTitle" class="col-xl-2 control-label">
+        <label for="pageTitle" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pageTitle') ?>:
         </label>
         <div class="col-xl-4">
@@ -20,7 +20,7 @@ $entrie = $this->get('page');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('pageContent') ? 'has-error' : '' ?>">
-        <label for="pageContent" class="col-xl-2 control-label">
+        <label for="pageContent" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pageContent') ?>:
         </label>
         <div class="col-xl-8">
@@ -31,7 +31,7 @@ $entrie = $this->get('page');
     </div>
     <?php if ($this->get('multilingual') && $this->getRequest()->getParam('locale')): ?>
         <div class="row mb-3">
-            <label for="pageLanguage" class="col-xl-2 control-label">
+            <label for="pageLanguage" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('pageLanguage') ?>:
             </label>
             <div class="col-xl-2">
@@ -48,7 +48,7 @@ $entrie = $this->get('page');
     <?php endif; ?>
     <h1><?=$this->getTrans('seo') ?></h1>
     <div class="row mb-3">
-        <label for="description" class="col-xl-2 control-label">
+        <label for="description" class="col-xl-2 col-form-label">
             <?=$this->getTrans('seoDescription') ?>:
         </label>
         <div class="col-xl-4">
@@ -58,7 +58,7 @@ $entrie = $this->get('page');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="keywords" class="col-xl-2 control-label">
+        <label for="keywords" class="col-xl-2 col-form-label">
             <?=$this->getTrans('seoKeywords') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/admin/views/admin/settings/htaccess.php
+++ b/application/modules/admin/views/admin/settings/htaccess.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('modRewrite') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('modRewrite') ?>:
         </div>
         <div class="col-xl-4">

--- a/application/modules/admin/views/admin/settings/index.php
+++ b/application/modules/admin/views/admin/settings/index.php
@@ -8,7 +8,7 @@
 <form method="POST">
     <?= $this->getTokenField() ?>
     <div class="row mb-3">
-        <label for="startPage" class="col-xl-2 control-label">
+        <label for="startPage" class="col-xl-2 col-form-label">
             <?= $this->getTrans('startPage') ?>:
         </label>
         <div class="col-xl-4">
@@ -62,7 +62,7 @@
         </div>
     </div>
     <div class="row mb-3<?= $this->validation()->hasError('multilingualAcp') ? ' has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?= $this->getTrans('multilingualAcp') ?>:
         </div>
         <div class="col-xl-4">
@@ -76,7 +76,7 @@
         </div>
     </div>
     <div id="contentLanguage" class="row mb-3"<?= ($this->get('multilingualAcp') != '1') ? ' hidden' : ''; ?>>
-        <label for="languageInput" class="col-xl-2 control-label">
+        <label for="languageInput" class="col-xl-2 col-form-label">
             <?= $this->getTrans('contentLanguage') ?>:
         </label>
         <div class="col-xl-4">
@@ -93,7 +93,7 @@
         </div>
     </div>
     <div id="contentLanguage" class="row mb-3">
-        <label for="localeInput" class="col-xl-2 control-label">
+        <label for="localeInput" class="col-xl-2 col-form-label">
             <?= $this->getTrans('locale') ?>:
         </label>
         <div class="col-xl-4">
@@ -110,7 +110,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="timezone" class="col-xl-2 control-label">
+        <label for="timezone" class="col-xl-2 col-form-label">
             <?= $this->getTrans('timezone') ?>:
         </label>
         <div class="col-xl-4">
@@ -128,7 +128,7 @@
         </div>
     </div>
     <div class="row mb-3<?= $this->validation()->hasError('standardMail') ? ' has-error' : '' ?>">
-        <label for="standardMailInput" class="col-xl-2 control-label">
+        <label for="standardMailInput" class="col-xl-2 col-form-label">
             <?= $this->getTrans('standardMail') ?>:
         </label>
         <div class="col-xl-4">
@@ -141,7 +141,7 @@
         </div>
     </div>
     <div class="row mb-3<?= $this->validation()->hasError('defaultPaginationObjects') ? ' has-error' : '' ?>">
-        <label for="defaultPaginationObjectsInput" class="col-xl-2 control-label">
+        <label for="defaultPaginationObjectsInput" class="col-xl-2 col-form-label">
             <?= $this->getTrans('defaultPaginationObjects') ?>:
         </label>
         <div class="col-xl-1">
@@ -156,7 +156,7 @@
 
     <h1><?= $this->getTrans('captcha') ?></h1>
     <div class="row mb-3">
-        <div for="captcha" class="col-xl-2 control-label">
+        <div for="captcha" class="col-xl-2 col-form-label">
             <?= $this->getTrans('captcha') ?>:
         </div>
         <div class="col-xl-4">
@@ -174,7 +174,7 @@
     </div>
     <div id="captcha_apikey" class="">
         <div class="row mb-3">
-            <label for="captcha_apikey" class="col-xl-2 control-label">
+            <label for="captcha_apikey" class="col-xl-2 col-form-label">
                     <?= $this->getTrans('captcha_apikey') ?>:
             </label>
             <div class="col-xl-4">
@@ -188,7 +188,7 @@
     </div>
     <div id="captcha_seckey" class="">
         <div class="row mb-3">
-            <label for="captcha_seckey" class="col-xl-2 control-label">
+            <label for="captcha_seckey" class="col-xl-2 col-form-label">
                     <?= $this->getTrans('captcha_seckey') ?>:
             </label>
             <div class="col-xl-4">
@@ -201,7 +201,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="hideCaptchaFor" class="col-xl-2 control-label">
+        <label for="hideCaptchaFor" class="col-xl-2 col-form-label">
             <?= $this->getTrans('hideCaptchaFor') ?>:
         </label>
         <div class="col-xl-4">
@@ -234,7 +234,7 @@
     <h1><?= $this->getTrans('htmlPurifier') ?></h1>
     <p><?= $this->getTrans('htmlPurifierDescription') ?></p>
     <div id="htmlPurifier" class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?= $this->getTrans('htmlPurifier') ?>:
         </div>
         <div class="col-xl-4">
@@ -250,7 +250,7 @@
 
     <h1><?= $this->getTrans('backendFunctions') ?></h1>
     <div id="hmenuFixed" class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?= $this->getTrans('hmenuFixed') ?>:
         </div>
         <div class="col-xl-4">

--- a/application/modules/admin/views/admin/settings/mail.php
+++ b/application/modules/admin/views/admin/settings/mail.php
@@ -6,7 +6,7 @@
         <p id="smtpModeDescription"><?=($this->get('smtp_mode') === '1') ? $this->getTrans('smtpModeEnabledDescription') : $this->getTrans('smtpModeDisabledDescription') ?></p>
     </div>
     <div class="row mb-3">
-        <label for="navbarFixed" class="col-xl-2 control-label">
+        <label for="navbarFixed" class="col-xl-2 col-form-label">
             <?=$this->getTrans('smtpMode') ?>:
         </label>
         <div class="col-xl-8">
@@ -21,7 +21,7 @@
     </div>
     <div id="smtpSettings" class="smtpSettings" <?=($this->get('smtp_mode') !== '1') ? 'hidden' : '' ?>>
         <div class="row mb-3">
-            <label for="smtp_server" class="col-xl-2 control-label">
+            <label for="smtp_server" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('smtp_server') ?>:
             </label>
             <div class="col-xl-6">
@@ -33,7 +33,7 @@
             </div>
         </div>
         <div class="row mb-3">
-            <label for="smtp_port" class="col-xl-2 control-label">
+            <label for="smtp_port" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('smtp_port') ?>:
             </label>
             <div class="col-xl-2">
@@ -45,7 +45,7 @@
             </div>
         </div>
         <div class="row mb-3">
-            <label for="smtp_secure" class="col-xl-2 control-label">
+            <label for="smtp_secure" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('smtp_secure') ?>:
             </label>
             <div class="col-xl-2">
@@ -67,7 +67,7 @@
             </div>
         </div>
         <div class="row mb-3">
-            <label for="smtp_user" class="col-xl-2 control-label">
+            <label for="smtp_user" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('smtp_user') ?>:
             </label>
             <div class="col-xl-6">
@@ -79,7 +79,7 @@
             </div>
         </div>
         <div class="row mb-3">
-            <label for="smtp_pass" class="col-xl-2 control-label">
+            <label for="smtp_pass" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('smtp_pass') ?>:
             </label>
             <div class="col-xl-6">
@@ -93,7 +93,7 @@
     </div>
     <legend><?=$this->getTrans('emailBlacklist') ?></legend>
     <div class="row mb-3">
-        <label for="emailBlacklist" class="col-xl-2 control-label">
+        <label for="emailBlacklist" class="col-xl-2 col-form-label">
             <?=$this->getTrans('emailBlacklist') ?>:
         </label>
         <div class="col-xl-6">

--- a/application/modules/admin/views/admin/settings/maintenance.php
+++ b/application/modules/admin/views/admin/settings/maintenance.php
@@ -4,7 +4,7 @@
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('maintenanceMode') ?>:
         </div>
         <div class="col-xl-2">
@@ -18,7 +18,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="maintenanceDateTime" class="col-lg-2 control-label">
+        <label for="maintenanceDateTime" class="col-lg-2 col-form-label">
             <?=$this->getTrans('maintenanceEndDateTime') ?>:
         </label>
         <div id="maintenanceEndDateTime" class="col-xl-2 input-group ilch-date date form_datetime">
@@ -34,7 +34,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="maintenanceStatus" class="col-lg-2 control-label">
+        <label for="maintenanceStatus" class="col-lg-2 col-form-label">
             <?=$this->getTrans('maintenanceStatus') ?>:
         </label>
         <div class="col-xl-4">
@@ -45,7 +45,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="maintenanceText" class="col-xl-2 control-label">
+        <label for="maintenanceText" class="col-xl-2 col-form-label">
             <?=$this->getTrans('maintenanceText') ?>:
         </label>
         <div class="col-xl-10">

--- a/application/modules/article/views/admin/cats/treat.php
+++ b/application/modules/article/views/admin/cats/treat.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>:
         </label>
         <div class="col-xl-3">

--- a/application/modules/article/views/admin/index/treat.php
+++ b/application/modules/article/views/admin/index/treat.php
@@ -9,7 +9,7 @@ if ($this->get('article')) {
 <form id="article_form" method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('template') ? 'has-error' : '' ?>">
-        <label for="template" class="col-xl-2 control-label">
+        <label for="template" class="col-xl-2 col-form-label">
             <?=$this->getTrans('template') ?>:
         </label>
         <div class="col-xl-4">
@@ -28,7 +28,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('teaser') ? 'has-error' : '' ?>">
-        <label for="teaser" class="col-lg-2 control-label">
+        <label for="teaser" class="col-lg-2 col-form-label">
             <?=$this->getTrans('teaser') ?>:
         </label>
         <div class="col-xl-4">
@@ -40,7 +40,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>:
         </label>
         <div class="col-xl-4">
@@ -52,7 +52,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3">
-        <label for="date_created" class="col-xl-2 control-label">
+        <label for="date_created" class="col-xl-2 col-form-label">
             <?=$this->getTrans('date') ?>:
         </label>
         <div id="date_created" class="col-xl-4 input-group ilch-date date form_datetime">
@@ -68,7 +68,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('cats') ? 'has-error' : '' ?>">
-        <label for="cats" class="col-xl-2 control-label">
+        <label for="cats" class="col-xl-2 col-form-label">
             <?=$this->getTrans('cats') ?>:
         </label>
         <div class="col-xl-4">
@@ -105,7 +105,7 @@ if ($this->get('article')) {
     </div>
     <?php if ($this->get('multilingual') && $this->getRequest()->getParam('locale') != ''): ?>
         <div class="row mb-3">
-            <label for="language" class="col-lg-2 control-label">
+            <label for="language" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('language') ?>:
             </label>
             <div class="col-xl-8">
@@ -130,7 +130,7 @@ if ($this->get('article')) {
     <?php endif; ?>
     <h1><?=$this->getTrans('options') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('groups') ? 'has-error' : '' ?>">
-        <label for="access" class="col-lg-2 control-label">
+        <label for="access" class="col-lg-2 col-form-label">
             <?=$this->getTrans('visibleFor') ?>
         </label>
         <div class="col-xl-4">
@@ -142,7 +142,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3">
-        <label for="topArticle" class="col-lg-2 control-label">
+        <label for="topArticle" class="col-lg-2 col-form-label">
             <?=$this->getTrans('topArticle') ?>:
         </label>
         <div class="col-xl-4">
@@ -154,7 +154,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3">
-        <label for="commentsDisabled" class="col-lg-2 control-label">
+        <label for="commentsDisabled" class="col-lg-2 col-form-label">
             <?=$this->getTrans('commentsDisabled') ?>:
         </label>
         <div class="col-xl-4">
@@ -166,7 +166,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3">
-        <label for="saveAsTemplate" class="col-lg-2 control-label">
+        <label for="saveAsTemplate" class="col-lg-2 col-form-label">
             <?=$this->getTrans('saveAsTemplate') ?>:
         </label>
         <div class="col-xl-4">
@@ -178,7 +178,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('image') ? 'has-error' : '' ?>">
-        <label for="selectedImage" class="col-lg-2 control-label">
+        <label for="selectedImage" class="col-lg-2 col-form-label">
             <?=$this->getTrans('image') ?>:
         </label>
         <div class="col-xl-4">
@@ -193,7 +193,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3">
-        <label for="imageSource" class="col-lg-2 control-label">
+        <label for="imageSource" class="col-lg-2 col-form-label">
             <?=$this->getTrans('imageSource') ?>:
         </label>
         <div class="col-xl-4">
@@ -205,7 +205,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3">
-        <label for="preview" class="col-lg-2 control-label">
+        <label for="preview" class="col-lg-2 col-form-label">
             <?=$this->getTrans('preview') ?>:
         </label>
         <div class="col-xl-4">
@@ -214,7 +214,7 @@ if ($this->get('article')) {
     </div>
     <h1><?=$this->getTrans('seo') ?></h1>
     <div class="row mb-3">
-        <label for="description" class="col-lg-2 control-label">
+        <label for="description" class="col-lg-2 col-form-label">
             <?=$this->getTrans('seoDescription') ?>:
         </label>
         <div class="col-xl-4">
@@ -224,7 +224,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3">
-        <label for="keywords" class="col-lg-2 control-label">
+        <label for="keywords" class="col-lg-2 col-form-label">
             <?=$this->getTrans('seoKeywords') ?>:
         </label>
         <div class="col-xl-4">
@@ -234,7 +234,7 @@ if ($this->get('article')) {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('permaLink') ? 'has-error' : '' ?>">
-        <label for="permaLink" class="col-lg-2 control-label">
+        <label for="permaLink" class="col-lg-2 col-form-label">
             <?=$this->getTrans('permaLink') ?>:
         </label>
         <div class="col-xl-8">

--- a/application/modules/article/views/admin/settings/index.php
+++ b/application/modules/article/views/admin/settings/index.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('articlesPerPage') ? 'has-error' : '' ?>">
-        <label for="articlesPerPageInput" class="col-lg-2 control-label">
+        <label for="articlesPerPageInput" class="col-lg-2 col-form-label">
             <?=$this->getTrans('articlesPerPage') ?>
         </label>
         <div class="col-lg-1">
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('articleRating') ? 'has-error' : '' ?>">
-        <div class="col-lg-2 control-label">
+        <div class="col-lg-2 col-form-label">
             <?=$this->getTrans('articleRating') ?>
         </div>
         <div class="col-lg-4">
@@ -29,7 +29,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('disableComments') ? 'has-error' : '' ?>">
-        <div class="col-lg-2 control-label">
+        <div class="col-lg-2 col-form-label">
             <?=$this->getTrans('disableComments') ?>
         </div>
         <div class="col-lg-4">
@@ -46,7 +46,7 @@
     <h2><?=$this->getTrans('boxSettings') ?></h2>
     <b><?=$this->getTrans('boxArticle') ?></b>
     <div class="row mb-3 <?=$this->validation()->hasError('boxArticleLimit') ? 'has-error' : '' ?>">
-        <label for="boxArticleLimit" class="col-lg-2 control-label">
+        <label for="boxArticleLimit" class="col-lg-2 col-form-label">
             <?=$this->getTrans('boxArticleLimit') ?>
         </label>
         <div class="col-lg-1">
@@ -60,7 +60,7 @@
     </div>
     <b><?=$this->getTrans('boxArchive') ?></b>
     <div class="row mb-3 <?=$this->validation()->hasError('boxArchiveLimit') ? 'has-error' : '' ?>">
-        <label for="boxArchiveLimit" class="col-lg-2 control-label">
+        <label for="boxArchiveLimit" class="col-lg-2 col-form-label">
             <?=$this->getTrans('boxArchiveLimit') ?>
         </label>
         <div class="col-lg-1">
@@ -74,7 +74,7 @@
     </div>
     <b><?=$this->getTrans('boxKeywords') ?></b>
     <div class="row mb-3 <?=$this->validation()->hasError('boxKeywordsH2') ? 'has-error' : '' ?>">
-        <label for="boxKeywordsH2" class="col-lg-2 control-label">
+        <label for="boxKeywordsH2" class="col-lg-2 col-form-label">
             <?=$this->getTrans('boxKeywordsH2') ?>
         </label>
         <div class="col-lg-1">
@@ -88,7 +88,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('boxKeywordsH3') ? 'has-error' : '' ?>">
-        <label for="boxKeywordsH3" class="col-lg-2 control-label">
+        <label for="boxKeywordsH3" class="col-lg-2 col-form-label">
             <?=$this->getTrans('boxKeywordsH3') ?>
         </label>
         <div class="col-lg-1">
@@ -102,7 +102,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('boxKeywordsH4') ? 'has-error' : '' ?>">
-        <label for="boxKeywordsH4" class="col-lg-2 control-label">
+        <label for="boxKeywordsH4" class="col-lg-2 col-form-label">
             <?=$this->getTrans('boxKeywordsH4') ?>
         </label>
         <div class="col-lg-1">
@@ -116,7 +116,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('boxKeywordsH5') ? 'has-error' : '' ?>">
-        <label for="boxKeywordsH5" class="col-lg-2 control-label">
+        <label for="boxKeywordsH5" class="col-lg-2 col-form-label">
             <?=$this->getTrans('boxKeywordsH5') ?>
         </label>
         <div class="col-lg-1">

--- a/application/modules/article/views/admin/templates/treat.php
+++ b/application/modules/article/views/admin/templates/treat.php
@@ -8,7 +8,7 @@ if ($this->get('article') != '') {
 <form id="article_form" method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('teaser') ? 'has-error' : '' ?>">
-        <label for="teaser" class="col-xl-2 control-label">
+        <label for="teaser" class="col-xl-2 col-form-label">
             <?=$this->getTrans('teaser') ?>:
         </label>
         <div class="col-xl-4">
@@ -20,7 +20,7 @@ if ($this->get('article') != '') {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>:
         </label>
         <div class="col-xl-4">
@@ -41,7 +41,7 @@ if ($this->get('article') != '') {
     </div>
     <?php if ($this->get('multilingual')): ?>
         <div class="row mb-3">
-            <label for="language" class="col-xl-2 control-label">
+            <label for="language" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('language') ?>:
             </label>
             <div class="col-xl-8">
@@ -66,7 +66,7 @@ if ($this->get('article') != '') {
     <?php endif; ?>
     <h1><?=$this->getTrans('options') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('image') ? 'has-error' : '' ?>">
-        <label for="selectedImage" class="col-xl-2 control-label">
+        <label for="selectedImage" class="col-xl-2 col-form-label">
             <?=$this->getTrans('image') ?>:
         </label>
         <div class="col-xl-4">
@@ -81,7 +81,7 @@ if ($this->get('article') != '') {
         </div>
     </div>
     <div class="row mb-3">
-        <label for="imageSource" class="col-xl-2 control-label">
+        <label for="imageSource" class="col-xl-2 col-form-label">
             <?=$this->getTrans('imageSource') ?>:
         </label>
         <div class="col-xl-4">
@@ -94,7 +94,7 @@ if ($this->get('article') != '') {
     </div>
     <h1><?=$this->getTrans('seo') ?></h1>
     <div class="row mb-3">
-        <label for="description" class="col-xl-2 control-label">
+        <label for="description" class="col-xl-2 col-form-label">
             <?=$this->getTrans('seoDescription') ?>:
         </label>
         <div class="col-xl-4">
@@ -104,7 +104,7 @@ if ($this->get('article') != '') {
         </div>
     </div>
     <div class="row mb-3">
-        <label for="keywords" class="col-xl-2 control-label">
+        <label for="keywords" class="col-xl-2 col-form-label">
             <?=$this->getTrans('seoKeywords') ?>:
         </label>
         <div class="col-xl-4">
@@ -114,7 +114,7 @@ if ($this->get('article') != '') {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('permaLink') ? 'has-error' : '' ?>">
-        <label for="permaLink" class="col-xl-2 control-label">
+        <label for="permaLink" class="col-xl-2 col-form-label">
             <?=$this->getTrans('permaLink') ?>:
         </label>
         <div class="col-xl-8">

--- a/application/modules/awards/views/admin/index/treat.php
+++ b/application/modules/awards/views/admin/index/treat.php
@@ -15,7 +15,7 @@ if ($awards != '') {
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName(), 'id' => $this->getRequest()->getParam('id')]) ?>">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('date') ? 'has-error' : '' ?>">
-        <label for="date" class="col-xl-2 control-label">
+        <label for="date" class="col-xl-2 col-form-label">
             <?=$this->getTrans('date') ?>:
         </label>
         <div id="date" class="col-xl-2 input-group ilch-date date form_datetime">
@@ -31,7 +31,7 @@ if ($awards != '') {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('rank') ? 'has-error' : '' ?>">
-        <label for="rank" class="col-xl-2 control-label">
+        <label for="rank" class="col-xl-2 col-form-label">
             <?=$this->getTrans('rank') ?>:
         </label>
         <div class="col-xl-1">
@@ -45,7 +45,7 @@ if ($awards != '') {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('image') ? 'has-error' : '' ?>">
-        <label for="selectedImage" class="col-xl-2 control-label">
+        <label for="selectedImage" class="col-xl-2 col-form-label">
             <?=$this->getTrans('image') ?>:
         </label>
         <div class="col-xl-4">
@@ -66,7 +66,7 @@ if ($awards != '') {
         </div>
     </div>
     <div class="row mb-3 <?=($this->validation()->hasError('typ') || $this->validation()->hasError('utId')) ? 'has-error' : '' ?>">
-        <label for="user" class="col-xl-2 control-label">
+        <label for="user" class="col-xl-2 col-form-label">
             <?=$this->getTrans('userTeam') ?>:
         </label>
         <div class="col-xl-2">
@@ -113,7 +113,7 @@ if ($awards != '') {
         </div>
     </div>
     <div class="row mb-3 <?=($this->validation()->hasError('event')) ? 'has-error' : '' ?>">
-        <label for="event" class="col-xl-2 control-label">
+        <label for="event" class="col-xl-2 col-form-label">
             <?=$this->getTrans('event') ?>:
         </label>
         <div class="col-xl-4">
@@ -125,7 +125,7 @@ if ($awards != '') {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('page') ? 'has-error' : '' ?>">
-        <label for="page" class="col-xl-2 control-label">
+        <label for="page" class="col-xl-2 col-form-label">
             <?=$this->getTrans('page') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/away/views/admin/settings/index.php
+++ b/application/modules/away/views/admin/settings/index.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('adminNotification') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('adminNotification') ?>
         </div>
         <div class="col-xl-4">
@@ -16,7 +16,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('userNotification') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('userNotification') ?>
         </div>
         <div class="col-xl-4">
@@ -30,7 +30,7 @@
         </div>
     </div>
     <div id="notifyGroupsDiv" class="row mb-3 <?=$this->validation()->hasError('notifyGroups') ? 'has-error' : '' ?>" <?=($this->get('userNotification') !== '1') ? 'hidden' : '' ?>>
-        <label for="notifyGroups" class="col-xl-2 control-label">
+        <label for="notifyGroups" class="col-xl-2 col-form-label">
             <?=$this->getTrans('notifyGroups') ?>
         </label>
         <div class="col-xl-4">

--- a/application/modules/away/views/index/index.php
+++ b/application/modules/away/views/index/index.php
@@ -111,7 +111,7 @@ if ($this->getUser()) {
         <h1><?=$this->getTrans('menuEntry') ?></h1>
 
         <div class="row mb-3 <?=in_array('reason', $this->get('errorFields')) ? 'has-error' : '' ?>">
-            <label for="reason" class="col-xl-2 control-label">
+            <label for="reason" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('reason') ?>:
             </label>
             <div class="col-xl-6">
@@ -123,7 +123,7 @@ if ($this->getUser()) {
             </div>
         </div>
         <div class="row mb-3 <?=in_array('when', $this->get('errorFields')) ? 'has-error' : '' ?>">
-            <label for="start" class="col-xl-2 control-label">
+            <label for="start" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('when') ?>:
             </label>
             <div id="start" class="col-xl-3 input-group ilch-date date form_datetime float-start">
@@ -150,7 +150,7 @@ if ($this->getUser()) {
             </div>
         </div>
         <div class="row mb-3 <?=in_array('text', $this->get('errorFields')) ? 'has-error' : '' ?>">
-            <label for="text" class="col-xl-2 control-label">
+            <label for="text" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('description') ?>:
             </label>
             <div class="col-xl-6">

--- a/application/modules/birthday/views/admin/index/index.php
+++ b/application/modules/birthday/views/admin/index/index.php
@@ -5,7 +5,7 @@
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('numberOfBirthdaysShow') ? 'has-error' : '' ?>">
-        <label for="numberOfBirthdaysShow" class="col-xl-2 control-label">
+        <label for="numberOfBirthdaysShow" class="col-xl-2 col-form-label">
             <?=$this->getTrans('numberOfBirthdaysShow') ?>:
         </label>
         <div class="col-xl-1">
@@ -18,7 +18,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('visibleForGuest') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('visibleForGuest') ?>:
         </div>
         <div class="col-xl-2">

--- a/application/modules/calendar/views/admin/index/treat.php
+++ b/application/modules/calendar/views/admin/index/treat.php
@@ -37,7 +37,7 @@ $entry = $this->get('calendar');
         <?=($entry->getId()) ? $this->getTrans('edit') : $this->getTrans('add') ?>
     </h1>
     <div class="row mb-3 <?=$this->validation()->hasError('start') ? ' has-error' : '' ?>">
-        <label for="start" class="col-xl-2 control-label">
+        <label for="start" class="col-xl-2 col-form-label">
             <?=$this->getTrans('start') ?>:
         </label>
         <div id="start" class="col-xl-4 input-group ilch-date date form_datetime_1">
@@ -53,7 +53,7 @@ $entry = $this->get('calendar');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('end') ? ' has-error' : '' ?>">
-        <label for="end" class="col-xl-2 control-label">
+        <label for="end" class="col-xl-2 col-form-label">
             <?=$this->getTrans('end') ?>:
         </label>
         <div id="end" class="col-xl-4 input-group ilch-date date form_datetime_2">
@@ -68,7 +68,7 @@ $entry = $this->get('calendar');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>:
         </label>
         <div class="col-xl-4">
@@ -80,7 +80,7 @@ $entry = $this->get('calendar');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('place') ? ' has-error' : '' ?>">
-        <label for="place" class="col-xl-2 control-label">
+        <label for="place" class="col-xl-2 col-form-label">
             <?=$this->getTrans('place') ?>:
         </label>
         <div class="col-xl-4">
@@ -92,7 +92,7 @@ $entry = $this->get('calendar');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('periodType') ? ' has-error' : '' ?>">
-        <label for="periodType" class="col-xl-2 control-label">
+        <label for="periodType" class="col-xl-2 col-form-label">
             <?=$this->getTrans('periodEntry') ?>:
         </label>
         <div class="col-xl-4">
@@ -106,7 +106,7 @@ $entry = $this->get('calendar');
     </div>
     <div class="<?=$this->validation()->hasError('periodDays') ? ' has-error' : '' ?>" id="periodDays_div">
       <div class="row mb-3">
-        <label for="periodDays" class="col-xl-2 control-label"></label>
+        <label for="periodDays" class="col-xl-2 col-form-label"></label>
         <div class="col-xl-4">
             <select class="form-select" name="periodDays" id="periodDays">
                 <option value="0" <?=($this->originalInput('periodDay', ($entry->getId()?$entry->getPeriodDay():'0'))) == '0' ? 'selected=""' : '' ?>><?=$this->getTrans('noPeriodEntry') ?></option>
@@ -119,7 +119,7 @@ $entry = $this->get('calendar');
     </div>
     <div class="<?=$this->validation()->hasError('periodDay') ? ' has-error' : '' ?>" id="periodDay_div">
       <div class="row mb-3">
-        <label for="periodDay" class="col-xl-2 control-label"></label>
+        <label for="periodDay" class="col-xl-2 col-form-label"></label>
         <div class="col-xl-4 input-group">
             <span class="input-group-text"><?=$this->getTrans('periodEvery') ?></span>
             <input type="text"
@@ -134,7 +134,7 @@ $entry = $this->get('calendar');
 
     <div class="<?=$this->validation()->hasError('repeatUntil') ? ' has-error' : '' ?>" id="repeatUntil_div">
       <div class="row mb-3">
-        <label for="repeatUntil" class="col-xl-2 control-label">
+        <label for="repeatUntil" class="col-xl-2 col-form-label">
             <?=$this->getTrans('repeatUntil') ?>:
         </label>
         <div id="repeatUntil" class="col-xl-4 input-group ilch-date date form_datetime_3">
@@ -152,7 +152,7 @@ $entry = $this->get('calendar');
     </div>
 
     <div class="row mb-3<?=$this->validation()->hasError('color') ? ' has-error' : '' ?>">
-        <label for="color" class="col-xl-2 control-label">
+        <label for="color" class="col-xl-2 col-form-label">
             <?=$this->getTrans('color') ?>:
         </label>
         <div class="col-xl-4 input-group date">
@@ -166,7 +166,7 @@ $entry = $this->get('calendar');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('groups') ? ' has-error' : '' ?>">
-        <label for="access" class="col-xl-2 control-label">
+        <label for="access" class="col-xl-2 col-form-label">
             <?=$this->getTrans('visibleFor') ?>
         </label>
         <div class="col-xl-4">
@@ -181,7 +181,7 @@ $entry = $this->get('calendar');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('text') ? ' has-error' : '' ?>">
-        <label for="ck_1" class="col-xl-2 control-label">
+        <label for="ck_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('text') ?>:
         </label>
         <div class="col-xl-10">

--- a/application/modules/checkoutbasic/views/admin/currency/treat.php
+++ b/application/modules/checkoutbasic/views/admin/currency/treat.php
@@ -12,7 +12,7 @@ $currency = $this->get('currency');
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>
         </label>
         <div class="col-xl-4">

--- a/application/modules/checkoutbasic/views/admin/index/index.php
+++ b/application/modules/checkoutbasic/views/admin/index/index.php
@@ -12,7 +12,7 @@ $checkouts = $this->get('checkout');
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
     <div class="row mb-3<?=$this->validation()->hasError('name') ? ' has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>
         </label>
         <div class="col-xl-4">
@@ -25,7 +25,7 @@ $checkouts = $this->get('checkout');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('checkoutdate') ? ' has-error' : '' ?>">
-        <label for="datetime" class="col-xl-2 control-label">
+        <label for="datetime" class="col-xl-2 col-form-label">
             <?=$this->getTrans('datetime') ?>
         </label>
         <div class="col-xl-4">
@@ -38,7 +38,7 @@ $checkouts = $this->get('checkout');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('usage') ? ' has-error' : '' ?>">
-        <label for="usage" class="col-xl-2 control-label">
+        <label for="usage" class="col-xl-2 col-form-label">
             <?=$this->getTrans('usage') ?>
         </label>
         <div class="col-xl-4">
@@ -51,7 +51,7 @@ $checkouts = $this->get('checkout');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('amount') ? ' has-error' : '' ?>">
-        <label for="amount" class="col-xl-2 control-label">
+        <label for="amount" class="col-xl-2 col-form-label">
             <?=$this->getTrans('amount') ?>
         </label>
         <div class="col-xl-4">

--- a/application/modules/checkoutbasic/views/admin/index/settings.php
+++ b/application/modules/checkoutbasic/views/admin/index/settings.php
@@ -12,7 +12,7 @@
                   name="checkoutContact"><?=$this->get('checkoutContact') ?></textarea>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('checkoutCurrency') ? 'has-error' : '' ?>">
-        <label for="checkoutCurrency" class="control-label col-xl-2">
+        <label for="checkoutCurrency" class="col-form-label col-xl-2">
             <?=$this->getTrans('checkoutCurrency') ?>:
         </label>
         <div class="col-2">

--- a/application/modules/checkoutbasic/views/admin/index/treatPayment.php
+++ b/application/modules/checkoutbasic/views/admin/index/treatPayment.php
@@ -10,7 +10,7 @@ $checkout = $this->get('checkout');
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3<?=$this->validation()->hasError('name') ? ' has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>
         </label>
         <div class="col-xl-4">
@@ -23,7 +23,7 @@ $checkout = $this->get('checkout');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('datetime') ? ' has-error' : '' ?>">
-        <label for="datetime" class="col-xl-2 control-label">
+        <label for="datetime" class="col-xl-2 col-form-label">
             <?=$this->getTrans('datetime') ?>
         </label>
         <div class="col-xl-4">
@@ -36,7 +36,7 @@ $checkout = $this->get('checkout');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('usage') ? ' has-error' : '' ?>">
-        <label for="usage" class="col-xl-2 control-label">
+        <label for="usage" class="col-xl-2 col-form-label">
             <?=$this->getTrans('usage') ?>
         </label>
         <div class="col-xl-4">
@@ -49,7 +49,7 @@ $checkout = $this->get('checkout');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('amount') ? ' has-error' : '' ?>">
-        <label for="amount" class="col-xl-2 control-label">
+        <label for="amount" class="col-xl-2 col-form-label">
             <?=$this->getTrans('amount') ?>
         </label>
         <div class="col-xl-4">

--- a/application/modules/comment/views/admin/settings/index.php
+++ b/application/modules/comment/views/admin/settings/index.php
@@ -6,7 +6,7 @@
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('reply') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('acceptReply') ?>:
         </div>
         <div class="col-xl-4">
@@ -20,7 +20,7 @@
          </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('nesting') ? 'has-error' : '' ?>">
-        <label for="nesting" class="col-xl-2 control-label">
+        <label for="nesting" class="col-xl-2 col-form-label">
             <?=$this->getTrans('nesting') ?>:
         </label>
         <div class="col-xl-1">
@@ -33,7 +33,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="floodIntervalInput" class="col-xl-2 control-label">
+        <label for="floodIntervalInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('floodInterval') ?>:
         </label>
         <div class="col-xl-1">
@@ -46,7 +46,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="excludeFloodProtection" class="col-xl-2 control-label">
+        <label for="excludeFloodProtection" class="col-xl-2 col-form-label">
             <?=$this->getTrans('excludeFloodProtection') ?>:
         </label>
         <div class="col-xl-4">
@@ -76,7 +76,7 @@
     </div>
     <h2><?=$this->getTrans('boxSettings') ?></h2>
     <div class="row mb-3">
-        <label for="boxCommentsLimit" class="col-xl-2 control-label">
+        <label for="boxCommentsLimit" class="col-xl-2 col-form-label">
             <?=$this->getTrans('boxCommentsLimit') ?>
         </label>
         <div class="col-xl-1">

--- a/application/modules/contact/views/admin/index/treat.php
+++ b/application/modules/contact/views/admin/index/treat.php
@@ -10,7 +10,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>:
         </label>
         <div class="col-xl-2">
@@ -22,7 +22,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
-        <label for="email" class="col-xl-2 control-label">
+        <label for="email" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('email') ?>:
         </label>
         <div class="col-xl-2">

--- a/application/modules/contact/views/admin/settings/index.php
+++ b/application/modules/contact/views/admin/settings/index.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?= $this->validation()->hasError('welcomeMessage') ? 'has-error' : '' ?>">
-        <label for="ck_1" class="col-xl-2 control-label">
+        <label for="ck_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('welcomeMessage') ?>:
         </label>
         <div class="col-xl-8">

--- a/application/modules/contact/views/index/index.php
+++ b/application/modules/contact/views/index/index.php
@@ -8,7 +8,7 @@
     <form id="contactForm" name="contactForm" method="POST">
         <?=$this->getTokenField() ?>
         <div class="row mb-3 d-none">
-            <label class="col-xl-2 control-label">
+            <label class="col-xl-2 col-form-label">
                 <?=$this->getTrans('bot') ?>*
             </label>
             <div class="col-xl-8">
@@ -19,7 +19,7 @@
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('receiver') ? 'has-error' : '' ?>">
-            <label for="receiver" class="col-xl-2 control-label">
+            <label for="receiver" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('receiver') ?>
             </label>
             <div class="col-xl-8">
@@ -31,7 +31,7 @@
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('senderName') ? 'has-error' : '' ?>">
-            <label for="name" class="col-xl-2 control-label">
+            <label for="name" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('name') ?>
             </label>
             <div class="col-xl-8">
@@ -43,7 +43,7 @@
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('senderEmail') ? 'has-error' : '' ?>">
-            <label for="email" class="col-xl-2 control-label">
+            <label for="email" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('email') ?>
             </label>
             <div class="col-xl-8">
@@ -55,7 +55,7 @@
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('message') ? 'has-error' : '' ?>">
-            <label for="message" class="col-xl-2 control-label">
+            <label for="message" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('message') ?>
             </label>
             <div class="col-xl-8">

--- a/application/modules/cookieconsent/views/admin/index/index.php
+++ b/application/modules/cookieconsent/views/admin/index/index.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('cookieConsent') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('cookieConsentShow') ?>:
         </div>
         <div class="col-xl-2">
@@ -16,7 +16,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('cookieConsentLayout') ? 'has-error' : '' ?>">
-        <label for="cookieConsentLayout" class="col-xl-2 control-label">
+        <label for="cookieConsentLayout" class="col-xl-2 col-form-label">
             <?=$this->getTrans('cookieConsentLayout') ?>:
         </label>
         <div class="col-xl-2">
@@ -28,7 +28,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('cookieConsentPos') ? 'has-error' : '' ?>">
-        <label for="cookieConsentPos" class="col-xl-2 control-label">
+        <label for="cookieConsentPos" class="col-xl-2 col-form-label">
             <?=$this->getTrans('cookieConsentPos') ?>:
         </label>
         <div class="col-xl-2">
@@ -41,7 +41,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('cookieConsentType') ? 'has-error' : '' ?>">
-        <label for="cookieConsentType" class="col-xl-2 control-label">
+        <label for="cookieConsentType" class="col-xl-2 col-form-label">
             <?=$this->getTrans('cookieConsentType') ?>:
         </label>
         <div class="col-xl-2">
@@ -55,7 +55,7 @@
 
     <h1><?=$this->getTrans('cookieConsentPopUp') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('cookieConsentPopUpBGColor') ? 'has-error' : '' ?>">
-        <label for="color" class="col-xl-2 control-label">
+        <label for="color" class="col-xl-2 col-form-label">
             <?=$this->getTrans('cookieConsentPopUpBGColor') ?>:
         </label>
         <div class="col-xl-2 input-group ilch-date">
@@ -69,7 +69,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('cookieConsentPopUpTextColor') ? 'has-error' : '' ?>">
-        <label for="color" class="col-xl-2 control-label">
+        <label for="color" class="col-xl-2 col-form-label">
             <?=$this->getTrans('cookieConsentPopUpTextColor') ?>:
         </label>
         <div class="col-xl-2 input-group ilch-date">
@@ -85,7 +85,7 @@
 
     <h1><?=$this->getTrans('cookieConsentBtn') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('cookieConsentBtnBGColor') ? 'has-error' : '' ?>">
-        <label for="color" class="col-xl-2 control-label">
+        <label for="color" class="col-xl-2 col-form-label">
             <?=$this->getTrans('cookieConsentBtnBGColor') ?>:
         </label>
         <div class="col-xl-2 input-group ilch-date">
@@ -99,7 +99,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('cookieConsentBtnTextColor') ? 'has-error' : '' ?>">
-        <label for="color" class="col-xl-2 control-label">
+        <label for="color" class="col-xl-2 col-form-label">
             <?=$this->getTrans('cookieConsentBtnTextColor') ?>:
         </label>
         <div class="col-xl-2 input-group ilch-date">

--- a/application/modules/downloads/views/admin/file/treatfile.php
+++ b/application/modules/downloads/views/admin/file/treatfile.php
@@ -21,7 +21,7 @@ if ($file->getFileImage() != '') {
                 <div class="col-lg-8">
                     <?=$this->getTokenField() ?>
                     <div class="row mb-3">
-                        <label for="fileTitleInput" class="col-lg-2 control-label">
+                        <label for="fileTitleInput" class="col-lg-2 col-form-label">
                             <?=$this->getTrans('fileTitle') ?>:
                         </label>
                         <div class="col-xl-8">
@@ -33,7 +33,7 @@ if ($file->getFileImage() != '') {
                         </div>
                     </div>
                     <div class="row mb-3">
-                        <label for="selectedImage" class="col-xl-2 control-label">
+                        <label for="selectedImage" class="col-xl-2 col-form-label">
                             <?=$this->getTrans('fileImage') ?>:
                         </label>
                         <div class="col-xl-8">
@@ -49,7 +49,7 @@ if ($file->getFileImage() != '') {
                         </div>
                     </div>
                     <div class="row mb-3">
-                        <label for="fileDescInput" class="col-xl-2 control-label">
+                        <label for="fileDescInput" class="col-xl-2 col-form-label">
                             <?=$this->getTrans('fileDesc') ?>:
                         </label>
                         <div class="col-xl-8">

--- a/application/modules/downloads/views/admin/index/index.php
+++ b/application/modules/downloads/views/admin/index/index.php
@@ -72,7 +72,7 @@ function rec($item, $downloadsMapper, $obj, $fileMapper)
         <div class="col-xl-6 changeBox">
             <input type="hidden" id="id" value="" />
             <div class="row mb-3">
-                <label for="title" class="col-xl-3 control-label">
+                <label for="title" class="col-xl-3 col-form-label">
                     <?=$this->getTrans('title') ?>
                 </label>
                 <div class="col-xl-6">
@@ -80,7 +80,7 @@ function rec($item, $downloadsMapper, $obj, $fileMapper)
                 </div>
             </div>
             <div class="row mb-3">
-                <label for="desc" class="col-xl-3 control-label">
+                <label for="desc" class="col-xl-3 col-form-label">
                     <?=$this->getTrans('description') ?>
                 </label>
                 <div class="col-xl-6">
@@ -92,7 +92,7 @@ function rec($item, $downloadsMapper, $obj, $fileMapper)
                 </div>
             </div>
             <div class="row mb-3">
-                <label for="type" class="col-xl-3 control-label">
+                <label for="type" class="col-xl-3 col-form-label">
                     <?=$this->getTrans('type') ?>
                 </label>
                 <div class="col-xl-6">
@@ -104,7 +104,7 @@ function rec($item, $downloadsMapper, $obj, $fileMapper)
             </div>
             <div class="dyn"></div>
             <div class="row mb-3">
-                <label class="col-xl-3 control-label"></label>
+                <label class="col-xl-3 col-form-label"></label>
                 <div class="col-xl-6 actions">
                     <input type="button" class="btn btn-outline-secondary" id="menuItemAdd" value="<?=$this->getTrans('downloadsItemAdd') ?>">
                 </div>
@@ -175,7 +175,7 @@ $(document).ready (
                 return;
             }
 
-            const menuHtml = '<div class="row mb-3"><label for="href" class="col-xl-3 control-label"><?=$this->getTrans('cat') ?></label>\n\
+            const menuHtml = '<div class="row mb-3"><label for="href" class="col-xl-3 col-form-label"><?=$this->getTrans('cat') ?></label>\n\
                               <div class="col-xl-6"><select class="form-select" id="menukey">'+options+'</select></div></div>';
 
             if ($(this).val() == '0') {

--- a/application/modules/downloads/views/admin/settings/index.php
+++ b/application/modules/downloads/views/admin/settings/index.php
@@ -3,7 +3,7 @@
     <div class="row">
         <?=$this->getTokenField() ?>
         <div class="row mb-3">
-            <label for="downloadsPerPageInput" class="col-xl-2 control-label">
+            <label for="downloadsPerPageInput" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('downloadsPerPage') ?>:
             </label>
             <div class="col-xl-1">
@@ -16,7 +16,7 @@
             </div>
         </div>
         <div class="row mb-3">
-            <label class="col-xl-2 control-label"></label>
+            <label class="col-xl-2 col-form-label"></label>
             <div class="col-xl-6">
                 <a class="btn btn-outline-secondary" href="<?=$this->getUrl(['module' => 'media', 'controller' => 'settings', 'action' => 'index'], 'admin') ?>"><?=$this->getTrans('moreSettings') ?></a>
             </div>

--- a/application/modules/events/views/admin/settings/index.php
+++ b/application/modules/events/views/admin/settings/index.php
@@ -4,7 +4,7 @@
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3">
-        <label for="event_add_entries_accesses" class="col-xl-2 control-label">
+        <label for="event_add_entries_accesses" class="col-xl-2 col-form-label">
             <?=$this->getTrans('addEntriesGroupAccesses') ?>
         </label>
         <div class="col-xl-3">
@@ -32,7 +32,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="event_show_members_accesses" class="col-xl-2 control-label">
+        <label for="event_show_members_accesses" class="col-xl-2 col-form-label">
             <?=$this->getTrans('showEntryMembersAccesses') ?>
         </label>
         <div class="col-xl-3">
@@ -60,7 +60,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('event_upcoming_event_limit') ? 'has-error' : '' ?>">
-        <label for="event_upcoming_event_limit" class="col-xl-2 control-label">
+        <label for="event_upcoming_event_limit" class="col-xl-2 col-form-label">
             <?=$this->getTrans('upcomingEventLimit') ?>:
         </label>
         <div class="col-xl-1">
@@ -74,7 +74,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('event_current_event_limit') ? 'has-error' : '' ?>">
-        <label for="event_current_event_limit" class="col-xl-2 control-label">
+        <label for="event_current_event_limit" class="col-xl-2 col-form-label">
             <?=$this->getTrans('currentEventLimit') ?>:
         </label>
         <div class="col-xl-1">
@@ -88,7 +88,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('event_past_event_limit') ? 'has-error' : '' ?>">
-        <label for="event_past_event_limit" class="col-xl-2 control-label">
+        <label for="event_past_event_limit" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pastEventLimit') ?>:
         </label>
         <div class="col-xl-1">
@@ -102,7 +102,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('event_height') ? 'has-error' : '' ?>">
-        <label for="event_height" class="col-xl-2 control-label">
+        <label for="event_height" class="col-xl-2 col-form-label">
             <?=$this->getTrans('imageHeight') ?>:
         </label>
         <div class="col-xl-2">
@@ -116,7 +116,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('event_width') ? 'has-error' : '' ?>">
-        <label for="event_width" class="col-xl-2 control-label">
+        <label for="event_width" class="col-xl-2 col-form-label">
             <?=$this->getTrans('imageWidth') ?>:
         </label>
         <div class="col-xl-2">
@@ -130,7 +130,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('event_size') ? 'has-error' : '' ?>">
-        <label for="event_size" class="col-xl-2 control-label">
+        <label for="event_size" class="col-xl-2 col-form-label">
             <?=$this->getTrans('imageSizeBytes') ?>:
         </label>
         <div class="col-xl-2">
@@ -144,7 +144,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('event_filetypes') ? 'has-error' : '' ?>">
-        <label for="event_filetypes" class="col-xl-2 control-label">
+        <label for="event_filetypes" class="col-xl-2 col-form-label">
             <?=$this->getTrans('imageAllowedFileExtensions') ?>:
         </label>
         <div class="col-xl-2">
@@ -159,7 +159,7 @@
 
     <h1><?=$this->getTrans('menuGoogleMaps') ?></h1>
     <div class="row mb-3">
-        <label for="event_google_maps_api_key" class="col-xl-2 control-label">
+        <label for="event_google_maps_api_key" class="col-xl-2 col-form-label">
             <?=$this->getTrans('googleMapsAPIKey') ?>:
             <a class="badge rounded-pill bg-secondary" data-bs-toggle="modal" data-bs-target="#googleMapsAPIInfoModal">
                 <i class="fa-solid fa-info"></i>
@@ -174,7 +174,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('event_google_maps_map_typ') ? 'has-error' : '' ?>">
-        <label for="event_google_maps_map_typ" class="col-xl-2 control-label">
+        <label for="event_google_maps_map_typ" class="col-xl-2 col-form-label">
             <?=$this->getTrans('googleMapsMapTyp') ?>:
         </label>
         <div class="col-xl-2">
@@ -187,7 +187,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('event_google_maps_zoom') ? 'has-error' : '' ?>">
-        <label for="event_google_maps_zoom" class="col-xl-2 control-label">
+        <label for="event_google_maps_zoom" class="col-xl-2 col-form-label">
             <?=$this->getTrans('googleMapsZoom') ?>:
         </label>
         <div class="col-xl-1">
@@ -203,7 +203,7 @@
 
     <h1><?=$this->getTrans('menuBoxes') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('event_box_event_limit') ? 'has-error' : '' ?>">
-        <label for="event_box_event_limit" class="col-xl-2 control-label">
+        <label for="event_box_event_limit" class="col-xl-2 col-form-label">
             <?=$this->getTrans('boxEventLimit') ?>:
         </label>
         <div class="col-xl-1">

--- a/application/modules/events/views/index/treat.php
+++ b/application/modules/events/views/index/treat.php
@@ -18,7 +18,7 @@ $types = $this->get('types');
     <form method="POST" enctype="multipart/form-data" action="">
         <?=$this->getTokenField() ?>
         <div class="row mb-3">
-            <div class="col-xl-2 control-label"><?=$this->getTrans('image') ?></div>
+            <div class="col-xl-2 col-form-label"><?=$this->getTrans('image') ?></div>
             <div class="col-xl-10">
                 <?php if ($this->get('event') != '' && $this->escape($this->get('event')->getImage()) != ''): ?>
                     <div class="col-xl-7 col-md-7 col-7">
@@ -53,7 +53,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('creator') ? 'has-error' : '' ?>">
-            <label for="creator" class="col-xl-2 control-label">
+            <label for="creator" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('by') ?>
             </label>
             <div class="col-xl-4">
@@ -66,7 +66,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('start') ? 'has-error' : '' ?>">
-            <label for="start" class="col-lg-2 control-label">
+            <label for="start" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('startTime') ?>
             </label>
             <div id="start" class="col-xl-4 input-group ilch-date date form_datetime">
@@ -83,7 +83,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('end') ? 'has-error' : '' ?>">
-            <label for="end" class="col-lg-2 control-label">
+            <label for="end" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('endTime') ?>
             </label>
             <div id="end" class="col-xl-4 input-group ilch-date date form_datetime">
@@ -103,7 +103,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-            <label for="title" class="col-xl-2 control-label">
+            <label for="title" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('title') ?>
             </label>
             <div class="col-xl-6">
@@ -115,7 +115,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('place') ? 'has-error' : '' ?>">
-            <label for="place" class="col-xl-2 control-label">
+            <label for="place" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('place') ?>
             </label>
             <div class="col-xl-6">
@@ -127,7 +127,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('type') ? 'has-error' : '' ?>">
-            <label for="place" class="col-xl-2 control-label">
+            <label for="place" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('type') ?>
             </label>
             <div class="col-xl-6">
@@ -149,7 +149,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('website') ? 'has-error' : '' ?>">
-            <label for="website" class="col-xl-2 control-label">
+            <label for="website" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('website') ?>
             </label>
             <div class="col-xl-6">
@@ -162,7 +162,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-            <label for="ck_1" class="col-xl-2 control-label">
+            <label for="ck_1" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('text') ?>
             </label>
             <div class="col-xl-10">
@@ -174,7 +174,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('price') ? 'has-error' : '' ?>">
-            <label for="price" class="col-xl-2 control-label">
+            <label for="price" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('price') ?>
             </label>
             <div class="col-xl-2">
@@ -208,7 +208,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('userLimit') ? 'has-error' : '' ?>">
-            <label for="userLimit" class="col-xl-2 control-label">
+            <label for="userLimit" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('userLimit') ?> <div class="badge rounded-pill bg-secondary" data-bs-toggle="tooltip" data-bs-custom-class="custom-tooltip" data-bs-title="<?=$this->getTrans('userLimitInfo') ?>"><i class="fa-solid fa-info"></i></div>
             </label>
             <div class="col-xl-2">
@@ -222,7 +222,7 @@ $types = $this->get('types');
             </div>
         </div>
         <div class="row mb-3">
-            <label for="access" class="col-xl-2 control-label">
+            <label for="access" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('visibleFor') ?>
             </label>
             <div class="col-xl-6">

--- a/application/modules/faq/views/admin/cats/treat.php
+++ b/application/modules/faq/views/admin/cats/treat.php
@@ -12,7 +12,7 @@ $cat = $this->get('cat');
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>:
         </label>
         <div class="col-xl-3">
@@ -24,7 +24,7 @@ $cat = $this->get('cat');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('groups') ? 'has-error' : '' ?>">
-        <label for="access" class="col-xl-2 control-label">
+        <label for="access" class="col-xl-2 col-form-label">
             <?=$this->getTrans('visibleFor') ?>:
         </label>
         <div class="col-xl-3">

--- a/application/modules/faq/views/admin/index/treat.php
+++ b/application/modules/faq/views/admin/index/treat.php
@@ -16,7 +16,7 @@ $cats = $this->get('cats');
     <form method="POST" action="">
         <?=$this->getTokenField() ?>
         <div class="chosen-select row mb-3 <?=$this->validation()->hasError('catId') ? 'has-error' : '' ?>">
-            <label for="catId" class="col-xl-2 control-label">
+            <label for="catId" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('cat') ?>:
             </label>
             <div class="col-xl-2">
@@ -28,7 +28,7 @@ $cats = $this->get('cats');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('question') ? 'has-error' : '' ?>">
-            <label for="question" class="col-xl-2 control-label">
+            <label for="question" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('question') ?>:
             </label>
             <div class="col-xl-4">
@@ -40,7 +40,7 @@ $cats = $this->get('cats');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('answer') ? 'has-error' : '' ?>">
-            <label for="ck_1" class="col-xl-2 control-label">
+            <label for="ck_1" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('answer') ?>:
             </label>
             <div class="col-xl-10">

--- a/application/modules/faq/views/admin/settings/index.php
+++ b/application/modules/faq/views/admin/settings/index.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('sortCategoriesAlphabetically') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('sortCategoriesAlphabetically') ?>
         </div>
         <div class="col-xl-4">
@@ -16,7 +16,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('sortQuestionsAlphabetically') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('sortQuestionsAlphabetically') ?>
         </div>
         <div class="col-xl-4">

--- a/application/modules/forum/static/css/forum.css
+++ b/application/modules/forum/static/css/forum.css
@@ -626,7 +626,7 @@ legend .forum.fa {
     margin-left: 0;
     margin-right: 0;
 }
-#editRememberedPost .form-group .control-label {
+#editRememberedPost .form-group {
     text-align: left;
 }
 

--- a/application/modules/forum/views/admin/index/index.php
+++ b/application/modules/forum/views/admin/index/index.php
@@ -64,7 +64,7 @@ function rec(ForumItem $item, \Ilch\View $obj)
     <div class="col-xl-6 changeBox">
         <input type="hidden" id="id" value="" />
         <div class="row mb-3">
-            <label for="title" class="col-xl-3 control-label">
+            <label for="title" class="col-xl-3 col-form-label">
                 <?=$this->getTrans('title') ?>
             </label>
             <div class="col-xl-6">
@@ -72,7 +72,7 @@ function rec(ForumItem $item, \Ilch\View $obj)
             </div>
         </div>
         <div class="row mb-3">
-            <label for="desc" class="col-xl-3 control-label">
+            <label for="desc" class="col-xl-3 col-form-label">
                 <?=$this->getTrans('description') ?>
             </label>
             <div class="col-xl-6">
@@ -84,7 +84,7 @@ function rec(ForumItem $item, \Ilch\View $obj)
             </div>
         </div>
         <div class="row mb-3">
-            <label for="type" class="col-xl-3 control-label">
+            <label for="type" class="col-xl-3 col-form-label">
                 <?=$this->getTrans('type') ?>
             </label>
             <div class="col-xl-6">
@@ -96,7 +96,7 @@ function rec(ForumItem $item, \Ilch\View $obj)
         </div>
         <div class="dyn"></div>
         <div class="row mb-3">
-            <label class="col-xl-3 control-label"></label>
+            <label class="col-xl-3 col-form-label"></label>
             <div class="col-xl-6 actions">
                 <input type="button" class="btn btn-outline-secondary" id="menuItemAdd" value="<?=$this->getTrans('forumItemAdd') ?>">
             </div>
@@ -166,25 +166,25 @@ $(document).ready (
                 return;
             }
 
-            menuHtml = '<div class="row mb-3"><label for="menukey" class="col-xl-3 control-label"><?=$this->getTrans('menuSelection') ?></label>\n\
+            menuHtml = '<div class="row mb-3"><label for="menukey" class="col-xl-3 col-form-label"><?=$this->getTrans('menuSelection') ?></label>\n\
                         <div class="col-xl-6"><select class="form-select" id="menukey">'+options+'</select></div></div>\n\
-                        <div class="row mb-3"><label for="prefixes" class="col-xl-3 control-label"><?=$this->getTrans('prefixes') ?></label>\n\
+                        <div class="row mb-3"><label for="prefixes" class="col-xl-3 col-form-label"><?=$this->getTrans('prefixes') ?></label>\n\
                         <div class="col-xl-6"><input type="text" class="form-control" id="prefixes" placeholder="<?=$this->getTrans('selectPrefixes') ?>"></div></div>\n\
-                        <div class="row mb-3"><label for="assignedGroupsRead" class="col-xl-3 control-label"><?=$this->getTrans('see') ?></label>\n\
+                        <div class="row mb-3"><label for="assignedGroupsRead" class="col-xl-3 col-form-label"><?=$this->getTrans('see') ?></label>\n\
                         <div class="col-xl-6"><select class="chosen-select form-control" id="assignedGroupsRead" name="user[groups][]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>\n\
                         \n\
                         <?php foreach ($this->get('userGroupList') as $groupList) : ?>\n\
                         <option value="<?=$groupList->getId() ?>"><?=$this->escape($groupList->getName()) ?></option>\n\
                         <?php endforeach; ?>\n\
                         </select></div></div>\n\
-                        <div class="row mb-3"><label for="assignedGroupsReply" class="col-xl-3 control-label"><?=$this->getTrans('answer') ?></label>\n\
+                        <div class="row mb-3"><label for="assignedGroupsReply" class="col-xl-3 col-form-label"><?=$this->getTrans('answer') ?></label>\n\
                         <div class="col-xl-6"><select class="chosen-select form-control" id="assignedGroupsReply" name="user[groups][]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>\n\
                         \n\
                         <?php foreach ($this->get('userGroupList') as $groupList) : ?>\n\
                         <option value="<?=$groupList->getId() ?>"><?=$this->escape($groupList->getName()) ?></option>\n\
                         <?php endforeach; ?>\n\
                         </select></div></div>\n\
-                        <div class="row mb-3"><label for="assignedGroupsCreate" class="col-xl-3 control-label"><?=$this->getTrans('create') ?></label>\n\
+                        <div class="row mb-3"><label for="assignedGroupsCreate" class="col-xl-3 col-form-label"><?=$this->getTrans('create') ?></label>\n\
                         <div class="col-xl-6"><select class="chosen-select form-control" id="assignedGroupsCreate" name="user[groups][]" data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>" multiple>\n\
                         \n\
                         <?php foreach ($this->get('userGroupList') as $groupList) : ?>\n\

--- a/application/modules/forum/views/admin/prefixes/treat.php
+++ b/application/modules/forum/views/admin/prefixes/treat.php
@@ -6,7 +6,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="form-group <?=$this->validation()->hasError('prefix') ? 'has-error' : '' ?>">
-        <label for="prefix" class="col-lg-2 control-label">
+        <label for="prefix" class="col-lg-2 col-form-label">
             <?=$this->getTrans('prefix') ?>:
         </label>
         <div class="col-lg-2">

--- a/application/modules/forum/views/admin/ranks/treat.php
+++ b/application/modules/forum/views/admin/ranks/treat.php
@@ -6,7 +6,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>:
         </label>
         <div class="col-xl-2">
@@ -19,7 +19,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('posts') ? 'has-error' : '' ?>">
-        <label for="posts" class="col-xl-2 control-label">
+        <label for="posts" class="col-xl-2 col-form-label">
             <?=$this->getTrans('posts') ?>:
         </label>
         <div class="col-xl-2">

--- a/application/modules/forum/views/admin/reports/show.php
+++ b/application/modules/forum/views/admin/reports/show.php
@@ -16,7 +16,7 @@ $report = $this->get('report');
 <h1><?=$this->getTrans('report') ?></h1>
 <?php if (!empty($report)) : ?>
     <div class="row mb-3">
-        <label for="date" class="col-xl-2 control-label">
+        <label for="date" class="col-xl-2 col-form-label">
             <?=$this->getTrans('date') ?>:
         </label>
         <div class="col-xl-10">
@@ -25,7 +25,7 @@ $report = $this->get('report');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="reason" class="col-xl-2 control-label">
+        <label for="reason" class="col-xl-2 col-form-label">
             <?=$this->getTrans('reason') ?>:
         </label>
         <div class="col-xl-10">
@@ -33,7 +33,7 @@ $report = $this->get('report');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="details" class="col-xl-2 control-label">
+        <label for="details" class="col-xl-2 col-form-label">
             <?=$this->getTrans('details') ?>:
         </label>
         <div class="col-xl-10">
@@ -41,7 +41,7 @@ $report = $this->get('report');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="reporter" class="col-xl-2 control-label">
+        <label for="reporter" class="col-xl-2 col-form-label">
             <?=$this->getTrans('reporter') ?>:
         </label>
         <div class="col-xl-10">

--- a/application/modules/forum/views/admin/settings/index.php
+++ b/application/modules/forum/views/admin/settings/index.php
@@ -6,7 +6,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3">
-        <label for="threadsPerPageInput" class="col-xl-2 control-label">
+        <label for="threadsPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('threadsPerPage') ?>:
         </label>
         <div class="col-xl-1">
@@ -19,7 +19,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="postsPerPageInput" class="col-xl-2 control-label">
+        <label for="postsPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('postsPerPage') ?>:
         </label>
         <div class="col-xl-1">
@@ -32,7 +32,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="floodIntervalInput" class="col-xl-2 control-label">
+        <label for="floodIntervalInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('floodInterval') ?>:
         </label>
         <div class="col-xl-1">
@@ -45,7 +45,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="excludeFloodProtection" class="col-xl-2 control-label">
+        <label for="excludeFloodProtection" class="col-xl-2 col-form-label">
             <?=$this->getTrans('excludeFloodProtection') ?>:
         </label>
         <div class="col-xl-4">
@@ -75,7 +75,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('postVoting') ?>:
         </div>
         <div class="col-xl-4">
@@ -89,7 +89,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('topicSubscription') ?>:
         </div>
         <div class="col-xl-4">
@@ -103,7 +103,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('DESCPostorder') ?>:
         </div>
         <div class="col-xl-4">
@@ -118,7 +118,7 @@
     </div>
     <h2><?=$this->getTrans('boxSettings') ?></h2>
     <div class="row mb-3">
-        <label for="boxForumLimit" class="col-xl-2 control-label">
+        <label for="boxForumLimit" class="col-xl-2 col-form-label">
             <?=$this->getTrans('boxForumLimit') ?>
         </label>
         <div class="col-xl-1">
@@ -132,7 +132,7 @@
     </div>
     <h2><?=$this->getTrans('reportSettings') ?></h2>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('reportingPosts') ?>:
         </div>
         <div class="col-xl-4">
@@ -146,7 +146,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('reportNotificationEMail') ?>:
         </div>
         <div class="col-xl-4">

--- a/application/modules/forum/views/edittopic/index.php
+++ b/application/modules/forum/views/edittopic/index.php
@@ -62,7 +62,7 @@ function rec(ForumItem $item, View $obj, ?int $i)
                 <form method="POST">
                     <?=$this->getTokenField() ?>
                     <div class="row mb-3">
-                        <label for="selectForum" class="col-xl-2 control-label">
+                        <label for="selectForum" class="col-xl-2 col-form-label">
                             <?=$this->getTrans('selectForum') ?>
                         </label>
                         <div class="col-xl-6">

--- a/application/modules/forum/views/newtopic/index.php
+++ b/application/modules/forum/views/newtopic/index.php
@@ -38,7 +38,7 @@ if ($this->getUser()) {
                         <div class="row">
                             <div class="col-xl-12">
                                 <div class="row mb-3 <?=$this->validation()->hasError('topicTitle') ? 'has-error' : '' ?>">
-                                    <label for="topicTitle" class="col-lg-2 control-label">
+                                    <label for="topicTitle" class="col-lg-2 col-form-label">
                                         <?=$this->getTrans('topicTitle') ?>
                                     </label>
                                     <?php if ($forum->getPrefixes() != '') : ?>
@@ -69,7 +69,7 @@ if ($this->getUser()) {
                                     </div>
                                 </div>
                                 <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-                                    <label class="col-xl-2 control-label">
+                                    <label class="col-xl-2 col-form-label">
                                         <?=$this->getTrans('text') ?>
                                     </label>
                                     <div class="col-xl-10">
@@ -81,7 +81,7 @@ if ($this->getUser()) {
                                 </div>
                                 <?php if ($this->getUser()->isAdmin()) : ?>
                                     <div class="row mb-3">
-                                        <div class="col-xl-2 control-label">
+                                        <div class="col-xl-2 col-form-label">
                                             <?=$this->getTrans('forumOptions') ?>
                                         </div>
                                         <div class="col-xl-10">

--- a/application/modules/forum/views/rememberedposts/treat.php
+++ b/application/modules/forum/views/rememberedposts/treat.php
@@ -10,7 +10,7 @@
     <form id="editRememberedPost_form" method="POST">
         <?=$this->getTokenField() ?>
         <div class="row mb-3 <?=$this->validation()->hasError('note') ? 'has-error' : '' ?>">
-            <label for="note" class="col-xl-2 control-label">
+            <label for="note" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('rememberedPostNote') ?>:
             </label>
             <div class="col-xl-6">

--- a/application/modules/forum/views/showposts/edit.php
+++ b/application/modules/forum/views/showposts/edit.php
@@ -27,7 +27,7 @@ $prefixes = $this->get('prefixes');
                     <?=$this->getTokenField() ?>
                     <?php if ($this->get('isFirstPost')) : ?>
                     <div class="row mb-3 <?=$this->validation()->hasError('topicTitle') ? 'has-error' : '' ?>">
-                        <label for="topicTitle" class="col-xl-2 control-label">
+                        <label for="topicTitle" class="col-xl-2 col-form-label">
                             <?=$this->getTrans('topicTitle') ?>
                         </label>
                         <?php if ($forum->getPrefixes() != '') : ?>
@@ -59,7 +59,7 @@ $prefixes = $this->get('prefixes');
                     </div>
                     <?php endif; ?>
                     <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-                        <label class="col-xl-2 control-label">
+                        <label class="col-xl-2 col-form-label">
                             <?=$this->getTrans('text') ?>
                         </label>
                         <div class="col-xl-10">

--- a/application/modules/forum/views/showposts/report.php
+++ b/application/modules/forum/views/showposts/report.php
@@ -16,7 +16,7 @@
                 <form method="POST">
                     <?=$this->getTokenField() ?>
                     <div class="row mb-3 <?=$this->validation()->hasError('reason') ? 'has-error' : '' ?>">
-                        <label for="reason" class="col-xl-2 control-label">
+                        <label for="reason" class="col-xl-2 col-form-label">
                             <?=$this->getTrans('reason') ?>
                         </label>
                         <div class="col-xl-10">
@@ -29,7 +29,7 @@
                         </div>
                     </div>
                     <div class="row mb-3">
-                        <label for="details" class="col-xl-2 control-label">
+                        <label for="details" class="col-xl-2 col-form-label">
                             <?=$this->getTrans('details') ?>
                         </label>
                         <div class="col-xl-10">

--- a/application/modules/gallery/views/admin/image/treatimage.php
+++ b/application/modules/gallery/views/admin/image/treatimage.php
@@ -18,7 +18,7 @@ $image = $this->get('image');
             </div>
             <div class="col-lg-8">
                 <div class="row mb-3">
-                    <label for="imageTitleInput" class="col-xl-2 control-label">
+                    <label for="imageTitleInput" class="col-xl-2 col-form-label">
                         <?=$this->getTrans('imageTitle') ?>:
                     </label>
                     <div class="col-xl-8">
@@ -30,7 +30,7 @@ $image = $this->get('image');
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label for="imageDescInput" class="col-xl-2 control-label">
+                    <label for="imageDescInput" class="col-xl-2 col-form-label">
                         <?=$this->getTrans('imageDesc') ?>:
                     </label>
                     <div class="col-xl-8">

--- a/application/modules/gallery/views/admin/index/index.php
+++ b/application/modules/gallery/views/admin/index/index.php
@@ -84,7 +84,7 @@ function rec(\Modules\Gallery\Models\GalleryItem $item, \Modules\Gallery\Mappers
     <div class="col-xl-6 changeBox">
         <input type="hidden" id="id" value="" />
         <div class="row mb-3">
-            <label for="title" class="col-xl-3 control-label">
+            <label for="title" class="col-xl-3 col-form-label">
                 <?=$this->getTrans('title') ?>
             </label>
             <div class="col-xl-6">
@@ -92,7 +92,7 @@ function rec(\Modules\Gallery\Models\GalleryItem $item, \Modules\Gallery\Mappers
             </div>
         </div>
         <div class="row mb-3">
-            <label for="desc" class="col-xl-3 control-label">
+            <label for="desc" class="col-xl-3 col-form-label">
                 <?=$this->getTrans('description') ?>
             </label>
             <div class="col-xl-6">
@@ -104,7 +104,7 @@ function rec(\Modules\Gallery\Models\GalleryItem $item, \Modules\Gallery\Mappers
             </div>
         </div>
         <div class="row mb-3">
-            <label for="type" class="col-xl-3 control-label">
+            <label for="type" class="col-xl-3 col-form-label">
                 <?=$this->getTrans('type') ?>
             </label>
             <div class="col-xl-6">
@@ -116,7 +116,7 @@ function rec(\Modules\Gallery\Models\GalleryItem $item, \Modules\Gallery\Mappers
         </div>
         <div class="dyn"></div>
         <div class="row mb-3">
-            <label class="col-xl-3 control-label"></label>
+            <label class="col-xl-3 col-form-label"></label>
             <div class="col-xl-6 actions">
                 <input type="button" class="btn btn-outline-secondary" id="menuItemAdd" value="<?=$this->getTrans('galleryItemAdd') ?>">
             </div>
@@ -205,7 +205,7 @@ $(document).ready (
                 return;
             }
 
-            let menuHtml = '<div class="row mb-3"><label for="href" class="col-xl-3 control-label"><?=$this->getTrans('cat') ?></label>\n\
+            let menuHtml = '<div class="row mb-3"><label for="href" class="col-xl-3 col-form-label"><?=$this->getTrans('cat') ?></label>\n\
                         <div class="col-xl-6"><select class="form-select" id="menukey">'+options+'</select></div></div>';
 
             if ($(this).val() === '0') {

--- a/application/modules/gallery/views/admin/settings/index.php
+++ b/application/modules/gallery/views/admin/settings/index.php
@@ -6,7 +6,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('picturesPerPage') ? 'has-error' : '' ?>">
-        <label for="picturesPerPageInput" class="col-xl-2 control-label">
+        <label for="picturesPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('picturesPerPage') ?>:
         </label>
         <div class="col-xl-1">
@@ -20,7 +20,7 @@
     </div>
     <h1><?=$this->getTrans('box') ?>: <?=$this->getTrans('pictureOfX') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('pictureOfXSource') ? 'has-error' : '' ?>">
-        <label for="pictureOfXSource" class="col-xl-2 control-label">
+        <label for="pictureOfXSource" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pictureOfXSource') ?>:
         </label>
         <div class="col-xl-4">
@@ -39,7 +39,7 @@
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('pictureOfXInterval') ? 'has-error' : '' ?>">
         <?php $selected = ($this->get('pictureOfXInterval')) ? 'selected="selected"' : ''?>
-        <label for="pictureOfXInterval" class="col-xl-2 control-label">
+        <label for="pictureOfXInterval" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pictureOfXInterval') ?>:
         </label>
         <div class="col-xl-4">
@@ -56,7 +56,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('pictureOfXRandom') ? 'has-error' : '' ?>">
-        <label for="pictureOfXRandom" class="col-xl-2 control-label">
+        <label for="pictureOfXRandom" class="col-xl-2 col-form-label">
             <?=$this->getTrans('pictureOfXRandom') ?>:
         </label>
         <div class="col-xl-4">
@@ -72,7 +72,7 @@
 
     <h1><?=$this->getTrans('venoboxSetting') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('venoboxNumeration') ? 'has-error' : '' ?>">
-        <label for="venoboxNumeration" class="col-xl-2 control-label">
+        <label for="venoboxNumeration" class="col-xl-2 col-form-label">
             <?=$this->getTrans('venoboxNumeration') ?>:
         </label>
         <div class="col-xl-4">
@@ -87,7 +87,7 @@
     </div>
 
     <div class="row mb-3 <?=$this->validation()->hasError('venoboxOverlayColor') ? 'has-error' : '' ?>">
-        <label for="venoboxOverlayColor" class="col-xl-2 control-label">
+        <label for="venoboxOverlayColor" class="col-xl-2 col-form-label">
             <?=$this->getTrans('venoboxOverlayColor') ?>:
         </label>
         <div class="col-xl-2 input-group">
@@ -102,7 +102,7 @@
     </div>
 
     <div class="row mb-3 <?=$this->validation()->hasError('venoboxInfiniteGallery') ? 'has-error' : '' ?>">
-        <label for="venoboxInfiniteGallery" class="col-xl-2 control-label">
+        <label for="venoboxInfiniteGallery" class="col-xl-2 col-form-label">
             <?=$this->getTrans('venoboxInfiniteGallery') ?>:
         </label>
         <div class="col-xl-4">
@@ -117,7 +117,7 @@
     </div>
 
     <div class="row mb-3 <?=$this->validation()->hasError('venoboxBgcolor') ? 'has-error' : '' ?>">
-        <label for="venoboxBgcolor" class="col-xl-2 control-label">
+        <label for="venoboxBgcolor" class="col-xl-2 col-form-label">
             <?=$this->getTrans('venoboxBgcolor') ?>:
         </label>
         <div class="col-xl-2 input-group">
@@ -132,7 +132,7 @@
     </div>
 
     <div class="row mb-3 <?=$this->validation()->hasError('venoboxBorder') ? 'has-error' : '' ?>">
-        <label for="venoboxBorder" class="col-xl-2 control-label">
+        <label for="venoboxBorder" class="col-xl-2 col-form-label">
             <?=$this->getTrans('venoboxBorder') ?>:
         </label>
         <div class="col-xl-2 input-group">
@@ -147,7 +147,7 @@
     </div>
 
     <div class="row mb-3 <?=$this->validation()->hasError('venoboxTitleattr') ? 'has-error' : '' ?>">
-        <label for="venoboxTitleattr" class="col-xl-2 control-label">
+        <label for="venoboxTitleattr" class="col-xl-2 col-form-label">
             <?=$this->getTrans('venoboxTitleattr') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/guestbook/views/admin/settings/index.php
+++ b/application/modules/guestbook/views/admin/settings/index.php
@@ -2,7 +2,7 @@
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('entrySettings') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('entrySettings') ?>:
         </div>
         <div class="col-xl-2">
@@ -16,7 +16,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('notificationOnNewEntry') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('notificationOnNewEntry') ?>:
         </div>
         <div class="col-xl-2">
@@ -30,7 +30,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('entriesPerPage') ? 'has-error' : '' ?>">
-        <label for="entriesPerPageInput" class="col-xl-2 control-label">
+        <label for="entriesPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('entriesPerPage') ?>:
         </label>
         <div class="col-xl-1">
@@ -43,7 +43,7 @@
         </div>
     </div>
     <div class="row mb-3 <?= $this->validation()->hasError('welcomeMessage') ? 'has-error' : '' ?>" data-bs-toggle="dropdown" aria-expanded="false">
-        <label for="ck_1" class="col-xl-2 control-label">
+        <label for="ck_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('welcomeMessage') ?>:
         </label>
         <div class="col-xl-8">

--- a/application/modules/guestbook/views/index/newentry.php
+++ b/application/modules/guestbook/views/index/newentry.php
@@ -3,7 +3,7 @@
 <form id="guestbookForm" name="guestbookForm" method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 d-none Entries">
-        <label for="bot" class="col-xl-2 control-label">
+        <label for="bot" class="col-xl-2 col-form-label">
             <?=$this->getTrans('bot') ?>*
         </label>
         <div class="col-xl-8">
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>*
         </label>
         <div class="col-xl-8">
@@ -28,7 +28,7 @@
         </div>
     </div>
     <div class="row mb-3 <?= $this->validation()->hasError('email') ? 'has-error' : '' ?>">
-        <label for="email" class="col-xl-2 control-label">
+        <label for="email" class="col-xl-2 col-form-label">
             <?=$this->getTrans('email') ?>*
         </label>
         <div class="col-xl-8">
@@ -41,7 +41,7 @@
         </div>
     </div>
     <div class="row mb-3 <?= $this->validation()->hasError('homepage') ? 'has-error' : '' ?>">
-        <label for="homepage" class="col-xl-2 control-label">
+        <label for="homepage" class="col-xl-2 col-form-label">
             <?=$this->getTrans('page') ?>
         </label>
         <div class="col-xl-8">
@@ -54,7 +54,7 @@
         </div>
     </div>
     <div class="row mb-3 <?= $this->validation()->hasError('text') ? 'has-error' : '' ?>">
-        <label for="text" class="col-xl-2 control-label">
+        <label for="text" class="col-xl-2 col-form-label">
             <?=$this->getTrans('message') ?>*
         </label>
         <div class="col-xl-8">

--- a/application/modules/history/views/admin/index/treat.php
+++ b/application/modules/history/views/admin/index/treat.php
@@ -14,7 +14,7 @@ $history = $this->get('history');
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('date') ? 'has-error' : '' ?>">
-        <label for="date" class="col-lg-2 control-label">
+        <label for="date" class="col-lg-2 col-form-label">
             <?=$this->getTrans('date') ?>:
         </label>
         <div id="date" class="col-lg-2 input-group ilch-date date form_datetime">
@@ -33,7 +33,7 @@ $history = $this->get('history');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>:
         </label>
         <div class="col-xl-4">
@@ -45,7 +45,7 @@ $history = $this->get('history');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-        <label for="ck_1" class="col-xl-2 control-label">
+        <label for="ck_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('text') ?>:
         </label>
         <div class="col-xl-10">
@@ -57,7 +57,7 @@ $history = $this->get('history');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="symbol" class="col-xl-2 control-label">
+        <label for="symbol" class="col-xl-2 col-form-label">
             <?=$this->getTrans('symbol') ?>:
         </label>
         <div class="col-xl-2 input-group ilch-date">
@@ -76,7 +76,7 @@ $history = $this->get('history');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="color" class="col-xl-2 control-label">
+        <label for="color" class="col-xl-2 col-form-label">
             <?=$this->getTrans('color') ?>:
         </label>
         <div class="col-xl-2 input-group ilch-date">

--- a/application/modules/history/views/admin/settings/index.php
+++ b/application/modules/history/views/admin/settings/index.php
@@ -7,7 +7,7 @@
     <?=$this->getTokenField() ?>
     <h1><?=$this->getTrans('desc_order') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('desc_order') ? 'has-error' : '' ?>">
-        <label for="desc_order" class="col-xl-2 control-label">
+        <label for="desc_order" class="col-xl-2 col-form-label">
             <?=$this->getTrans('desc_orderText') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/imprint/views/admin/index/index.php
+++ b/application/modules/imprint/views/admin/index/index.php
@@ -9,7 +9,7 @@ $imprint = $this->get('imprint');
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('imprint') ? 'has-error' : '' ?>">
-        <label for="ck_2" class="col-xl-2 control-label">
+        <label for="ck_2" class="col-xl-2 col-form-label">
             <?=$this->getTrans('imprint') ?>:
         </label>
         <div class="col-xl-12">

--- a/application/modules/jobs/views/admin/index/treat.php
+++ b/application/modules/jobs/views/admin/index/treat.php
@@ -11,7 +11,7 @@ $job = $this->get('job');
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('show') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('show') ?>:
         </div>
         <div class="col-xl-4">
@@ -25,7 +25,7 @@ $job = $this->get('job');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>:
         </label>
         <div class="col-xl-4">
@@ -37,7 +37,7 @@ $job = $this->get('job');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-        <label for="ck_1" class="col-xl-2 control-label">
+        <label for="ck_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('text') ?>:
         </label>
         <div class="col-xl-10">
@@ -49,7 +49,7 @@ $job = $this->get('job');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
-        <label for="email" class="col-xl-2 control-label">
+        <label for="email" class="col-xl-2 col-form-label">
             <?=$this->getTrans('email') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/jobs/views/index/show.php
+++ b/application/modules/jobs/views/index/show.php
@@ -29,7 +29,7 @@ $job = $this->get('job');
     <form action="" method="POST">
         <?=$this->getTokenField() ?>
         <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-            <label for="title" class="col-xl-3 control-label">
+            <label for="title" class="col-xl-3 col-form-label">
                 <div class="text-start">
                     <?=$this->getTrans('applyAs') ?>:
                 </div>

--- a/application/modules/link/views/admin/index/treatCat.php
+++ b/application/modules/link/views/admin/index/treatCat.php
@@ -9,7 +9,7 @@ $cat = $this->get('category');
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>:
         </label>
         <div class="col-xl-4">
@@ -22,7 +22,7 @@ $cat = $this->get('category');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="desc" class="col-xl-2 control-label">
+        <label for="desc" class="col-xl-2 col-form-label">
             <?=$this->getTrans('description') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/link/views/admin/index/treatLink.php
+++ b/application/modules/link/views/admin/index/treatLink.php
@@ -12,7 +12,7 @@ $cats = $this->get('cats');
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>:
         </label>
         <div class="col-xl-4">
@@ -25,7 +25,7 @@ $cats = $this->get('cats');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('link') ? 'has-error' : '' ?>">
-        <label for="link" class="col-xl-2 control-label">
+        <label for="link" class="col-xl-2 col-form-label">
             <?=$this->getTrans('link') ?>:
         </label>
         <div class="col-xl-4">
@@ -38,7 +38,7 @@ $cats = $this->get('cats');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('banner') ? 'has-error' : '' ?>">
-        <label for="selectedImage_1" class="col-xl-2 control-label">
+        <label for="selectedImage_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('banner') ?>:
         </label>
         <div class="col-xl-4">
@@ -54,7 +54,7 @@ $cats = $this->get('cats');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="desc" class="col-xl-2 control-label">
+        <label for="desc" class="col-xl-2 col-form-label">
             <?=$this->getTrans('description') ?>:
         </label>
         <div class="col-xl-4">
@@ -66,7 +66,7 @@ $cats = $this->get('cats');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('catId') ? 'has-error' : '' ?>">
-        <label for="catId" class="col-xl-2 control-label">
+        <label for="catId" class="col-xl-2 col-form-label">
             <?=$this->getTrans('category') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/linkus/views/admin/index/treat.php
+++ b/application/modules/linkus/views/admin/index/treat.php
@@ -10,7 +10,7 @@
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName(), 'id' => $this->getRequest()->getParam('id')]) ?>">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>:
         </label>
         <div class="col-xl-4">
@@ -22,7 +22,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('banner') ? 'has-error' : '' ?>">
-        <label for="selectedImage_1" class="col-xl-2 control-label">
+        <label for="selectedImage_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('banner') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/linkus/views/admin/settings/index.php
+++ b/application/modules/linkus/views/admin/settings/index.php
@@ -12,7 +12,7 @@ if (!$this->validation()->hasErrors()) {
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('showHtml') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('showHtml') ?>:
         </div>
         <div class="col-xl-4">
@@ -26,7 +26,7 @@ if (!$this->validation()->hasErrors()) {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('showBBCode') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('showBBCode') ?>:
         </div>
         <div class="col-xl-4">

--- a/application/modules/media/views/admin/index/index.php
+++ b/application/modules/media/views/admin/index/index.php
@@ -7,7 +7,7 @@
             <form method="POST">
                 <?=$this->getTokenField() ?>
                 <div class="row mb-3">
-                    <label class="col-xl-2 control-label" for="pref-perpage"><?=$this->getTrans('rowsPerPage') ?>:</label>
+                    <label class="col-xl-2 col-form-label" for="pref-perpage"><?=$this->getTrans('rowsPerPage') ?>:</label>
                     <div class="col-xl-2">
                         <select class="form-select" id="pref-perpage" name="rows">
                             <option value="2">2</option>
@@ -34,7 +34,7 @@
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label class="col-xl-2 control-label" for="pref-orderby"><?=$this->getTrans('orderBy') ?>:</label>
+                    <label class="col-xl-2 col-form-label" for="pref-orderby"><?=$this->getTrans('orderBy') ?>:</label>
                     <div class="col-xl-2">
                         <select class="form-select" id="pref-orderby" name="order">
                             <option value="ASC"><?=$this->getTrans('ascending') ?></option>
@@ -43,7 +43,7 @@
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label class="col-xl-2 control-label" for="pref-orderbytype"><?=$this->getTrans('mediaType') ?>:</label>
+                    <label class="col-xl-2 col-form-label" for="pref-orderbytype"><?=$this->getTrans('mediaType') ?>:</label>
                     <div class="col-xl-2">
                         <select class="form-select" id="pref-orderbytype" name="orderbytype">
                             <option value="all"><?=$this->getTrans('all') ?></option>

--- a/application/modules/media/views/admin/settings/index.php
+++ b/application/modules/media/views/admin/settings/index.php
@@ -6,7 +6,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3">
-        <label for="allowedImagesInput" class="col-xl-2 control-label">
+        <label for="allowedImagesInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('allowedImages') ?>:
         </label>
         <div class="col-xl-8">
@@ -16,7 +16,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="allowedVideosInput" class="col-xl-2 control-label">
+        <label for="allowedVideosInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('allowedVideos') ?>:
         </label>
         <div class="col-xl-8">
@@ -26,7 +26,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="allowedFilesInput" class="col-xl-2 control-label">
+        <label for="allowedFilesInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('allowedFiles') ?>:
         </label>
         <div class="col-xl-8">
@@ -36,7 +36,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="mediaPerPageInput" class="col-xl-2 control-label">
+        <label for="mediaPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('mediaPerPage') ?>:
         </label>
         <div class="col-xl-1">
@@ -49,7 +49,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('directoriesAsCategories') ?>
         </div>
         <div class="col-xl-4">

--- a/application/modules/newsletter/views/admin/index/treat.php
+++ b/application/modules/newsletter/views/admin/index/treat.php
@@ -3,7 +3,7 @@
     <form method="POST" action="">
         <?=$this->getTokenField() ?>
         <div class="row mb-3 <?=$this->validation()->hasError('subject') ? 'has-error' : '' ?>">
-            <label for="subject" class="col-xl-2 control-label">
+            <label for="subject" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('subject') ?>:
             </label>
             <div class="col-xl-4">
@@ -16,7 +16,7 @@
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-            <label for="ck_1" class="col-xl-2 control-label">
+            <label for="ck_1" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('text') ?>:
             </label>
             <div class="col-xl-10">

--- a/application/modules/newsletter/views/admin/settings/index.php
+++ b/application/modules/newsletter/views/admin/settings/index.php
@@ -7,7 +7,7 @@
     <?=$this->getTokenField() ?>
     <p><?=$this->getTrans('doubleOptInInfo') ?></p>
     <div class="form-group">
-        <div class="col-lg-2 control-label">
+        <div class="col-lg-2 col-form-label">
             <?=$this->getTrans('doubleOptIn') ?>:
         </div>
         <div class="col-lg-4">

--- a/application/modules/newsletter/views/index/settings.php
+++ b/application/modules/newsletter/views/index/settings.php
@@ -11,7 +11,7 @@
             <form action="" method="POST">
                 <?=$this->getTokenField() ?>
                 <div class="row mb-3 <?=$this->validation()->hasError('acceptNewsletter') ? 'has-error' : '' ?>">
-                    <div class="col-xl-3 control-label">
+                    <div class="col-xl-3 col-form-label">
                         <?=$this->getTrans('acceptNewsletter') ?>:
                     </div>
                     <div class="col-xl-4">

--- a/application/modules/partner/views/admin/index/treat.php
+++ b/application/modules/partner/views/admin/index/treat.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>:
         </label>
         <div class="col-xl-6">
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="link" class="col-xl-2 control-label">
+        <label for="link" class="col-xl-2 col-form-label">
             <?=$this->getTrans('link') ?>:
         </label>
         <div class="col-xl-3 <?=$this->validation()->hasError('link') ? 'has-error' : '' ?>">
@@ -34,7 +34,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('banner') ? 'has-error' : '' ?>">
-        <label for="selectedImage_1" class="col-xl-2 control-label">
+        <label for="selectedImage_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('banner') ?>:
         </label>
         <div class="col-xl-6">

--- a/application/modules/partner/views/admin/settings/index.php
+++ b/application/modules/partner/views/admin/settings/index.php
@@ -11,7 +11,7 @@ if ($this->validation()->hasErrors()) {
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('slider') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('slider') ?>:
         </div>
         <div class="col-xl-2">
@@ -26,7 +26,7 @@ if ($this->validation()->hasErrors()) {
     </div>
     <div id="contentHeight" <?=(!$slider) ? 'hidden' : '' ?>>
         <div class="row mb-3 <?=$this->validation()->hasError('boxSliderMode') ? 'has-error' : '' ?>">
-            <label for="boxSliderMode" class="col-xl-2 control-label">
+            <label for="boxSliderMode" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('boxSliderMode') ?>:
             </label>
             <div class="col-xl-2">
@@ -37,7 +37,7 @@ if ($this->validation()->hasErrors()) {
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('boxSliderHeight') ? 'has-error' : '' ?>">
-            <label for="boxSliderHeight" class="col-xl-2 control-label">
+            <label for="boxSliderHeight" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('boxSliderHeight') ?>:
             </label>
             <div class="col-xl-1">
@@ -51,7 +51,7 @@ if ($this->validation()->hasErrors()) {
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('boxSliderSpeed') ? 'has-error' : '' ?>">
-            <label for="boxSliderSpeed" class="col-xl-2 control-label">
+            <label for="boxSliderSpeed" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('boxSliderSpeed') ?>:
             </label>
             <div class="col-xl-1">

--- a/application/modules/partner/views/index/index.php
+++ b/application/modules/partner/views/index/index.php
@@ -2,7 +2,7 @@
 <form id="partnerForm" name="partnerForm" method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 d-none">
-        <label class="col-xl-2 control-label">
+        <label class="col-xl-2 col-form-label">
             <?=$this->getTrans('bot') ?>*
         </label>
         <div class="col-xl-8">
@@ -13,7 +13,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>:
         </label>
         <div class="col-xl-8">
@@ -26,7 +26,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('link') ? 'has-error' : '' ?>">
-        <label for="link" class="col-xl-2 control-label">
+        <label for="link" class="col-xl-2 col-form-label">
             <?=$this->getTrans('link') ?>:
         </label>
         <div class="col-xl-8">
@@ -39,7 +39,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('banner') ? 'has-error' : '' ?>">
-        <label for="banner" class="col-xl-2 control-label">
+        <label for="banner" class="col-xl-2 col-form-label">
             <?=$this->getTrans('banner') ?>:
         </label>
         <div class="col-xl-8">

--- a/application/modules/privacy/views/admin/index/treat.php
+++ b/application/modules/privacy/views/admin/index/treat.php
@@ -11,7 +11,7 @@ $privacy = $this->get('privacy');
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('show') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('show') ?>
         </div>
         <div class="col-xl-4">
@@ -25,7 +25,7 @@ $privacy = $this->get('privacy');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>
         </label>
         <div class="col-xl-4">
@@ -37,7 +37,7 @@ $privacy = $this->get('privacy');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-        <label for="ck_1" class="col-xl-2 control-label">
+        <label for="ck_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('text') ?>
         </label>
         <div class="col-xl-10">
@@ -49,7 +49,7 @@ $privacy = $this->get('privacy');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="urltitle" class="col-xl-2 control-label">
+        <label for="urltitle" class="col-xl-2 col-form-label">
             <?=$this->getTrans('urlTitle') ?>
         </label>
         <div class="col-xl-4">
@@ -61,7 +61,7 @@ $privacy = $this->get('privacy');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('url') ? 'has-error' : '' ?>">
-        <label for="url" class="col-xl-2 control-label">
+        <label for="url" class="col-xl-2 col-form-label">
             <?=$this->getTrans('url') ?>
         </label>
         <div class="col-xl-4">

--- a/application/modules/rule/views/admin/cats/treat.php
+++ b/application/modules/rule/views/admin/cats/treat.php
@@ -15,7 +15,7 @@ $userGroupList = $this->get('userGroupList');
 <form method="POST">
     <?=$this->getTokenField(); ?>
     <div class="row mb-3 <?=$this->validation()->hasError('paragraph') ? 'has-error' : '' ?>">
-        <label for="paragraph" class="col-xl-2 control-label">
+        <label for="paragraph" class="col-xl-2 col-form-label">
             <?=$this->getTrans('art') ?>
         </label>
         <div class="col-xl-1">
@@ -28,7 +28,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('name') ?>:
         </label>
         <div class="col-xl-3">
@@ -41,7 +41,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3">
-        <label for="assignedGroupsRead" class="col-xl-2 control-label">
+        <label for="assignedGroupsRead" class="col-xl-2 col-form-label">
             <?=$this->getTrans('see') ?>
             <a href="#" data-bs-toggle="tooltip" data-bs-custom-class="custom-tooltip" data-bs-title="<?=$this->getTrans('seetext') ?>"><i class="fa-solid fa-circle-info"></i></a>
         </label>

--- a/application/modules/rule/views/admin/index/treat.php
+++ b/application/modules/rule/views/admin/index/treat.php
@@ -18,7 +18,7 @@ $userGroupList = $this->get('userGroupList');
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('paragraph') ? 'has-error' : '' ?>">
-        <label for="paragraph" class="col-xl-2 control-label">
+        <label for="paragraph" class="col-xl-2 col-form-label">
             <?=$this->getTrans('paragraph') ?>
         </label>
         <div class="col-xl-1">
@@ -31,7 +31,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('title') ? 'has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>
         </label>
         <div class="col-xl-4">
@@ -44,7 +44,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('cat') ? 'has-error' : '' ?>">
-        <label for="cat" class="col-xl-2 control-label">
+        <label for="cat" class="col-xl-2 col-form-label">
             <?=$this->getTrans('cat') ?>
         </label>
         <div class="col-xl-4">
@@ -56,7 +56,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('groups') ? 'has-error' : '' ?>">
-        <label for="assignedGroupsRead" class="col-xl-2 control-label">
+        <label for="assignedGroupsRead" class="col-xl-2 col-form-label">
             <?=$this->getTrans('see') ?>
             <a href="#" data-bs-toggle="tooltip" data-bs-custom-class="custom-tooltip" data-bs-title="<?=$this->getTrans('seetext') ?>"><i class="fa-solid fa-circle-info"></i></a>
         </label>
@@ -72,7 +72,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-        <label for="ck_1" class="col-xl-2 control-label">
+        <label for="ck_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('text') ?>
         </label>
         <div class="col-xl-10">

--- a/application/modules/rule/views/admin/settings/index.php
+++ b/application/modules/rule/views/admin/settings/index.php
@@ -6,7 +6,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('showallonstart') ? 'has-error' : '' ?>">
-        <label for="threadsPerPageInput" class="col-xl-2 control-label">
+        <label for="threadsPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('showallonstart') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/shop/views/admin/cats/treat.php
+++ b/application/modules/shop/views/admin/cats/treat.php
@@ -5,7 +5,7 @@
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('catTitle') ?>:
         </label>
         <div class="col-xl-4">
@@ -17,7 +17,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="access" class="col-xl-2 control-label">
+        <label for="access" class="col-xl-2 col-form-label">
             <?=$this->getTrans('visibleFor') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/shop/views/admin/currency/treat.php
+++ b/application/modules/shop/views/admin/currency/treat.php
@@ -12,7 +12,7 @@
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label"><?=$this->getTrans('name') ?>:</label>
+        <label for="name" class="col-xl-2 col-form-label"><?=$this->getTrans('name') ?>:</label>
         <div class="col-xl-4">
             <input type="text"
                    class="form-control"
@@ -23,7 +23,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('code') ? 'has-error' : '' ?>">
-        <label for="code" class="col-xl-2 control-label"><?=$this->getTrans('currencyCode') ?>:</label>
+        <label for="code" class="col-xl-2 col-form-label"><?=$this->getTrans('currencyCode') ?>:</label>
         <div class="col-xl-4">
             <div class="input-group">
                 <span class="input-group-text">

--- a/application/modules/shop/views/admin/items/treat.php
+++ b/application/modules/shop/views/admin/items/treat.php
@@ -13,7 +13,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         <?=$this->getTokenField() ?>
 
         <div class="row mb-3 <?=$this->validation()->hasError('status') ? 'has-error' : '' ?>">
-            <label for="status" class="col-xl-2 control-label">
+            <label for="status" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('visibility') ?>
             </label>
             <div class="col-xl-4">
@@ -28,7 +28,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('catId') ? 'has-error' : '' ?>">
-            <label for="catId" class="col-xl-2 control-label">
+            <label for="catId" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('cat') ?>:
             </label>
             <div class="col-xl-5">
@@ -51,7 +51,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-            <label for="name" class="col-xl-2 control-label">
+            <label for="name" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('productName') ?>:
             </label>
             <div class="col-xl-5">
@@ -64,7 +64,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('itemnumber') ? 'has-error' : '' ?>">
-            <label for="itemnumber" class="col-xl-2 control-label">
+            <label for="itemnumber" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('itemNumber') ?>:
             </label>
             <div class="col-xl-5">
@@ -77,7 +77,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('stock') ? 'has-error' : '' ?>">
-            <label for="stock" class="col-xl-2 control-label">
+            <label for="stock" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('stock') ?> / <?=$this->getTrans('salesUnit') ?>:
             </label>
             <div class="col-xl-5 input-group">
@@ -101,7 +101,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('cordon') || $this->validation()->hasError('cordonColor') ? 'has-error' : '' ?>">
-            <label for="cordon" class="col-xl-2 control-label">
+            <label for="cordon" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('cordon') ?>:
             </label>
             <div class="col-xl-5">
@@ -132,7 +132,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('price') ? 'has-error' : '' ?>">
-            <label for="price" class="col-xl-2 control-label">
+            <label for="price" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('price') ?>:
             </label>
             <div class="col-xl-5">
@@ -155,7 +155,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3<?=$this->validation()->hasError('tax') ? 'has-error' : '' ?>">
-            <label for="tax" class="col-xl-2 control-label">
+            <label for="tax" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('tax') ?>:
             </label>
             <div class="col-xl-5">
@@ -181,7 +181,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('shippingCosts') ? 'has-error' : '' ?>">
-            <label for="shippingCosts" class="col-xl-2 control-label">
+            <label for="shippingCosts" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('shippingCosts') ?>:
             </label>
             <div class="col-xl-5">
@@ -210,7 +210,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('shippingTime') ? 'has-error' : '' ?>">
-            <label for="shippingTime" class="col-xl-2 control-label">
+            <label for="shippingTime" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('shippingTime') ?>:
             </label>
             <div class="col-xl-5">
@@ -236,7 +236,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('image') ? 'has-error' : '' ?>">
-            <label for="selectedImage_image" class="col-xl-2 control-label">
+            <label for="selectedImage_image" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('productThumbnail') ?>:
             </label>
             <div class="col-xl-5">
@@ -273,7 +273,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('image1') ? 'has-error' : '' ?>">
-            <label for="selectedImage_image1" class="col-xl-2 control-label">
+            <label for="selectedImage_image1" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('productImage') ?> 1:
             </label>
             <div class="col-xl-5">
@@ -310,7 +310,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('image2') ? 'has-error' : '' ?>">
-            <label for="selectedImage_image2" class="col-xl-2 control-label">
+            <label for="selectedImage_image2" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('productImage') ?> 2:
             </label>
             <div class="col-xl-5">
@@ -347,7 +347,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('image3') ? 'has-error' : '' ?>">
-            <label for="selectedImage_image3" class="col-xl-2 control-label">
+            <label for="selectedImage_image3" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('productImage') ?> 3:
             </label>
             <div class="col-xl-5">
@@ -384,7 +384,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('info') ? 'has-error' : '' ?>">
-            <label for="info" class="col-xl-2 control-label">
+            <label for="info" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('shortInfo') ?>:
             </label>
             <div class="col-xl-10">
@@ -400,7 +400,7 @@ $shopImgPath = '/application/modules/shop/static/img/';
         </div>
 
         <div class="row mb-3 <?=$this->validation()->hasError('desc') ? 'has-error' : '' ?>">
-            <label for="desc" class="col-xl-2 control-label">
+            <label for="desc" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('description') ?>:
             </label>
             <div class="col-xl-10">

--- a/application/modules/shop/views/admin/settings/agb.php
+++ b/application/modules/shop/views/admin/settings/agb.php
@@ -33,7 +33,7 @@
     </ul>
     <br />
     <div class="row mb-3 <?=$this->validation()->hasError('settingsAGB') ? 'has-error' : '' ?>">
-        <label for="settingsAGB" class="col-xl-2 control-label">
+        <label for="settingsAGB" class="col-xl-2 col-form-label">
             <?=$this->getTrans('AGB') ?>:
         </label>
         <div class="col-xl-10">

--- a/application/modules/shop/views/admin/settings/bank.php
+++ b/application/modules/shop/views/admin/settings/bank.php
@@ -33,7 +33,7 @@
     </ul>
     <br />
     <div class="row mb-3 <?=$this->validation()->hasError('bankName') ? 'has-error' : '' ?>">
-        <label for="bankName" class="col-xl-2 control-label">
+        <label for="bankName" class="col-xl-2 col-form-label">
             <?=$this->getTrans('bankName') ?>:
         </label>
         <div class="col-xl-3">
@@ -46,7 +46,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('bankOwner') ? 'has-error' : '' ?>">
-        <label for="bankOwner" class="col-xl-2 control-label">
+        <label for="bankOwner" class="col-xl-2 col-form-label">
             <?=$this->getTrans('bankOwner') ?>:
         </label>
         <div class="col-xl-3">
@@ -59,7 +59,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('bankIBAN') ? 'has-error' : '' ?>">
-        <label for="bankIBAN" class="col-xl-2 control-label">
+        <label for="bankIBAN" class="col-xl-2 col-form-label">
             <?=$this->getTrans('bankIBAN') ?>:
         </label>
         <div class="col-xl-3">
@@ -72,7 +72,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('bankBIC') ? 'has-error' : '' ?>">
-        <label for="bankBIC" class="col-xl-2 control-label">
+        <label for="bankBIC" class="col-xl-2 col-form-label">
             <?=$this->getTrans('bankBIC') ?>:
         </label>
         <div class="col-xl-3">

--- a/application/modules/shop/views/admin/settings/default.php
+++ b/application/modules/shop/views/admin/settings/default.php
@@ -33,7 +33,7 @@
     </ul>
     <br />
     <div class="row mb-3 <?=$this->validation()->hasError('shopCurrency') ? 'has-error' : '' ?>">
-        <label for="shopCurrency" class="col-xl-2 control-label">
+        <label for="shopCurrency" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopCurrency') ?>:
         </label>
         <div class="col-xl-3">
@@ -53,7 +53,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('fixTax') ? 'has-error' : '' ?>">
-        <label for="fixTax" class="col-xl-2 control-label">
+        <label for="fixTax" class="col-xl-2 col-form-label">
             <?=$this->getTrans('fixTax') ?>:
         </label>
         <div class="col-xl-3">
@@ -72,7 +72,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('fixShippingCosts') ? 'has-error' : '' ?>">
-        <label for="fixShippingCosts" class="col-xl-2 control-label">
+        <label for="fixShippingCosts" class="col-xl-2 col-form-label">
             <?=$this->getTrans('fixShippingCosts') ?>:
         </label>
         <div class="col-xl-3">
@@ -94,7 +94,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('fixShippingTime') ? 'has-error' : '' ?>">
-        <label for="fixShippingTime" class="col-xl-2 control-label">
+        <label for="fixShippingTime" class="col-xl-2 col-form-label">
             <?=$this->getTrans('fixShippingTime') ?>:
         </label>
         <div class="col-xl-3">
@@ -113,7 +113,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('allowWillCollect') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('allowWillCollect') ?>
         </div>
         <div class="col-xl-4">
@@ -128,7 +128,7 @@
     </div>
     <hr />
     <div class="row mb-3 <?=$this->validation()->hasError('invoiceTextTop') ? 'has-error' : '' ?>">
-        <label for="invoiceTextTop" class="col-xl-2 control-label">
+        <label for="invoiceTextTop" class="col-xl-2 col-form-label">
             <?=$this->getTrans('invoiceTextTop') ?>:
         </label>
         <div class="col-xl-10">
@@ -145,7 +145,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('invoiceTextBottom') ? 'has-error' : '' ?>">
-        <label for="invoiceTextBottom" class="col-xl-2 control-label">
+        <label for="invoiceTextBottom" class="col-xl-2 col-form-label">
             <?=$this->getTrans('invoiceTextBottom') ?>:
         </label>
         <div class="col-xl-10">
@@ -162,7 +162,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('deliveryTextTop') ? 'has-error' : '' ?>">
-        <label for="deliveryTextTop" class="col-xl-2 control-label">
+        <label for="deliveryTextTop" class="col-xl-2 col-form-label">
             <?=$this->getTrans('deliveryTextTop') ?>:
         </label>
         <div class="col-xl-10">

--- a/application/modules/shop/views/admin/settings/index.php
+++ b/application/modules/shop/views/admin/settings/index.php
@@ -33,7 +33,7 @@
     </ul>
     <br />
     <div class="row mb-3 <?=$this->validation()->hasError('shopName') ? 'has-error' : '' ?>">
-        <label for="shopName" class="col-xl-2 control-label">
+        <label for="shopName" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopName') ?>:
         </label>
         <div class="col-xl-3">
@@ -46,7 +46,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('shopStreet') ? 'has-error' : '' ?>">
-        <label for="shopStreet" class="col-xl-2 control-label">
+        <label for="shopStreet" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopStreet') ?>:
         </label>
         <div class="col-xl-3">
@@ -59,7 +59,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('shopPlz') ? 'has-error' : '' ?>">
-        <label for="shopPlz" class="col-xl-2 control-label">
+        <label for="shopPlz" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopPlz') ?>:
         </label>
         <div class="col-xl-3">
@@ -72,7 +72,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('shopCity') ? 'has-error' : '' ?>">
-        <label for="shopCity" class="col-xl-2 control-label">
+        <label for="shopCity" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopCity') ?>:
         </label>
         <div class="col-xl-3">
@@ -86,7 +86,7 @@
     </div>
     <hr />
     <div class="row mb-3 <?=$this->validation()->hasError('shopLogo') ? 'has-error' : '' ?>">
-        <label for="selectedImage_shopLogo" class="col-xl-2 control-label">
+        <label for="selectedImage_shopLogo" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopLogo') ?>:
         </label>
         <div class="col-xl-3">
@@ -123,7 +123,7 @@
     </div>
     <hr />
     <div class="row mb-3 <?=$this->validation()->hasError('shopTel') ? 'has-error' : '' ?>">
-        <label for="shopTel" class="col-xl-2 control-label">
+        <label for="shopTel" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopTel') ?>:
         </label>
         <div class="col-xl-3">
@@ -136,7 +136,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('shopFax') ? 'has-error' : '' ?>">
-        <label for="shopFax" class="col-xl-2 control-label">
+        <label for="shopFax" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopFax') ?>:
         </label>
         <div class="col-xl-3">
@@ -149,7 +149,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('shopMail') ? 'has-error' : '' ?>">
-        <label for="shopMail" class="col-xl-2 control-label">
+        <label for="shopMail" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopMail') ?>:
         </label>
         <div class="col-xl-3">
@@ -162,7 +162,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('shopWeb') ? 'has-error' : '' ?>">
-        <label for="shopWeb" class="col-xl-2 control-label">
+        <label for="shopWeb" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopWeb') ?>:
         </label>
         <div class="col-xl-3">
@@ -176,7 +176,7 @@
     </div>
     <hr />
         <div class="row mb-3 <?=$this->validation()->hasError('shopStNr') ? 'has-error' : '' ?>">
-        <label for="shopStNr" class="col-xl-2 control-label">
+        <label for="shopStNr" class="col-xl-2 col-form-label">
             <?=$this->getTrans('shopStNr') ?>:
         </label>
         <div class="col-xl-3">

--- a/application/modules/shop/views/admin/settings/payment.php
+++ b/application/modules/shop/views/admin/settings/payment.php
@@ -37,7 +37,7 @@
     <?=$this->getTokenField() ?>
 
     <div class="row mb-3">
-        <label for="clientID" class="col-xl-2 control-label">
+        <label for="clientID" class="col-xl-2 col-form-label">
             <?=$this->getTrans('clientID') ?>:
         </label>
         <div class="col-xl-4">
@@ -57,7 +57,7 @@
     <hr>
     <p><?=$this->getTrans('paypalMeDesc') ?></p>
     <div class="row mb-3">
-        <label for="paypalMe" class="col-xl-2 control-label">
+        <label for="paypalMe" class="col-xl-2 col-form-label">
             <?=$this->getTrans('paypalMe') ?>:
         </label>
         <div class="col-xl-4">
@@ -75,7 +75,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('paypalMePresetAmount') ? 'has-error' : '' ?>">
-        <label for="paypalMePresetAmount" class="col-xl-2 control-label">
+        <label for="paypalMePresetAmount" class="col-xl-2 col-form-label">
             <?=$this->getTrans('paypalMePresetAmount') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/shop/views/index/order.php
+++ b/application/modules/shop/views/index/order.php
@@ -47,7 +47,7 @@ if (!empty($_SESSION['shopping_cart'])) {
             <div id="deliveryAddress">
                 <?php if ($this->get('addresses')) : ?>
                 <div class="row mb-3 <?=$this->validation()->hasError('dropdownDeliveryAddress') ? 'has-error' : '' ?>">
-                    <label for="dropdownDeliveryAddress" class="control-label col-xl-2">
+                    <label for="dropdownDeliveryAddress" class="col-form-label col-xl-2">
                         <?=$this->getTrans('dropdownDeliveryAddress') ?>
                     </label>
                     <div class="col-xl-9">
@@ -62,7 +62,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 <?php endif; ?>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('prename') ? 'has-error' : '' ?>">
-                    <label for="prename" class="control-label col-xl-2">
+                    <label for="prename" class="col-form-label col-xl-2">
                         <?=$this->getTrans('preName') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -76,7 +76,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('lastname') ? 'has-error' : '' ?>">
-                    <label for="lastname" class="control-label col-xl-2">
+                    <label for="lastname" class="col-form-label col-xl-2">
                         <?=$this->getTrans('lastName') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -90,7 +90,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('street') ? 'has-error' : '' ?>">
-                    <label for="street" class="control-label col-xl-2">
+                    <label for="street" class="col-form-label col-xl-2">
                         <?=$this->getTrans('street') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -104,7 +104,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('postcode') ? 'has-error' : '' ?>">
-                    <label for="postcode" class="control-label col-xl-2">
+                    <label for="postcode" class="col-form-label col-xl-2">
                         <?=$this->getTrans('postCode') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -118,7 +118,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('city') ? 'has-error' : '' ?>">
-                    <label for="city" class="control-label col-xl-2">
+                    <label for="city" class="col-form-label col-xl-2">
                         <?=$this->getTrans('city') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -132,7 +132,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('country') ? 'has-error' : '' ?>">
-                    <label for="country" class="control-label col-xl-2">
+                    <label for="country" class="col-form-label col-xl-2">
                         <?=$this->getTrans('country') ?>&nbsp;&nbsp;
                     </label>
                     <div class="col-xl-9">
@@ -146,7 +146,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
-                    <label for="email" class="control-label col-xl-2">
+                    <label for="email" class="col-form-label col-xl-2">
                         <?=$this->getTrans('emailAddress') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -168,7 +168,7 @@ if (!empty($_SESSION['shopping_cart'])) {
 
                 <?php if ($this->get('addresses')) : ?>
                 <div class="row mb-3 <?=$this->validation()->hasError('dropdownInvoiceAddress') ? 'has-error' : '' ?>">
-                    <label for="dropdownInvoiceAddress" class="control-label col-xl-2">
+                    <label for="dropdownInvoiceAddress" class="col-form-label col-xl-2">
                         <?=$this->getTrans('dropdownInvoiceAddress') ?>
                     </label>
                     <div class="col-xl-9">
@@ -183,7 +183,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 <?php endif; ?>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('invoiceAddressPrename') ? 'has-error' : '' ?>">
-                    <label for="invoiceAddressPrename" class="control-label col-xl-2">
+                    <label for="invoiceAddressPrename" class="col-form-label col-xl-2">
                         <?=$this->getTrans('preName') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -197,7 +197,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('invoiceAddressLastname') ? 'has-error' : '' ?>">
-                    <label for="invoiceAddressLastname" class="control-label col-xl-2">
+                    <label for="invoiceAddressLastname" class="col-form-label col-xl-2">
                         <?=$this->getTrans('lastName') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -211,7 +211,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('invoiceAddressStreet') ? 'has-error' : '' ?>">
-                    <label for="invoiceAddressStreet" class="control-label col-xl-2">
+                    <label for="invoiceAddressStreet" class="col-form-label col-xl-2">
                         <?=$this->getTrans('street') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -225,7 +225,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('invoiceAddressPostcode') ? 'has-error' : '' ?>">
-                    <label for="invoiceAddressPostcode" class="control-label col-xl-2">
+                    <label for="invoiceAddressPostcode" class="col-form-label col-xl-2">
                         <?=$this->getTrans('postCode') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -239,7 +239,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('invoiceAddressCity') ? 'has-error' : '' ?>">
-                    <label for="invoiceAddressCity" class="control-label col-xl-2">
+                    <label for="invoiceAddressCity" class="col-form-label col-xl-2">
                         <?=$this->getTrans('city') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -253,7 +253,7 @@ if (!empty($_SESSION['shopping_cart'])) {
                 </div>
 
                 <div class="row mb-3 <?=$this->validation()->hasError('invoiceAddressCountry') ? 'has-error' : '' ?>">
-                    <label for="invoiceAddressCountry" class="control-label col-xl-2">
+                    <label for="invoiceAddressCountry" class="col-form-label col-xl-2">
                         <?=$this->getTrans('country') ?>&nbsp;&nbsp;
                     </label>
                     <div class="col-xl-9">
@@ -269,7 +269,7 @@ if (!empty($_SESSION['shopping_cart'])) {
 
             <?php if ($this->get('captchaNeeded')) : ?>
                 <div class="row mb-3 <?=$this->validation()->hasError('captcha') ? 'has-error' : '' ?>">
-                    <label class="col-xl-2 control-label">
+                    <label class="col-xl-2 col-form-label">
                         <?=$this->getTrans('captcha') ?>&nbsp;*
                     </label>
                     <div class="col-xl-9">
@@ -432,7 +432,7 @@ if (!empty($_SESSION['shopping_cart'])) {
             <div class="row space20"></div>
 
             <div class="row mb-3 <?=$this->validation()->hasError('acceptOrder') ? 'has-error' : '' ?>">
-                <label for="acceptOrder" class="col-xl-2 control-label">
+                <label for="acceptOrder" class="col-xl-2 col-form-label">
                     <?=$this->getTrans('acceptOrder') ?>&nbsp;*
                 </label>
                 <div class="col-xl-9" style="position:relative;">

--- a/application/modules/shoutbox/boxes/views/shoutbox.php
+++ b/application/modules/shoutbox/boxes/views/shoutbox.php
@@ -109,7 +109,7 @@ $config = \Ilch\Registry::get('config');
                 <input type="hidden" name="uniqid" value="<?=$this->get('uniqid') ?>">
                <?=$this->getTokenField() ?>
                 <div class="row mb-3 d-none">
-                    <label class="col-xl-2 control-label" for="bot">
+                    <label class="col-xl-2 col-form-label" for="bot">
                         <?=$this->getTrans('bot') ?>
                     </label>
                     <div class="col-xl-8">

--- a/application/modules/shoutbox/views/admin/settings/index.php
+++ b/application/modules/shoutbox/views/admin/settings/index.php
@@ -6,7 +6,7 @@
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('limit') ? 'has-error' : '' ?>">
-        <label for="limit" class="col-xl-2 control-label">
+        <label for="limit" class="col-xl-2 col-form-label">
             <?=$this->getTrans('numberOfMessagesDisplayed') ?>
         </label>
         <div class="col-xl-1">
@@ -19,7 +19,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('maxtextlength') ? 'has-error' : '' ?>">
-        <label for="maxtextlength" class="col-xl-2 control-label">
+        <label for="maxtextlength" class="col-xl-2 col-form-label">
             <?=$this->getTrans('maximumTextLength') ?>
         </label>
         <div class="col-xl-1">
@@ -32,7 +32,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('writeAccess') ? 'has-error' : '' ?>">
-        <label for="writeAccess" class="col-xl-2 control-label">
+        <label for="writeAccess" class="col-xl-2 col-form-label">
             <?=$this->getTrans('writeAccess') ?>
         </label>
         <div class="col-xl-3">

--- a/application/modules/statistic/views/admin/index/index.php
+++ b/application/modules/statistic/views/admin/index/index.php
@@ -10,7 +10,7 @@ $statistic_config = $this->get('statistic_config');
     <?=$this->getTokenField() ?>
     <?php foreach ($statistic_config->configNames as $names) : ?>
     <div class="row mb-3 <?=$this->validation()->hasError($names) ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans($names) ?>:
         </div>
         <div class="col-xl-4">

--- a/application/modules/teams/views/admin/index/treat.php
+++ b/application/modules/teams/views/admin/index/treat.php
@@ -21,7 +21,7 @@ $userGroupList = $this->get('userGroupList');
 <form method="POST" enctype="multipart/form-data">
     <?=$this->getTokenField() ?>
     <div class="row mb-3<?=$this->validation()->hasError('name') ? ' has-error' : '' ?>">
-        <label for="name" class="col-xl-2 control-label">
+        <label for="name" class="col-xl-2 col-form-label">
             <?=$this->getTrans('teamName') ?>
         </label>
         <div class="col-xl-4">
@@ -33,7 +33,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('upl') ? ' has-error' : '' ?>">
-        <label for="upl" class="col-xl-2 control-label">
+        <label for="upl" class="col-xl-2 col-form-label">
             <?=$this->getTrans('img') ?>:
         </label>
         <div class="col-lg-4">
@@ -59,7 +59,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('leader') ? ' has-error' : '' ?>">
-        <label for="leader" class="col-xl-2 control-label">
+        <label for="leader" class="col-xl-2 col-form-label">
             <?=$this->getTrans('leader') ?>
         </label>
         <div class="col-xl-4">
@@ -81,7 +81,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('coLeader') ? ' has-error' : '' ?>">
-        <label for="coLeader" class="col-xl-2 control-label">
+        <label for="coLeader" class="col-xl-2 col-form-label">
             <?=$this->getTrans('coLeader') ?>
         </label>
         <div class="col-xl-4">
@@ -103,7 +103,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('members') ? ' has-error' : '' ?>">
-        <label for="groupId" class="col-xl-2 control-label">
+        <label for="groupId" class="col-xl-2 col-form-label">
             <?=$this->getTrans('group') ?>
         </label>
         <div class="col-xl-4">
@@ -122,7 +122,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('optShow') ? ' has-error' : '' ?>">
-        <label for="optShow" class="col-xl-2 control-label">
+        <label for="optShow" class="col-xl-2 col-form-label">
             <?=$this->getTrans('optShow') ?>:
         </label>
         <div class="col-xl-4">
@@ -136,7 +136,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('optIn') ? ' has-error' : '' ?>">
-        <label for="optIn" class="col-xl-2 control-label">
+        <label for="optIn" class="col-xl-2 col-form-label">
             <?=$this->getTrans('optIn') ?>:
         </label>
         <div class="col-xl-4">
@@ -150,7 +150,7 @@ $userGroupList = $this->get('userGroupList');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('notifyLeader') ? ' has-error' : '' ?>" id="notifyLeader">
-        <label for="notifyLeader" class="col-xl-2 control-label">
+        <label for="notifyLeader" class="col-xl-2 col-form-label">
             <?=$this->getTrans('notifyLeader') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/teams/views/admin/settings/index.php
+++ b/application/modules/teams/views/admin/settings/index.php
@@ -6,7 +6,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('image_height') ? 'has-error' : '' ?>">
-        <label for="image_height" class="col-xl-2 control-label">
+        <label for="image_height" class="col-xl-2 col-form-label">
             <?=$this->getTrans('imageHeight') ?>
         </label>
         <div class="col-xl-2">
@@ -20,7 +20,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('image_width') ? 'has-error' : '' ?>">
-        <label for="image_width" class="col-xl-2 control-label">
+        <label for="image_width" class="col-xl-2 col-form-label">
             <?=$this->getTrans('imageWidth') ?>
         </label>
         <div class="col-xl-2">
@@ -34,7 +34,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('image_filetypes') ? 'has-error' : '' ?>">
-        <label for="image_filetypes" class="col-xl-2 control-label">
+        <label for="image_filetypes" class="col-xl-2 col-form-label">
             <?=$this->getTrans('allowedFileExtensions') ?>
         </label>
         <div class="col-xl-2">

--- a/application/modules/teams/views/index/join.php
+++ b/application/modules/teams/views/index/join.php
@@ -23,7 +23,7 @@ $teams = $this->get('teams');
     <form id="joinForm" name="joinForm" method="POST">
         <?=$this->getTokenField() ?>
         <div class="row mb-3 d-none">
-            <label class="col-xl-2 control-label" for="bot">
+            <label class="col-xl-2 col-form-label" for="bot">
                 <?=$this->getTrans('bot') ?>*
             </label>
             <div class="col-xl-8">
@@ -35,7 +35,7 @@ $teams = $this->get('teams');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('teamId') ? 'has-error' : '' ?>">
-            <label for="teamId" class="col-xl-2 control-label">
+            <label for="teamId" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('team') ?>
             </label>
             <div class="col-xl-4">
@@ -62,7 +62,7 @@ $teams = $this->get('teams');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-            <label for="name" class="col-lg-2 control-label">
+            <label for="name" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('name') ?>
             </label>
             <div class="col-xl-6">
@@ -83,7 +83,7 @@ $teams = $this->get('teams');
         </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
-            <label for="email" class="col-xl-2 control-label">
+            <label for="email" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('email') ?>
             </label>
             <div class="col-xl-6">
@@ -104,7 +104,7 @@ $teams = $this->get('teams');
             </div>
         </div>
         <div class="row mb-3">
-            <label class="col-xl-2 control-label" for="gender">
+            <label class="col-xl-2 col-form-label" for="gender">
                 <?=$this->getTrans('gender') ?>
             </label>
             <div class="col-xl-2">
@@ -124,7 +124,7 @@ $teams = $this->get('teams');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('birthday') ? 'has-error' : '' ?>">
-            <label for="age" class="col-xl-2 control-label" for="birthday">
+            <label for="age" class="col-xl-2 col-form-label" for="birthday">
                 <?=$this->getTrans('birthday') ?>
             </label>
             <?php if ($this->getUser() && $this->getUser()->getBirthday() && $this->getUser()->getBirthday() != '0000-00-00') : ?>
@@ -154,7 +154,7 @@ $teams = $this->get('teams');
             <?php endif; ?>
         </div>
         <div class="row mb-3<?=$this->validation()->hasError('place') ? 'has-error' : '' ?>">
-            <label for="place" class="col-xl-2 control-label">
+            <label for="place" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('place') ?>
             </label>
             <div class="col-xl-6">
@@ -166,7 +166,7 @@ $teams = $this->get('teams');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('skill') ? 'has-error' : '' ?>">
-            <label for="skill" class="col-xl-2 control-label">
+            <label for="skill" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('skill') ?>
             </label>
             <div class="col-xl-2">
@@ -179,7 +179,7 @@ $teams = $this->get('teams');
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('text') ? 'has-error' : '' ?>">
-            <label for="ck_1" class="col-xl-2 control-label">
+            <label for="ck_1" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('text') ?>
             </label>
             <div class="col-xl-10">

--- a/application/modules/training/views/admin/index/treat.php
+++ b/application/modules/training/views/admin/index/treat.php
@@ -14,7 +14,7 @@ $training = $this->get('training');
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="title" class="col-xl-2 control-label">
+        <label for="title" class="col-xl-2 col-form-label">
             <?=$this->getTrans('title') ?>:
         </label>
         <div class="col-xl-4">
@@ -26,7 +26,7 @@ $training = $this->get('training');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="date" class="col-md-2 control-label">
+        <label for="date" class="col-md-2 col-form-label">
             <?=$this->getTrans('dateTime') ?>:
         </label>
         <div class="col-xl-2 input-group ilch-date date form_datetime" id="date">
@@ -51,7 +51,7 @@ $training = $this->get('training');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="time" class="col-xl-2 control-label">
+        <label for="time" class="col-xl-2 col-form-label">
             <?=$this->getTrans('time') ?>:
         </label>
         <div class="col-xl-1">
@@ -64,7 +64,7 @@ $training = $this->get('training');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="place" class="col-xl-2 control-label">
+        <label for="place" class="col-xl-2 col-form-label">
             <?=$this->getTrans('place') ?>:
         </label>
         <div class="col-xl-4">
@@ -76,7 +76,7 @@ $training = $this->get('training');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="contact" class="col-xl-2 control-label">
+        <label for="contact" class="col-xl-2 col-form-label">
             <?=$this->getTrans('contactPerson') ?>:
         </label>
         <div class="col-xl-2">
@@ -94,7 +94,7 @@ $training = $this->get('training');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="voiceServer" class="col-xl-2 control-label">
+        <label for="voiceServer" class="col-xl-2 col-form-label">
             <?=$this->getTrans('voiceServer') ?>:
         </label>
         <div class="col-xl-6">
@@ -116,7 +116,7 @@ $training = $this->get('training');
     ?>
     <div id="voiceServerInfo" <?=$voiceDisplay ?>>
         <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-            <label for="voiceServerIP" class="col-xl-2 control-label">
+            <label for="voiceServerIP" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('voiceServerIP') ?>:
             </label>
             <div class="col-xl-4">
@@ -129,7 +129,7 @@ $training = $this->get('training');
             </div>
         </div>
         <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-            <label for="voiceServerPW" class="col-xl-2 control-label">
+            <label for="voiceServerPW" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('voiceServerPW') ?>:
             </label>
             <div class="col-xl-4">
@@ -143,7 +143,7 @@ $training = $this->get('training');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="gameServer" class="col-xl-2 control-label">
+        <label for="gameServer" class="col-xl-2 col-form-label">
             <?=$this->getTrans('gameServer') ?>:
         </label>
         <div class="col-xl-6">
@@ -165,7 +165,7 @@ $training = $this->get('training');
     ?>
     <div id="gameServerInfo" <?=$gameDisplay ?>>
         <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-            <label for="gameServerIP" class="col-xl-2 control-label">
+            <label for="gameServerIP" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('gameServerIP') ?>:
             </label>
             <div class="col-xl-4">
@@ -178,7 +178,7 @@ $training = $this->get('training');
             </div>
         </div>
         <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-            <label for="gameServerPW" class="col-xl-2 control-label">
+            <label for="gameServerPW" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('gameServerPW') ?>:
             </label>
             <div class="col-xl-4">
@@ -192,7 +192,7 @@ $training = $this->get('training');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="ck_1" class="col-xl-2 control-label">
+        <label for="ck_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('otherInfo') ?>:
         </label>
         <div class="col-xl-10">
@@ -204,7 +204,7 @@ $training = $this->get('training');
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-        <label for="access" class="col-xl-2 control-label">
+        <label for="access" class="col-xl-2 col-form-label">
             <?=$this->getTrans('visibleFor') ?>
         </label>
         <div class="col-xl-6">
@@ -219,7 +219,7 @@ $training = $this->get('training');
     </div>
     <?php if ($this->get('calendarShow')) : ?>
         <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
-            <label for="calendarShow" class="col-xl-2 control-label">
+            <label for="calendarShow" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('calendarShow') ?>
             </label>
             <div class="col-xl-6">

--- a/application/modules/training/views/admin/settings/index.php
+++ b/application/modules/training/views/admin/settings/index.php
@@ -8,7 +8,7 @@
 
     <h1><?=$this->getTrans('boxSettings') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('boxNexttrainingLimit') ? 'has-error' : '' ?>">
-        <label for="limitNextTrainingInput" class="col-xl-2 control-label">
+        <label for="limitNextTrainingInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('boxNexttrainingLimit') ?>:
         </label>
         <div class="col-xl-1">

--- a/application/modules/user/views/admin/group/access.php
+++ b/application/modules/user/views/admin/group/access.php
@@ -5,7 +5,7 @@
       id="groupAccessForm">
     <?=$this->getTokenField() ?>
     <div class="row mb-3">
-        <label for="groupId" class="control-label col-md-2"><?=$this->getTrans('group') ?></label>
+        <label for="groupId" class="col-form-label col-md-2"><?=$this->getTrans('group') ?></label>
         <div class="col-md-10">
             <select class="form-select" id="groupId" name="groupId">
                 <option value="0"
@@ -22,7 +22,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="accessId" class="control-label col-md-2">
+        <label for="accessId" class="col-form-label col-md-2">
         <?php
         $accessTypes = $this->get('accessTypes');
         foreach ($accessTypes as $accessType => $typeData) {

--- a/application/modules/user/views/admin/group/treat.php
+++ b/application/modules/user/views/admin/group/treat.php
@@ -16,7 +16,7 @@ if ($group->getId()) {
            name="group[id]"
            value="<?=$group->getId() ?>" />
     <div class="row mb-3">
-        <label for="groupName" class="col-xl-3 control-label">
+        <label for="groupName" class="col-xl-3 col-form-label">
             <?=$this->getTrans('groupName') ?>
         </label>
         <div class="col-xl-9">

--- a/application/modules/user/views/admin/index/treat.php
+++ b/application/modules/user/views/admin/index/treat.php
@@ -15,7 +15,7 @@ if ($user->getId()) {
            name="id"
            value="<?=$user->getId() ?>" />
     <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-        <label for="name" class="col-xl-3 control-label">
+        <label for="name" class="col-xl-3 col-form-label">
             <?=$this->getTrans('userName') ?>
         </label>
         <div class="col-xl-9">
@@ -28,7 +28,7 @@ if ($user->getId()) {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
-        <label for="email" class="col-xl-3 control-label">
+        <label for="email" class="col-xl-3 col-form-label">
             <?=$this->getTrans('userEmail') ?>
         </label>
         <div class="col-xl-9">
@@ -41,7 +41,7 @@ if ($user->getId()) {
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('userPassword') ? 'has-error' : '' ?>">
-        <label for="password" class="col-xl-3 control-label">
+        <label for="password" class="col-xl-3 col-form-label">
             <?=$this->getTrans('userPassword') ?>
         </label>
         <div class="col-xl-9">
@@ -68,7 +68,7 @@ if ($user->getId()) {
         }
     ?>
         <div class="row mb-3">
-            <label class="col-xl-3 control-label">
+            <label class="col-xl-3 col-form-label">
                 <?=$this->getTrans('userDateCreated') ?>
             </label>
             <div class="col-xl-9">
@@ -76,7 +76,7 @@ if ($user->getId()) {
             </div>
         </div>
         <div class="row mb-3">
-            <label class="col-xl-3 control-label">
+            <label class="col-xl-3 col-form-label">
                 <?=$this->getTrans('userDateConfirmed') ?>
             </label>
             <div class="col-xl-9">
@@ -84,7 +84,7 @@ if ($user->getId()) {
             </div>
         </div>
         <div class="row mb-3">
-            <label class="col-xl-3 control-label">
+            <label class="col-xl-3 col-form-label">
                 <?=$this->getTrans('userDateLastActivity') ?>
             </label>
             <div class="col-xl-9">
@@ -93,7 +93,7 @@ if ($user->getId()) {
         </div>
     <?php endif; ?>
     <div class="row mb-3">
-        <div class="col-xl-3 control-label">
+        <div class="col-xl-3 col-form-label">
             <?=$this->getTrans('usergalleryAllowed') ?>
         </div>
         <div class="col-xl-9">
@@ -112,7 +112,7 @@ if ($user->getId()) {
     </div>
     <?php if ($user->getId()) : ?>
     <div class="row mb-3">
-        <div class="col-xl-3 control-label">
+        <div class="col-xl-3 col-form-label">
             <?=$this->getTrans('lockUser') ?>
         </div>
         <div class="col-xl-9">
@@ -131,7 +131,7 @@ if ($user->getId()) {
     </div>
     <?php endif; ?>
     <div class="row mb-3">
-        <label for="assignedGroups" class="col-xl-3 control-label">
+        <label for="assignedGroups" class="col-xl-3 col-form-label">
                 <?=$this->getTrans('assignedGroups') ?>
         </label>
         <div class="col-xl-9">
@@ -163,7 +163,7 @@ if ($user->getId()) {
     </div>
     <?php if ($user->getId()) : ?>
     <div class="row mb-3">
-        <label for="assignedGroups" class="col-xl-3 control-label">
+        <label for="assignedGroups" class="col-xl-3 col-form-label">
             <?=$this->getTrans('userProfile') ?>
         </label>
         <div class="col-xl-4">

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -46,7 +46,7 @@ $iconArray = [
 
     <!-- select profilefield -->
     <div class="row mb-3">
-        <label for="profileFieldType" class="col-xl-2 control-label">
+        <label for="profileFieldType" class="col-xl-2 col-form-label">
             <?=$this->getTrans('profileFieldType') ?>
         </label>
         <div class="col-xl-4">
@@ -70,7 +70,7 @@ $iconArray = [
 
     <!-- field description -->
     <div class="row mb-3">
-        <label for="profileFieldDescription" class="col-lg-2 control-label">
+        <label for="profileFieldDescription" class="col-lg-2 col-form-label">
             <?=$this->getTrans('profileFieldDescription') ?>
         </label>
         <div class="col-xl-4">
@@ -85,7 +85,7 @@ $iconArray = [
             $icon = ($profileField->getIcon() !== '') ? $profileField->getIcon() : $this->get('post')['symbol'];
         }
         ?>
-        <label for="profileFieldIcon" class="col-xl-2 control-label">
+        <label for="profileFieldIcon" class="col-xl-2 col-form-label">
             <?=$this->getTrans('profileFieldIcon') ?>:
         </label>
         <div class="col-xl-4 input-group ilch-date">
@@ -106,7 +106,7 @@ $iconArray = [
 
     <!-- db key -->
     <div class="row mb-3">
-        <label for="profileFieldKey" class="col-xl-2 control-label">
+        <label for="profileFieldKey" class="col-xl-2 col-form-label">
             <?=$this->getTrans('profileFieldKey') ?>
         </label>
         <div class="col-xl-4">
@@ -125,7 +125,7 @@ $iconArray = [
 
     <!-- icon addition -->
     <div class="row mb-3" id="profileFieldAddition" <?=($profileField->getType() == 2) ? '' : 'hidden' ?>>
-        <label for="profileFieldLinkAddition" class="col-xl-2 control-label">
+        <label for="profileFieldLinkAddition" class="col-xl-2 col-form-label">
             <?=$this->getTrans('profileFieldLinkAddition') ?>
         </label>
         <div class="col-xl-4">
@@ -144,7 +144,7 @@ $iconArray = [
         <div class="row mb-3" id="profileFieldTrans<?=$i ?>">
             <input type="hidden" name="profileFieldTrans<?=$i ?>[field_id]" value="<?=$profileField->getId() ?>" />
             <input type="hidden" name="profileFieldTrans<?=$i ?>[locale]" value="<?=$profileFieldTranslation->getLocale() ?>" />
-            <label for="profileFieldName<?=$i ?>" class="col-lg-2 control-label">
+            <label for="profileFieldName<?=$i ?>" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('profileFieldName') ?>
             </label>
             <div class="col-xl-4">
@@ -173,7 +173,7 @@ $iconArray = [
         <?php endforeach; ?>
         <div id="addTranslations"></div>
         <div class="row mb-3">
-            <label for="profileFieldTranslation" class="col-xl-2 control-label">
+            <label for="profileFieldTranslation" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('addProfileFieldTranslation') ?>
             </label>
             <div class="col-xl-4">
@@ -188,7 +188,7 @@ $iconArray = [
         <?php if ($profileField->getOptions()) : ?>
             <?php $options = json_decode($profileField->getOptions(), true); ?>
             <div class="mb-3">
-                <label for="profileFieldOptions" class="col-lg-2 control-label">
+                <label for="profileFieldOptions" class="col-lg-2 col-form-label">
                     <?=$this->getTrans('profileFieldOptions')  ?>
                 </label>
                 <div class="col-xl-4">
@@ -206,7 +206,7 @@ $iconArray = [
             </div>
         <?php else : ?>
         <div class="row mb-3">
-            <label for="profileFieldOptions" class="col-lg-2 control-label">
+            <label for="profileFieldOptions" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('profileFieldOptions') ?>
             </label>
             <div class="col-xl-4">
@@ -312,7 +312,7 @@ function addTranslations() {
         '<input type="hidden"' +
         'name="profileFieldTrans' + index + '[field_id]"' +
         'value="<?=$profileField->getId() ?>" />' +
-        '<label for="" class="col-lg-2 control-label"><?=$this->getTrans('profileFieldName') ?></label>' +
+        '<label for="" class="col-lg-2 col-form-label"><?=$this->getTrans('profileFieldName') ?></label>' +
         '<div class="col-lg-4">' +
         '<div class="input-group">' +
         '<select class="form-select" name="profileFieldTrans' + index + '[locale]" onchange="isDuplicate()" required>' +

--- a/application/modules/user/views/admin/providers/edit.php
+++ b/application/modules/user/views/admin/providers/edit.php
@@ -10,7 +10,7 @@
     <h1><?= $this->getTrans('authProvider') ?> <?= $this->get('provider')->getName() ?></h1>
     <?=$this->getTokenField() ?>
     <div class="row mb-3">
-        <label for="moduleInput" class="col-xl-3 control-label">
+        <label for="moduleInput" class="col-xl-3 col-form-label">
             <?=$this->getTrans('module') ?>
         </label>
         <div class="col-xl-9">

--- a/application/modules/user/views/admin/settings/index.php
+++ b/application/modules/user/views/admin/settings/index.php
@@ -2,7 +2,7 @@
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('acceptUserRegis') ?>:
         </div>
         <div class="col-xl-4">
@@ -17,7 +17,7 @@
     </div>
     <div id="registRules" <?=($this->get('regist_accept') != '1') ? 'hidden' : '' ?>>
         <div class="row mb-3">
-            <div class="col-xl-2 control-label">
+            <div class="col-xl-2 col-form-label">
                 <?=$this->getTrans('confirmRegistrationEmail') ?>:
             </div>
             <div class="col-xl-4">
@@ -33,7 +33,7 @@
     </div>
     <div id="registSetfree" <?=($this->get('regist_accept') == '1' && $this->get('regist_confirm') == '1') ? 'hidden' : '' ?>>
         <div class="row mb-3">
-            <div class="col-xl-2 control-label">
+            <div class="col-xl-2 col-form-label">
                 <?=$this->getTrans('setfreeRegistration') ?>:
             </div>
             <div class="col-xl-4">
@@ -49,7 +49,7 @@
     </div>
     <div id="rulesForRegist" <?=($this->get('regist_accept') != '1') ? 'class="hidden"' : '' ?>>
         <div class="row mb-3">
-            <label for="ck_1" class="col-xl-2 control-label">
+            <label for="ck_1" class="col-xl-2 col-form-label">
                     <?=$this->getTrans('rulesForRegist') ?>:
             </label>
             <div class="col-xl-10">
@@ -63,7 +63,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="delete_time" class="col-xl-2 control-label">
+        <label for="delete_time" class="col-xl-2 col-form-label">
             <?=$this->getTrans('deletetime') ?>
         </label>
         <div class="col-xl-2">
@@ -77,7 +77,7 @@
 
     <h1><?=$this->getTrans('menuSettingsAvatar') ?></h1>
     <div class="row mb-3">
-        <label for="avatar_height" class="col-xl-2 control-label">
+        <label for="avatar_height" class="col-xl-2 col-form-label">
             <?=$this->getTrans('avatarHeight') ?>
         </label>
         <div class="col-xl-2">
@@ -89,7 +89,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="avatar_width" class="col-xl-2 control-label">
+        <label for="avatar_width" class="col-xl-2 col-form-label">
             <?=$this->getTrans('avatarWidth') ?>
         </label>
         <div class="col-xl-2">
@@ -101,7 +101,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="avatar_size" class="col-xl-2 control-label">
+        <label for="avatar_size" class="col-xl-2 col-form-label">
             <?=$this->getTrans('avatarSizeBytes') ?>
         </label>
         <div class="col-xl-2">
@@ -113,7 +113,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="avatar_filetypes" class="col-xl-2 control-label">
+        <label for="avatar_filetypes" class="col-xl-2 col-form-label">
             <?=$this->getTrans('allowedFileExtensions') ?>
         </label>
         <div class="col-xl-2">
@@ -127,7 +127,7 @@
 
     <h1><?=$this->getTrans('menuSettingsGallery') ?></h1>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('usergalleryAllowed') ?>:
         </div>
         <div class="col-xl-4">
@@ -141,7 +141,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="usergallery_filetypes" class="col-xl-2 control-label">
+        <label for="usergallery_filetypes" class="col-xl-2 col-form-label">
             <?=$this->getTrans('allowedFileExtensions') ?>
         </label>
         <div class="col-xl-2">
@@ -153,7 +153,7 @@
         </div>
     </div>
     <div class="row mb-3">
-        <label for="picturesPerPageInput" class="col-xl-2 control-label">
+        <label for="picturesPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('picturesPerPage') ?>:
         </label>
         <div class="col-lg-1">
@@ -168,7 +168,7 @@
 
     <h1><?=$this->getTrans('UserGroupsList') ?></h1>
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('userGroupsAllowed') ?>:
         </div>
         <div class="col-xl-4">
@@ -184,7 +184,7 @@
     </div>
 
     <div class="row mb-3">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('userAvatarsAllowed') ?>:
         </div>
         <div class="col-xl-4">

--- a/application/modules/user/views/login/forgotpassword.php
+++ b/application/modules/user/views/login/forgotpassword.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
-        <label for="email" class="control-label col-xl-2">
+        <label for="email" class="col-form-label col-xl-2">
             <?=$this->getTrans('email') ?>:
         </label>
         <div class="col-xl-8">

--- a/application/modules/user/views/login/index.php
+++ b/application/modules/user/views/login/index.php
@@ -15,7 +15,7 @@
         <?=$this->getTokenField() ?>
         <input type="hidden" name="login_redirect_url" value="<?=$this->escape($this->get('redirectUrl')) ?>" />
         <div class="row mb-3 <?=$this->validation()->hasError('login_emailname') ? 'has-error' : '' ?>">
-            <label for="login_emailname" class="col-xl-2 control-label">
+            <label for="login_emailname" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('nameEmail') ?>:
             </label>
             <div class="col-xl-10">
@@ -30,7 +30,7 @@
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('login_password') ? 'has-error' : '' ?>">
-            <label for="login_password" class="col-xl-2 control-label">
+            <label for="login_password" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('password') ?>:
             </label>
             <div class="col-xl-10">

--- a/application/modules/user/views/login/newpassword.php
+++ b/application/modules/user/views/login/newpassword.php
@@ -2,7 +2,7 @@
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('password') ? 'has-error' : '' ?>">
-        <label class="col-xl-2 control-label">
+        <label class="col-xl-2 col-form-label">
             <?=$this->getTrans('profileNewPassword') ?>*
         </label>
         <div class="col-xl-8">
@@ -17,7 +17,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('password2') ? 'has-error' : '' ?>">
-        <label class="col-xl-2 control-label">
+        <label class="col-xl-2 col-form-label">
             <?=$this->getTrans('profileNewPasswordRetype') ?>*
         </label>
         <div class="col-xl-8">

--- a/application/modules/user/views/mail/index.php
+++ b/application/modules/user/views/mail/index.php
@@ -5,7 +5,7 @@
         <form method="POST">
             <?=$this->getTokenField() ?>
             <div class="row mb-3 <?=$this->validation()->hasError('subject') ? 'has-error' : '' ?>">
-                <label for="subject" class="col-xl-2 control-label">
+                <label for="subject" class="col-xl-2 col-form-label">
                     <?=$this->getTrans('subject') ?>:
                 </label>
                 <div class="col-xl-8">
@@ -17,7 +17,7 @@
                 </div>
             </div>
             <div class="row mb-3 <?=$this->validation()->hasError('message') ? 'has-error' : '' ?>">
-                <label for="message" class="col-xl-2 control-label">
+                <label for="message" class="col-xl-2 col-form-label">
                     <?=$this->getTrans('message') ?>:
                 </label>
                 <div class="col-xl-8">

--- a/application/modules/user/views/panel/gallery.php
+++ b/application/modules/user/views/panel/gallery.php
@@ -79,7 +79,7 @@ function rec($item, $galleryMapper, $obj, $imageMapper)
                         <div class="col-xl-7 changeBox">
                             <input type="hidden" id="id" value="" />
                             <div class="row mb-3">
-                                <label for="title" class="col-xl-4 control-label">
+                                <label for="title" class="col-xl-4 col-form-label">
                                     <?=$this->getTrans('title') ?>:
                                 </label>
                                 <div class="col-xl-8">
@@ -90,7 +90,7 @@ function rec($item, $galleryMapper, $obj, $imageMapper)
                                 </div>
                             </div>
                             <div class="row mb-3">
-                                <label for="desc" class="col-xl-4 control-label">
+                                <label for="desc" class="col-xl-4 col-form-label">
                                     <?=$this->getTrans('description') ?>:
                                 </label>
                                 <div class="col-xl-8">
@@ -101,7 +101,7 @@ function rec($item, $galleryMapper, $obj, $imageMapper)
                                 </div>
                             </div>
                             <div class="row mb-3">
-                                <label for="type" class="col-xl-4 control-label">
+                                <label for="type" class="col-xl-4 col-form-label">
                                     <?=$this->getTrans('type') ?>:
                                 </label>
                                 <div class="col-xl-8">
@@ -113,7 +113,7 @@ function rec($item, $galleryMapper, $obj, $imageMapper)
                             </div>
                             <div class="dyn"></div>
                             <div class="row mb-3">
-                                <label class="col-xl-4 control-label"></label>
+                                <label class="col-xl-4 col-form-label"></label>
                                 <div class="col-xl-8 actions">
                                     <input type="button" class="btn btn-outline-secondary" id="menuItemAdd" value="<?=$this->getTrans('galleryItemAdd') ?>">
                                 </div>
@@ -192,7 +192,7 @@ $(document).ready (
                 return;
             }
 
-            menuHtml = '<div class="row mb-3"><label for="href" class="col-lg-4 control-label">Kategorie:</label>\n\
+            menuHtml = '<div class="row mb-3"><label for="href" class="col-lg-4 col-form-label">Kategorie:</label>\n\
                         <div class="col-xl-8"><select class="form-select" id="menukey">'+options+'</select></div></div>';
 
             if ($(this).val() == '0') {

--- a/application/modules/user/views/panel/password.php
+++ b/application/modules/user/views/panel/password.php
@@ -9,7 +9,7 @@
             <form method="POST">
                 <?=$this->getTokenField() ?>
                 <div class="row mb-3 <?=$this->validation()->hasError('password') ? 'has-error' : '' ?>">
-                    <label class="col-lg-2 control-label">
+                    <label class="col-lg-2 col-form-label">
                         <?=$this->getTrans('profileNewPassword') ?>*
                     </label>
                     <div class="col-xl-8">
@@ -24,7 +24,7 @@
                     </div>
                 </div>
                 <div class="row mb-3 <?=$this->validation()->hasError('password2') ? 'has-error' : '' ?>">
-                    <label class="col-xl-2 control-label">
+                    <label class="col-xl-2 col-form-label">
                         <?=$this->getTrans('profileNewPasswordRetype') ?>*
                     </label>
                     <div class="col-xl-8">

--- a/application/modules/user/views/panel/profile.php
+++ b/application/modules/user/views/panel/profile.php
@@ -21,7 +21,7 @@ if (!empty($profil->getBirthday())) {
             <form method="POST">
                 <?=$this->getTokenField() ?>
                 <div class="row mb-3 <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
-                    <label class="col-xl-2 control-label">
+                    <label class="col-xl-2 col-form-label">
                         <?=$this->getTrans('profileEmail') ?>*
                     </label>
                     <div class="col-xl-8">
@@ -34,7 +34,7 @@ if (!empty($profil->getBirthday())) {
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label class="col-xl-2 control-label">
+                    <label class="col-xl-2 col-form-label">
                         <?=$this->getTrans('profileFirstName') ?>
                     </label>
                     <div class="col-xl-8">
@@ -46,7 +46,7 @@ if (!empty($profil->getBirthday())) {
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label class="col-xl-2 control-label">
+                    <label class="col-xl-2 col-form-label">
                         <?=$this->getTrans('profileLastName') ?>
                     </label>
                     <div class="col-xl-8">
@@ -58,7 +58,7 @@ if (!empty($profil->getBirthday())) {
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label class="col-xl-2 control-label">
+                    <label class="col-xl-2 col-form-label">
                         <?=$this->getTrans('profileGender') ?>
                     </label>
                     <div class="col-xl-8">
@@ -71,7 +71,7 @@ if (!empty($profil->getBirthday())) {
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label class="col-xl-2 control-label">
+                    <label class="col-xl-2 col-form-label">
                         <?=$this->getTrans('profileCity') ?>
                     </label>
                     <div class="col-xl-8">
@@ -83,7 +83,7 @@ if (!empty($profil->getBirthday())) {
                     </div>
                 </div>
                 <div class="row mb-3">
-                    <label class="col-xl-2 control-label">
+                    <label class="col-xl-2 col-form-label">
                         <?=$this->getTrans('profileBirthday') ?>
                     </label>
                     <div id="birthday" class="col-xl-8 input-group ilch-date date form_datetime">
@@ -123,7 +123,7 @@ if (!empty($profil->getBirthday())) {
                             }
                         } ?>
                         <div class="row mb-3">
-                            <label class="col-xl-2 control-label">
+                            <label class="col-xl-2 col-form-label">
                                 <?=$this->escape($profileFieldName) ?>
                             </label>
                             <div class="col-xl-8">

--- a/application/modules/user/views/panel/setting.php
+++ b/application/modules/user/views/panel/setting.php
@@ -9,7 +9,7 @@
             <form method="POST">
                 <?=$this->getTokenField() ?>
                 <div class="row mb-3 <?=$this->validation()->hasError('locale') ? 'has-error' : '' ?>">
-                    <div class="col-xl-3 control-label">
+                    <div class="col-xl-3 col-form-label">
                         <?=$this->getTrans('locale') ?>
                     </div>
                     <div class="col-xl-2">
@@ -26,7 +26,7 @@
                     </div>
                 </div>
                 <div class="row mb-3 <?=$this->validation()->hasError('optMail') ? 'has-error' : '' ?>">
-                    <div class="col-xl-3 control-label">
+                    <div class="col-xl-3 col-form-label">
                         <?=$this->getTrans('optMail') ?>
                     </div>
                     <div class="col-xl-4">

--- a/application/modules/user/views/panel/treatgalleryimage.php
+++ b/application/modules/user/views/panel/treatgalleryimage.php
@@ -18,7 +18,7 @@
                     </div>
                     <div class="col-lg-7">
                         <div class="row lg-3">
-                            <label for="imageTitleInput" class="col-lg-4 control-label">
+                            <label for="imageTitleInput" class="col-lg-4 col-form-label">
                                 <?=$this->getTrans('title') ?>:
                             </label>
                             <div class="col-xl-8">
@@ -30,7 +30,7 @@
                             </div>
                         </div>
                         <div class="row lg-3">
-                            <label for="imageDescInput" class="col-lg-4 control-label">
+                            <label for="imageDescInput" class="col-lg-4 col-form-label">
                                 <?=$this->getTrans('description') ?>:
                             </label>
                             <div class="col-xl-8">

--- a/application/modules/user/views/regist/input.php
+++ b/application/modules/user/views/regist/input.php
@@ -12,7 +12,7 @@ $errors = $this->get('errors');
         </div>
         <div class="card-body">
             <div class="row mb-3 d-none">
-                <label class="col-xl-2 control-label">
+                <label class="col-xl-2 col-form-label">
                     <?=$this->getTrans('bot') ?>*
                 </label>
                 <div class="col-xl-8">
@@ -23,7 +23,7 @@ $errors = $this->get('errors');
                 </div>
             </div>
             <div class="row mb-3 <?=$this->validation()->hasError('name') ? 'has-error' : '' ?>">
-                <label for="name" class="control-label col-xl-2">
+                <label for="name" class="col-form-label col-xl-2">
                     <?=$this->getTrans('name') ?>:
                 </label>
                 <div class="col-xl-8">
@@ -36,7 +36,7 @@ $errors = $this->get('errors');
                 </div>
             </div>
             <div class="row mb-3 <?=$this->validation()->hasError('password') ? 'has-error' : '' ?>">
-                <label for="password" class="control-label col-xl-2">
+                <label for="password" class="col-form-label col-xl-2">
                     <?=$this->getTrans('password') ?>:
                 </label>
                 <div class="col-xl-8">
@@ -49,7 +49,7 @@ $errors = $this->get('errors');
                 </div>
             </div>
             <div class="row mb-3 <?=$this->validation()->hasError('password2') ? 'has-error' : '' ?>">
-                <label for="password2" class="control-label col-xl-2">
+                <label for="password2" class="col-form-label col-xl-2">
                     <?=$this->getTrans('password2') ?>:
                 </label>
                 <div class="col-xl-8">
@@ -62,7 +62,7 @@ $errors = $this->get('errors');
                 </div>
             </div>
             <div class="row mb-3 <?=$this->validation()->hasError('email') ? 'has-error' : '' ?>">
-                <label for="email" class="control-label col-xl-2">
+                <label for="email" class="col-form-label col-xl-2">
                     <?=$this->getTrans('emailAdress') ?>:
                 </label>
                 <div class="col-xl-8">

--- a/application/modules/vote/views/admin/index/treat.php
+++ b/application/modules/vote/views/admin/index/treat.php
@@ -10,7 +10,7 @@ $vote = $this->get('vote');
 <form role="form" method="POST">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('groups') ? 'has-error' : '' ?>">
-        <label for="group" class="col-xl-2 control-label">
+        <label for="group" class="col-xl-2 col-form-label">
             <?=$this->getTrans('participationGroup') ?>
         </label>
         <div class="col-xl-4">
@@ -30,7 +30,7 @@ $vote = $this->get('vote');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('access') ? 'has-error' : '' ?>">
-        <label for="access" class="col-xl-2 control-label">
+        <label for="access" class="col-xl-2 col-form-label">
             <?=$this->getTrans('visibleFor') ?>
         </label>
         <div class="col-xl-4">
@@ -50,7 +50,7 @@ $vote = $this->get('vote');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('question') ? 'has-error' : '' ?>">
-        <label for="question" class="col-xl-2 control-label">
+        <label for="question" class="col-xl-2 col-form-label">
             <?=$this->getTrans('question') ?>
         </label>
         <div class="col-xl-4">
@@ -62,7 +62,7 @@ $vote = $this->get('vote');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('multiplereply') ? 'has-error' : '' ?>">
-        <div class="col-xl-2 control-label">
+        <div class="col-xl-2 col-form-label">
             <?=$this->getTrans('multiplereply') ?>
         </div>
         <div class="col-xl-4">
@@ -76,7 +76,7 @@ $vote = $this->get('vote');
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('reply') ? 'has-error' : '' ?>">
-        <label for="reply" class="col-xl-2 control-label">
+        <label for="reply" class="col-xl-2 col-form-label">
             <?=$this->getTrans('reply') ?>
         </label>
         <?php if ($vote->getId()) : ?>

--- a/application/modules/war/views/admin/ajax/game.php
+++ b/application/modules/war/views/admin/ajax/game.php
@@ -8,7 +8,7 @@
         <input type="hidden" name="warGameIds[]" value="<?=$game->getId() ?>">
         <?php endif; ?>
         <div class=" row mb-3 ">
-            <label class="col-xl-2 control-label" for="warMapPlayed[]">
+            <label class="col-xl-2 col-form-label" for="warMapPlayed[]">
                 <?=$this->getTrans('warMapName') ?>
                 <?php if ($game->getId()): ?>
                 <a id="<?=$game->getId() ?>"
@@ -31,7 +31,7 @@
             </div>
         </div>
         <div class="row mb-3 ">
-            <label class="col-xl-2 control-label" for="warErgebnis[]">
+            <label class="col-xl-2 col-form-label" for="warErgebnis[]">
                 <?=$this->getTrans('warResult') ?>
             </label>
             <div class="col-xl-2">
@@ -61,7 +61,7 @@
 <?php endforeach; ?>
 </div>
 <div class="row mb-3 ">
-    <label class="col-xl-2 control-label" for="textinput"></label>
+    <label class="col-xl-2 col-form-label" for="textinput"></label>
     <div class="col-xl-2">
         <a id="button-duplicater" class="btn btn-outline-secondary"><?=$this->getTrans('warMoreMaps') ?></a>
     </div>

--- a/application/modules/war/views/admin/enemy/treat.php
+++ b/application/modules/war/views/admin/enemy/treat.php
@@ -3,7 +3,7 @@
 <form id="article_form" method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('enemyName') ? ' has-error' : '' ?>">
-        <label for="enemyNameInput" class="col-xl-2 control-label">
+        <label for="enemyNameInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('enemyName') ?>:
         </label>
         <div class="col-xl-4">
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('enemyTag') ? ' has-error' : '' ?>">
-        <label for="enemyTagInput" class="col-xl-2 control-label">
+        <label for="enemyTagInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('enemyTag') ?>:
         </label>
         <div class="col-xl-4">
@@ -27,7 +27,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('enemyHomepage') ? ' has-error' : '' ?>">
-        <label for="enemyHomepageInput" class="col-xl-2 control-label">
+        <label for="enemyHomepageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('enemyHomepage') ?>:
         </label>
         <div class="col-xl-4">
@@ -39,7 +39,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('enemyImage') ? ' has-error' : '' ?>">
-        <label for="selectedImage" class="col-xl-2 control-label">
+        <label for="selectedImage" class="col-xl-2 col-form-label">
             <?=$this->getTrans('enemyImage') ?>:
         </label>
         <div class="col-xl-4">
@@ -57,7 +57,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('enemyContactName') ? ' has-error' : '' ?>">
-        <label for="enemyContactNameInput" class="col-xl-2 control-label">
+        <label for="enemyContactNameInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('enemyContactName') ?>:
         </label>
         <div class="col-xl-4">
@@ -69,7 +69,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('enemyContactEmail') ? ' has-error' : '' ?>">
-        <label for="enemyContactEmailInput" class="col-xl-2 control-label">
+        <label for="enemyContactEmailInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('enemyContactEmail') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/war/views/admin/group/treat.php
+++ b/application/modules/war/views/admin/group/treat.php
@@ -3,7 +3,7 @@
 <form id="article_form" method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('groupName') ? ' has-error' : '' ?>">
-        <label for="groupNameInput" class="col-xl-2 control-label">
+        <label for="groupNameInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('groupName') ?>:
         </label>
         <div class="col-xl-4">
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('groupTag') ? ' has-error' : '' ?>">
-        <label for="groupTagInput" class="col-xl-2 control-label">
+        <label for="groupTagInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('groupTag') ?>:
         </label>
         <div class="col-xl-4">
@@ -27,7 +27,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('groupImage') ? ' has-error' : '' ?>">
-        <label for="selectedImage_1" class="col-xl-2 control-label">
+        <label for="selectedImage_1" class="col-xl-2 col-form-label">
             <?=$this->getTrans('groupImage') ?>:
         </label>
         <div class="col-xl-4">
@@ -45,7 +45,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('groupDesc') ? ' has-error' : '' ?>">
-        <label for="groupDesc" class="col-xl-2 control-label">
+        <label for="groupDesc" class="col-xl-2 col-form-label">
             <?=$this->getTrans('groupDesc') ?>:
         </label>
         <div class="col-xl-4">
@@ -60,7 +60,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('userGroup') ? ' has-error' : '' ?>">
-        <label for="warGroup" class="col-xl-2 control-label">
+        <label for="warGroup" class="col-xl-2 col-form-label">
             <?=$this->getTrans('assignedMember') ?>
         </label>
         <div class="col-xl-4">

--- a/application/modules/war/views/admin/icons/treat.php
+++ b/application/modules/war/views/admin/icons/treat.php
@@ -3,7 +3,7 @@
 <form id="warIcon_form" method="POST" action="" enctype="multipart/form-data">
     <?=$this->getTokenField() ?>
     <div class="row mb-3<?=$this->validation()->hasError('gameName') ? ' has-error' : '' ?>">
-        <label for="gameNameInput" class="col-xl-2 control-label">
+        <label for="gameNameInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('gameName') ?>:
         </label>
         <div class="col-xl-6">
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('gameIcon') ? ' has-error' : '' ?>">
-        <label for="gameIcon" class="col-xl-2 control-label">
+        <label for="gameIcon" class="col-xl-2 col-form-label">
             <?=$this->getTrans('gameIcon') ?><br>
         </label>
         <div class="col-xl-6">

--- a/application/modules/war/views/admin/index/index.php
+++ b/application/modules/war/views/admin/index/index.php
@@ -1,7 +1,7 @@
 <h1><?=$this->getTrans('manageWarOverview') ?></h1>
 <?php if ($this->get('war')): ?>
     <div class="row mb-3">
-        <label class="col-lg-2 control-label" for="filterLastNext">
+        <label class="col-lg-2 col-form-label" for="filterLastNext">
             <?=$this->getTrans('showOnly') ?>
         </label>
         <div class="col-lg-2">

--- a/application/modules/war/views/admin/index/treat.php
+++ b/application/modules/war/views/admin/index/treat.php
@@ -10,7 +10,7 @@ use Ilch\Date;
     <form method="POST" action="">
         <?=$this->getTokenField() ?>
         <div class="row mb-3 <?=$this->validation()->hasError('warEnemy') ? ' has-error' : '' ?>">
-            <label for="warEnemy" class="col-xl-2 control-label">
+            <label for="warEnemy" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('warEnemy') ?>:
             </label>
             <div class="col-xl-4">
@@ -24,7 +24,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('warGroup') ? ' has-error' : '' ?>">
-            <label for="warGroup" class="col-xl-2 control-label">
+            <label for="warGroup" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('warGroup') ?>:
             </label>
             <div class="col-xl-4">
@@ -38,7 +38,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('warTime') ? ' has-error' : '' ?>">
-            <label for="warTimeInput" class="col-lg-2 control-label">
+            <label for="warTimeInput" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('warTime') ?>:
             </label>
             <div id="warTime" class="input-group ilch-date date form_datetime col-xl-4">
@@ -55,7 +55,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('warMap') ? ' has-error' : '' ?>">
-            <label for="warMapInput" class="col-xl-2 control-label">
+            <label for="warMapInput" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('warMap') ?>
             </label>
             <div class="col-xl-4">
@@ -67,7 +67,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('warServer') ? ' has-error' : '' ?>">
-            <label for="warServerInput" class="col-xl-2 control-label">
+            <label for="warServerInput" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('warServer') ?>:
             </label>
             <div class="col-xl-4">
@@ -79,7 +79,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('warPassword') ? ' has-error' : '' ?>">
-            <label for="warPasswordInput" class="col-lg-2 control-label">
+            <label for="warPasswordInput" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('warPassword') ?>:
             </label>
             <div class="col-xl-4">
@@ -91,7 +91,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('warXonx') ? ' has-error' : '' ?>">
-            <label for="warXonx" class="col-xl-2 control-label">
+            <label for="warXonx" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('warXonx') ?>:
             </label>
             <div class="col-xl-2">
@@ -116,7 +116,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('warGame') ? ' has-error' : '' ?>">
-            <label for="warGame" class="col-xl-2 control-label">
+            <label for="warGame" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('warGame') ?>:
             </label>
             <div class="col-xl-2">
@@ -141,7 +141,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('warMatchtype') ? ' has-error' : '' ?>">
-            <label for="warMatchtype" class="col-xl-2 control-label">
+            <label for="warMatchtype" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('warMatchtype') ?>:
             </label>
             <div class="col-xl-2">
@@ -166,7 +166,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('lastAcceptTime') ? ' has-error' : '' ?>">
-            <label for="lastAcceptTimeInput" class="col-xl-2 control-label">
+            <label for="lastAcceptTimeInput" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('lastAcceptTime') ?>:
             </label>
             <div class="col-xl-4">
@@ -201,7 +201,7 @@ use Ilch\Date;
             </div>
         </div>
         <div class="row mb-3 <?=$this->validation()->hasError('groups') ? ' has-error' : '' ?>">
-            <label for="access" class="col-xl-2 control-label">
+            <label for="access" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('visibleFor') ?>
             </label>
             <div class="col-xl-6">
@@ -217,7 +217,7 @@ use Ilch\Date;
         </div>
         <?php if ($this->get('calendarShow') == 1): ?>
         <div class="row mb-3 <?=$this->validation()->hasError('calendarShow') ? ' has-error' : '' ?>">
-            <label for="calendarShow" class="col-xl-2 control-label">
+            <label for="calendarShow" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('calendarShow') ?>:
             </label>
             <div class="col-xl-4">
@@ -233,7 +233,7 @@ use Ilch\Date;
         <?php endif; ?>
         <h1><?=$this->getTrans('warStatus') ?></h1>
         <div class="row mb-3 <?=$this->validation()->hasError('warStatus') ? ' has-error' : '' ?>">
-            <label for="warStatus" class="col-xl-2 control-label">
+            <label for="warStatus" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('warStatus') ?>:
             </label>
             <div class="col-xl-4">

--- a/application/modules/war/views/admin/maps/treat.php
+++ b/application/modules/war/views/admin/maps/treat.php
@@ -3,7 +3,7 @@
 <form id="article_form" method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('mapsName') ? ' has-error' : '' ?>">
-        <label for="mapsNameInput" class="col-xl-2 control-label">
+        <label for="mapsNameInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('mapsName') ?>:
         </label>
         <div class="col-xl-4">

--- a/application/modules/war/views/admin/settings/index.php
+++ b/application/modules/war/views/admin/settings/index.php
@@ -2,7 +2,7 @@
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <div class="row mb-3 <?=$this->validation()->hasError('warsPerPage') ? 'has-error' : '' ?>">
-        <label for="warsPerPageInput" class="col-xl-2 control-label">
+        <label for="warsPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('warsPerPage') ?>:
         </label>
         <div class="col-xl-1">
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('enemiesPerPage') ? 'has-error' : '' ?>">
-        <label for="enemiesPerPageInput" class="col-xl-2 control-label">
+        <label for="enemiesPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('enemiesPerPage') ?>:
         </label>
         <div class="col-xl-1">
@@ -28,7 +28,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('groupsPerPage') ? 'has-error' : '' ?>">
-        <label for="groupsPerPageInput" class="col-xl-2 control-label">
+        <label for="groupsPerPageInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('groupsPerPage') ?>:
         </label>
         <div class="col-xl-1">
@@ -43,7 +43,7 @@
 
     <h1><?=$this->getTrans('boxSettings') ?></h1>
     <div class="row mb-3 <?=$this->validation()->hasError('boxNextWarLimit') ? 'has-error' : '' ?>">
-        <label for="limitNextWarInput" class="col-xl-2 control-label">
+        <label for="limitNextWarInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('nextWarLimit') ?>:
         </label>
         <div class="col-xl-1">
@@ -56,7 +56,7 @@
         </div>
     </div>
     <div class="row mb-3 <?=$this->validation()->hasError('boxLastWarLimit') ? 'has-error' : '' ?>">
-        <label for="limitLastWarInput" class="col-xl-2 control-label">
+        <label for="limitLastWarInput" class="col-xl-2 col-form-label">
             <?=$this->getTrans('lastWarLimit') ?>:
         </label>
         <div class="col-xl-1">


### PR DESCRIPTION
# Description
"Renamed .control-label to .col-form-label."
https://getbootstrap.com/docs/4.0/migration/#forms-1
