### PR TITLE
Use recommended "ubuntu-latest" and newer php

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,14 +11,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.3
           tools: composer
       - name: Get composer cache directory
         id: composer-cache
@@ -57,7 +57,7 @@ jobs:
           sftpArgs: '-o ConnectTimeout=5'
 
   create-draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [build]
     if: ${{ github.ref_type == 'tag' }}
     steps:


### PR DESCRIPTION
# Description
Use recommended "ubuntu-latest" and a newer php version in setup-php.

According to the setup-php documentation PHP 8.0 is end of life.
https://github.com/shivammathur/setup-php?tab=readme-ov-file#tada-php-support

August 2022
> Ubuntu 22.04 is now generally available on GitHub-hosted runners. To use it now, simply add runs-on: ubuntu-22.04 in your workflow file. **Otherwise, our recommendation is to use ubuntu-latest**, which currently utilizes Ubuntu 20.04 but will begin running on Ubuntu 22.04 in the near future.

https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/
