### PR TITLE
Layouts and modules: Check if compatible with Ilch >= 2.2.0

### DIFF
--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -252,6 +252,7 @@ return [
     'dbVersionError' => 'Die Version der Datenbank-Software ist zu alt.',
     'phpVersionError' => 'Die Version von PHP ist zu alt.',
     'ilchCoreError' => 'Die Ilch-Kern Version ist zu alt.',
+    'layoutTooOld' => 'Das Layout ist möglicherweise zu alt und nicht mit Ilch 2.2.0 oder neuer kompatibel.',
     'dependencyError' => 'Abhängigkeiten sind nicht erfüllt.',
     'dependencyInfo' => 'Andere Module sind von diesem Modul abhängig. Deinstallieren oder aktualisieren Sie diese Module zuerst.',
     'requirements' => 'Anforderungen',

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -253,6 +253,7 @@ return [
     'phpVersionError' => 'Die Version von PHP ist zu alt.',
     'ilchCoreError' => 'Die Ilch-Kern Version ist zu alt.',
     'layoutTooOld' => 'Das Layout ist möglicherweise zu alt und nicht mit Ilch 2.2.0 oder neuer kompatibel.',
+    'moduleTooOld' => 'Das Modul ist möglicherweise zu alt und nicht mit Ilch 2.2.0 oder neuer kompatibel.',
     'dependencyError' => 'Abhängigkeiten sind nicht erfüllt.',
     'dependencyInfo' => 'Andere Module sind von diesem Modul abhängig. Deinstallieren oder aktualisieren Sie diese Module zuerst.',
     'requirements' => 'Anforderungen',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -253,6 +253,7 @@ return [
     'dbVersionError' => 'The version of the database software is too old.',
     'ilchCoreError' => 'The Ilch-core version is too old.',
     'layoutTooOld' => 'The layout is possibly too old and not compatible with Ilch 2.2.0 or newer.',
+    'moduleTooOld' => 'The module is possibly too old and not compatible with Ilch 2.2.0 or newer.',
     'dependencyError' => 'Dependencies not fullfilled',
     'dependencyInfo' => 'Other moduls are dependent on this module. Uninstall or update these moduls first.',
     'requirements' => 'Requirements',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -252,6 +252,7 @@ return [
     'phpVersionError' => 'The version of PHP is too old.',
     'dbVersionError' => 'The version of the database software is too old.',
     'ilchCoreError' => 'The Ilch-core version is too old.',
+    'layoutTooOld' => 'The layout is possibly too old and not compatible with Ilch 2.2.0 or newer.',
     'dependencyError' => 'Dependencies not fullfilled',
     'dependencyInfo' => 'Other moduls are dependent on this module. Uninstall or update these moduls first.',
     'requirements' => 'Requirements',

--- a/application/modules/admin/views/admin/layouts/index.php
+++ b/application/modules/admin/views/admin/layouts/index.php
@@ -46,10 +46,13 @@ $modulesNotInstalled = $this->get('modulesNotInstalled');
                 <div class="clearfix">
                     <div class="float-start">
                         <?php
+                        // "layoutTooOld" was added to prevent the usage of old and likely with Ilch 2.2.0 and newer incompatible layouts.
                         if (empty($layout->getIlchCore())) {
                             $ilchCoreTooOld = false;
+                            $layoutTooOld = true;
                         } else {
                             $ilchCoreTooOld = version_compare($coreVersion, $layout->getIlchCore(), '<');
+                            $layoutTooOld = version_compare('2.2.0', $layout->getIlchCore(), '>');
                         }
 
                         $moduleNotInstalled = ($layout->getModulekey() != '' && isset($modulesNotInstalled[$layout->getModulekey()]));
@@ -66,6 +69,11 @@ $modulesNotInstalled = $this->get('modulesNotInstalled');
                             <?php if (version_compare($coreVersion, $layoutOnUpdateServerFound->ilchCore, '<')): ?>
                                 <button class="btn disabled"
                                         title="<?=$this->getTrans('ilchCoreError') ?>">
+                                    <i class="fa-solid fa-arrows-rotate"></i>
+                                </button>
+                            <?php elseif ($layoutTooOld) : ?>
+                                <button class="btn disabled"
+                                        title="<?=$this->getTrans('layoutTooOld') ?>">
                                     <i class="fa-solid fa-arrows-rotate"></i>
                                 </button>
                             <?php else: ?>
@@ -89,6 +97,11 @@ $modulesNotInstalled = $this->get('modulesNotInstalled');
                                             title="<?=$this->getTrans('ilchCoreError') ?>">
                                         <i class="fa"></i>
                                     </button>
+                                <?php elseif ($layoutTooOld) : ?>
+                                    <button class="btn btn-outline-secondary unchecked disabled"
+                                            title="<?=$this->getTrans('layoutTooOld') ?>">
+                                        <i class="fa"></i>
+                                    </button>
                                 <?php elseif ($moduleNotInstalled) : ?>
                                     <button class="btn btn-outline-secondary unchecked disabled"
                                             title="<?=$this->getTrans('layoutModuleNotInstalled') ?>">
@@ -105,6 +118,11 @@ $modulesNotInstalled = $this->get('modulesNotInstalled');
                         <?php if ($ilchCoreTooOld) : ?>
                             <button class="btn btn-outline-secondary disabled"
                                     title="<?=$this->getTrans('ilchCoreError') ?>">
+                                <i class="fa-solid fa-gears"></i>
+                            </button>
+                        <?php elseif ($layoutTooOld) : ?>
+                            <button class="btn btn-outline-secondary disabled"
+                                    title="<?=$this->getTrans('layoutTooOld') ?>">
                                 <i class="fa-solid fa-gears"></i>
                             </button>
                         <?php elseif ($moduleNotInstalled) : ?>

--- a/application/modules/admin/views/admin/layouts/search.php
+++ b/application/modules/admin/views/admin/layouts/search.php
@@ -49,6 +49,8 @@ if (empty($layoutsOnUpdateServer)) {
                         $layoutExists = in_array($layoutOnUpdateServer->key, $this->get('layouts'));
                         $ilchCoreRequirement = empty($layoutOnUpdateServer->ilchCore) ? $coreVersion : $layoutOnUpdateServer->ilchCore;
                         $ilchCoreTooOld = version_compare($coreVersion, $ilchCoreRequirement, '<');
+                        // "layoutTooOld" was added to prevent the usage of old and likely with Ilch 2.2.0 and newer incompatible layouts.
+                        $layoutTooOld = version_compare('2.2.0', $ilchCoreRequirement, '>');
                         if ($layoutExists && version_compare($versionsOfLayouts[$layoutOnUpdateServer->key], $layoutOnUpdateServer->version, '>=')): ?>
                             <span class="btn disabled" title="<?=$this->getTrans('alreadyExists') ?>">
                                 <i class="fa-solid fa-check text-success"></i>
@@ -57,6 +59,11 @@ if (empty($layoutsOnUpdateServer)) {
                             <?php if ($ilchCoreTooOld): ?>
                                 <button class="btn disabled"
                                         title="<?=$this->getTrans('ilchCoreError') ?>">
+                                    <i class="fa-solid fa-arrows-rotate"></i>
+                                </button>
+                            <?php elseif ($layoutTooOld) : ?>
+                                <button class="btn disabled"
+                                        title="<?=$this->getTrans('layoutTooOld') ?>">
                                     <i class="fa-solid fa-arrows-rotate"></i>
                                 </button>
                             <?php else: ?>
@@ -72,6 +79,11 @@ if (empty($layoutsOnUpdateServer)) {
                         <?php elseif ($ilchCoreTooOld): ?>
                             <button class="btn disabled"
                                     title="<?=$this->getTrans('ilchCoreError') ?>">
+                                <i class="fa-solid fa-download"></i>
+                            </button>
+                        <?php elseif ($layoutTooOld) : ?>
+                            <button class="btn disabled"
+                                    title="<?=$this->getTrans('layoutTooOld') ?>">
                                 <i class="fa-solid fa-download"></i>
                             </button>
                         <?php else: ?>

--- a/application/modules/admin/views/admin/modules/index.php
+++ b/application/modules/admin/views/admin/modules/index.php
@@ -142,6 +142,11 @@ function checkOwnDependencies($versionsOfModules, $moduleOnUpdateServer) {
                                             title="<?=$this->getTrans('ilchCoreError') ?>">
                                         <i class="<?=$icon ?>"></i>
                                     </button>
+                                <?php elseif (version_compare('2.2.0', $moduleUpdateInformation->ilchCore, '>')): ?>
+                                    <button class="btn disabled"
+                                            title="<?=$this->getTrans('moduleTooOld') ?>">
+                                        <i class="<?=$icon ?>"></i>
+                                    </button>
                                 <?php elseif (!empty(checkOthersDependencies([$moduleUpdateInformation->key => $moduleUpdateInformation->version], $dependencies))): ?>
                                     <button class="btn disabled"
                                             data-bs-toggle="modal"

--- a/application/modules/admin/views/admin/modules/index.php
+++ b/application/modules/admin/views/admin/modules/index.php
@@ -142,7 +142,7 @@ function checkOwnDependencies($versionsOfModules, $moduleOnUpdateServer) {
                                             title="<?=$this->getTrans('ilchCoreError') ?>">
                                         <i class="<?=$icon ?>"></i>
                                     </button>
-                                <?php elseif (version_compare('2.2.0', $moduleUpdateInformation->ilchCore, '>')): ?>
+                                <?php elseif (version_compare($versionsOfModules[$moduleUpdateInformation->key]['version'], $moduleUpdateInformation->version, '<') && version_compare('2.2.0', $moduleUpdateInformation->ilchCore, '>')): ?>
                                     <button class="btn disabled"
                                             title="<?=$this->getTrans('moduleTooOld') ?>">
                                         <i class="<?=$icon ?>"></i>

--- a/application/modules/admin/views/admin/modules/notinstalled.php
+++ b/application/modules/admin/views/admin/modules/notinstalled.php
@@ -109,6 +109,11 @@
                                         title="<?=$this->getTrans('ilchCoreError') ?>">
                                     <i class="fa-regular fa-floppy-disk"></i>
                                 </button>
+                            <?php elseif (!version_compare('2.2.0', $module->getIlchCore(), '>')): ?>
+                                <button class="btn disabled"
+                                        title="<?=$this->getTrans('moduleTooOld') ?>">
+                                    <i class="fa-regular fa-floppy-disk"></i>
+                                </button>
                             <?php elseif (!checkOwnDependencies($this->get('versionsOfModules'), $this->get('dependencies')[$module->getKey()] ?? null)): ?>
                                 <button class="btn disabled"
                                         title="<?=$this->getTrans('dependencyError') ?>">

--- a/application/modules/admin/views/admin/modules/notinstalled.php
+++ b/application/modules/admin/views/admin/modules/notinstalled.php
@@ -109,7 +109,7 @@
                                         title="<?=$this->getTrans('ilchCoreError') ?>">
                                     <i class="fa-regular fa-floppy-disk"></i>
                                 </button>
-                            <?php elseif (!version_compare('2.2.0', $module->getIlchCore(), '>')): ?>
+                            <?php elseif (version_compare('2.2.0', $module->getIlchCore(), '>')): ?>
                                 <button class="btn disabled"
                                         title="<?=$this->getTrans('moduleTooOld') ?>">
                                     <i class="fa-regular fa-floppy-disk"></i>

--- a/application/modules/admin/views/admin/modules/search.php
+++ b/application/modules/admin/views/admin/modules/search.php
@@ -131,6 +131,11 @@ usort($modulesOnUpdateServer, 'custom_sort');
                                     title="<?=$this->getTrans('ilchCoreError') ?>">
                                 <i class="<?=$iconClass ?>"></i>
                             </button>
+                        <?php elseif (version_compare('2.2.0', $moduleOnUpdateServer->ilchCore, '>')): ?>
+                            <button class="btn disabled"
+                                    title="<?=$this->getTrans('moduleTooOld') ?>">
+                                <i class="<?=$iconClass ?>"></i>
+                            </button>
                         <?php elseif ($isInstalled && version_compare($versionsOfModules[$moduleOnUpdateServer->key]['version'], $moduleOnUpdateServer->version, '>=')): ?>
                             <button class="btn disabled"
                                     title="<?=$this->getTrans('alreadyExists') ?>">

--- a/application/modules/admin/views/admin/modules/search.php
+++ b/application/modules/admin/views/admin/modules/search.php
@@ -131,7 +131,7 @@ usort($modulesOnUpdateServer, 'custom_sort');
                                     title="<?=$this->getTrans('ilchCoreError') ?>">
                                 <i class="<?=$iconClass ?>"></i>
                             </button>
-                        <?php elseif (version_compare('2.2.0', $moduleOnUpdateServer->ilchCore, '>')): ?>
+                        <?php elseif (version_compare($versionsOfModules[$moduleOnUpdateServer->key]['version'], $moduleOnUpdateServer->version, '<') && version_compare('2.2.0', $moduleOnUpdateServer->ilchCore, '>')): ?>
                             <button class="btn disabled"
                                     title="<?=$this->getTrans('moduleTooOld') ?>">
                                 <i class="<?=$iconClass ?>"></i>

--- a/application/modules/admin/views/admin/modules/updates.php
+++ b/application/modules/admin/views/admin/modules/updates.php
@@ -90,7 +90,8 @@ function checkOwnDependencies(array $versionsOfModules, $moduleOnUpdateServer): 
                 }
 
                 if (!$module->getSystemModule() && $this->getUser()->hasAccess('module_'.$module->getKey())):
-                    if ((empty($moduleUpdate['local']) && empty($moduleUpdate['updateserver'])) || (!empty($moduleUpdate['updateserver']) && !version_compare($versionsOfModules[$moduleUpdate['updateserver']->key]['version'], $moduleUpdate['updateserver']->version, '<'))): ?>
+                    // Skip if there are no updates available either locally or on the updateserver
+                    if ((empty($moduleUpdate['local']) && empty($moduleUpdate['updateserver'])) || (empty($moduleUpdate['local']) && (!empty($moduleUpdate['updateserver']) && !version_compare($versionsOfModules[$moduleUpdate['updateserver']->key]['version'], $moduleUpdate['updateserver']->version, '<')))) : ?>
                     <tr id="Module_<?=$module->getKey() ?>"></tr>
                     <?php continue; ?>
                     <?php else:

--- a/application/modules/admin/views/admin/modules/updates.php
+++ b/application/modules/admin/views/admin/modules/updates.php
@@ -153,6 +153,11 @@ function checkOwnDependencies(array $versionsOfModules, $moduleOnUpdateServer): 
                                             title="<?=$this->getTrans('ilchCoreError') ?>">
                                         <i class="<?=$icon ?>"></i>
                                     </button>
+                                <?php elseif (version_compare('2.2.0', $moduleUpdateInformation->ilchCore, '>')): ?>
+                                    <button class="btn disabled"
+                                            title="<?=$this->getTrans('moduleTooOld') ?>">
+                                        <i class="<?=$icon ?>"></i>
+                                    </button>
                                 <?php elseif (!empty(checkOthersDependencies([$moduleUpdateInformation->key => $moduleUpdateInformation->version], $dependencies))): ?>
                                     <button class="btn disabled"
                                             data-bs-toggle="modal"


### PR DESCRIPTION
# Description
Add checks to make sure the layout or module is compatible with Ilch 2.2.0 or newer or in other words has been adjusted for Bootstrap 5.

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
