### PR TITLE
Version 2.1.60

### DIFF
--- a/application/modules/admin/controllers/admin/Layouts.php
+++ b/application/modules/admin/controllers/admin/Layouts.php
@@ -336,7 +336,7 @@ class Layouts extends \Ilch\Controller\Admin
         if ($this->getRequest()->isPost()) {
             $postedSettings = [];
             foreach ($settings as $key => $value) {
-                if ($this->getRequest()->getPost($key) && $value['type'] !== 'separator') {
+                if ($value['type'] !== 'separator') {
                     $layoutAdvSettingsModel = new LayoutAdvSettingsModel();
                     $layoutAdvSettingsModel->setLayoutKey($layoutKey)
                         ->setKey($key)

--- a/application/modules/training/config/config.php
+++ b/application/modules/training/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'training',
-        'version' => '1.8.0',
+        'version' => '1.8.1',
         'icon_small' => 'fa-solid fa-graduation-cap',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -263,7 +263,9 @@ class Config extends \Ilch\Config\Install
                 $this->db()->query('ALTER TABLE `[prefix]_training_entrants` ADD INDEX `FK_[prefix]_training_entrants_[prefix]_users` (`user_id`) USING BTREE;');
                 $this->db()->query('ALTER TABLE `[prefix]_training_entrants` ADD CONSTRAINT `FK_[prefix]_training_entrants_[prefix]_training` FOREIGN KEY (`train_id`) REFERENCES `[prefix]_training` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
                 $this->db()->query('ALTER TABLE `[prefix]_training_entrants` ADD CONSTRAINT `FK_[prefix]_training_entrants_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
-            // no break
+                // no break
+            case "1.8.0":
+                // no break
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';

--- a/application/modules/training/mappers/Entrants.php
+++ b/application/modules/training/mappers/Entrants.php
@@ -75,7 +75,7 @@ class Entrants extends \Ilch\Mapper
      * Gets the Event entrants.
      *
      * @param int $trainId
-     * @return EntrantsModel[]|[]
+     * @return EntrantsModel[]|null
      */
     public function getEntrantsById(int $trainId): ?array
     {

--- a/application/modules/training/views/index/index.php
+++ b/application/modules/training/views/index/index.php
@@ -31,7 +31,7 @@ $training = $this->get('training');
                         <td><?=date('d.m.Y', strtotime($model->getDate())) ?> <?=$this->getTrans('at') ?> <?=date('H:i', strtotime($model->getDate())) ?> <?=$this->getTrans('clock') ?></td>
                         <td><a href="<?=$this->getUrl('training/index/show/id/' . $model->getId()) ?>"><?=$this->escape($model->getTitle()) ?></a></td>
                         <td><?=$this->escape($model->getPlace()) ?></td>
-                        <td class="text-center"><?=count($entrantsMapper->getEntrantsById($model->getId())) ?></td>
+                        <td class="text-center"><?=count($entrantsMapper->getEntrantsById($model->getId()) ?? []) ?></td>
                     </tr>
                 <?php endforeach; ?>
             <?php else : ?>

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@ header('Content-Type: text/html; charset=utf-8');
 $serverTimeZone = @date_default_timezone_get();
 date_default_timezone_set('UTC');
 
-define('VERSION', '2.1.59');
+define('VERSION', '2.1.60');
 define('SERVER_TIMEZONE', $serverTimeZone);
 define('DEFAULT_MODULE', 'page');
 define('DEFAULT_LAYOUT', 'index');


### PR DESCRIPTION
**Version 2.1.60**

Als eine der letzten offiziell unterstützten Versionen von Linux-Distributionen mit PHP 7.3 wird Debian 10 am 30. Juni 2024 den Support einstellen. Ab diesem Stichtag wird auch Ilch 2 kein PHP 7.3 mehr unterstützen. Wir empfehlen daher rechtzeitig auf neuere PHP-Versionen zu wechseln.  
  
Sollten Sie noch Inhalte im BBCode-Format haben, wird empfohlen diese bis vor Mitte des Jahres zu konvertieren. Ab diesem Zeitpunkt wird das BBCode-Konvertierung-Modul nicht mehr gepflegt.  
  
<a href="https://github.com/IlchCMS/Ilch-2.0/wiki/Hinweise-f%C3%BCr-Entwickler" target="_blank">Hinweise für Entwickler</a>  
**Ilch:**  
- Einige erweiterte Layout Einstellungen wurden seit Ilch 2.1.59 nicht gespeichert.  
  
**Artikel-Modul:**  
- Fehler in der Vorschau behoben.  
  
**Benutzer-Modul:**  
- Der Editor war im Chat bei einigen Layouts abgeschnitten und daher nicht nutzbar.

**BBCode-Konvertierung-Modul (1.0.8):**

- Unterstützung für die aktuelle Version von Ilch.

**Galerie-Modul (1.22.2):**

- Fehler bei fehlender Galerie und fehlenden Box-Einstellungen behoben.

**War-Modul (1.15.5):**

- Filter-Funktion im Admincenter war ohne Funktion.

**Training-Modul (1.8.1):**

- Fehler bei einem leeren Array behoben.

**Wie halte ich Ilch auf den aktuellen Stand?**  
<a href="https://github.com/IlchCMS/Ilch-2.0/wiki/Doku-Benutzer-Ilch-aktuell-halten" target="_blank">Doku Benutzer Ilch aktuell halten</a>