### PR TITLE
Update advSettingsShow.php to remove "ckeditorbbcode"

### DIFF
--- a/application/modules/admin/views/admin/layouts/advSettingsShow.php
+++ b/application/modules/admin/views/admin/layouts/advSettingsShow.php
@@ -22,12 +22,6 @@ function getInput(string $name, array $value, array $settingsValues, \Ilch\View 
                                data-jscolor=""
                                value="%s">', $name, $name, $settingsValue);
             break;
-        case 'ckeditorbbcode':
-            $input = sprintf('<textarea class="form-control ckeditor"
-                               name="%s"
-                               id="%s"
-                               toolbar="ilch_bbcode">%s</textarea>', $name, $name, $settingsValue);
-            break;
         case 'ckeditorhtml':
             $input = sprintf('<textarea class="form-control ckeditor"
                                name="%s"


### PR DESCRIPTION
# Description
- Update advSettingsShow.php to remove "ckeditorbbcode" as this can no longer be supported with CKEditor 5.

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update