### PR TITLE
Article: Fix "Passing null to parameter of type string is deprecated"

### DIFF
--- a/application/modules/article/controllers/Index.php
+++ b/application/modules/article/controllers/Index.php
@@ -115,7 +115,8 @@ class Index extends \Ilch\Controller\Frontend
                 ->setReadAccess($groups)
                 ->setImage($this->getRequest()->getPost('image'))
                 ->setImageSource($this->getRequest()->getPost('imageSource'))
-                ->setVisits(0);
+                ->setVisits(0)
+                ->setVotes('');
         } else {
             $article = $articleMapper->getArticleByIdLocale($this->getRequest()->getParam('id'), $this->locale);
         }


### PR DESCRIPTION
# Description
Article: Fix "Passing null to parameter of type string is deprecated" in preview

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
