### PR TITLE
static/js seems to be unoptimized in build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,8 @@ jobs:
       - name: Create archive
         run: |
           git archive --format=zip HEAD > Ilch-2.zip
-          zip -q -r -FS Ilch-2.zip vendor static/js
+          zip -d Ilch-2.zip static/js/\*
+          zip -q -r Ilch-2.zip vendor static/js
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Create archive
         run: |
           git archive --format=zip HEAD > Ilch-2.zip
-          zip -q -r Ilch-2.zip vendor
+          zip -q -r -FS Ilch-2.zip vendor static/js
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
# Description
static/js seems to be unoptimized in build. Delete "static/js" from the zip file returned by "git archive" before adding the optimized "static/js" again.

Composer install gets run, optimize_build gets called to optimize the vendor folder. Later the optimized vendor folder gets added to the Ilch-2.zip file. This isn't the case with "static/js" so therefore the zip file just contains the unoptimized folder.

> Run composer install --prefer-dist --no-dev --optimize-autoloader --no-interaction
> Run php build/optimize_build.php
> git archive --format=zip HEAD > Ilch-2.zip
> zip -q -r Ilch-2.zip vendor
