### PR TITLE
Improve getMenus function

### DIFF
--- a/application/modules/admin/mappers/Menu.php
+++ b/application/modules/admin/mappers/Menu.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -6,7 +7,6 @@
 
 namespace Modules\Admin\Mappers;
 
-use Ilch\Database\Exception;
 use Ilch\Mapper;
 use Modules\Admin\Models\MenuItem;
 use Modules\Admin\Models\Menu as MenuModel;
@@ -18,7 +18,6 @@ class Menu extends Mapper
      *
      * @param int $position
      * @return false|string|null
-     * @throws Exception
      */
     public function getMenuIdForPosition(int $position)
     {
@@ -33,7 +32,7 @@ class Menu extends Mapper
 
     /**
      * Gets the menus.
-     * 
+     *
      * @return MenuModel[]
      */
     public function getMenus(): array
@@ -63,7 +62,7 @@ class Menu extends Mapper
     public function getMenu(int $menuId): MenuModel
     {
         $menu = new MenuModel();
-        
+
         $menuRow = $this->db()->select(['id','title'])
             ->from('menu')
             ->where(['id' => $menuId])
@@ -85,11 +84,11 @@ class Menu extends Mapper
     {
         $items = [];
         $itemRows = $this->db()->select('*')
-                ->from('menu_items')
-                ->where(['menu_id' => $menuId])
-                ->order(['sort' => 'ASC'])
-                ->execute()
-                ->fetchRows();
+            ->from('menu_items')
+            ->where(['menu_id' => $menuId])
+            ->order(['sort' => 'ASC'])
+            ->execute()
+            ->fetchRows();
 
         if (empty($itemRows)) {
             return [];
@@ -125,11 +124,11 @@ class Menu extends Mapper
     {
         $items = [];
         $itemRows = $this->db()->select('*')
-                ->from('menu_items')
-                ->where(['menu_id' => $menuId, 'parent_id' => $itemId])
-                ->order(['sort' => 'ASC'])
-                ->execute()
-                ->fetchRows();
+            ->from('menu_items')
+            ->where(['menu_id' => $menuId, 'parent_id' => $itemId])
+            ->order(['sort' => 'ASC'])
+            ->execute()
+            ->fetchRows();
 
         if (empty($itemRows)) {
             return null;
@@ -206,7 +205,6 @@ class Menu extends Mapper
      * Get last menu id.
      *
      * @return false|string|null
-     * @throws Exception
      */
     public function getLastMenuId()
     {
@@ -220,7 +218,6 @@ class Menu extends Mapper
      * Get last menu item id.
      *
      * @return false|string|null
-     * @throws Exception
      */
     public function getLastMenuItemId()
     {
@@ -283,14 +280,14 @@ class Menu extends Mapper
                 ->where(['parent_id' => $parentID])
                 ->execute()
                 ->fetchRows();
-         }
+        }
 
-         foreach ($itemRows as $item) {
-             $this->deleteItemsByModuleKey($moduleKey, $item['id']);
-             $this->db()->delete('menu_items')
+        foreach ($itemRows as $item) {
+            $this->deleteItemsByModuleKey($moduleKey, $item['id']);
+            $this->db()->delete('menu_items')
                 ->where(['id' => $item['id']])
                 ->execute();
-         }
+        }
     }
 
     /**

--- a/application/modules/admin/mappers/Menu.php
+++ b/application/modules/admin/mappers/Menu.php
@@ -6,25 +6,27 @@
 
 namespace Modules\Admin\Mappers;
 
+use Ilch\Database\Exception;
+use Ilch\Mapper;
 use Modules\Admin\Models\MenuItem;
 use Modules\Admin\Models\Menu as MenuModel;
 
-class Menu extends \Ilch\Mapper
+class Menu extends Mapper
 {
     /**
      * Gets the menu id for the menu position.
      *
-     * @param integer $position
-     * @return int|string
-     * @throws \Ilch\Database\Exception
+     * @param int $position
+     * @return false|string|null
+     * @throws Exception
      */
-    public function getMenuIdForPosition($position)
+    public function getMenuIdForPosition(int $position)
     {
         return $this->db()->select(['id'])
             ->from('menu')
             ->order(['id' => 'ASC'])
             ->limit(1)
-            ->offset((int)$position-1)
+            ->offset($position - 1)
             ->execute()
             ->fetchCell();
     }
@@ -32,18 +34,20 @@ class Menu extends \Ilch\Mapper
     /**
      * Gets the menus.
      * 
-     * @return \Modules\Admin\Models\Menu[]
+     * @return MenuModel[]
      */
-    public function getMenus()
+    public function getMenus(): array
     {
         $menus = [];
-        $menuRows = $this->db()->select(['id'])
+        $menuRows = $this->db()->select(['id','title'])
             ->from('menu')
             ->execute()
             ->fetchRows();
 
         foreach ($menuRows as $menuRow) {
-            $menu = $this->getMenu($menuRow['id']);
+            $menu = new MenuModel();
+            $menu->setId($menuRow['id']);
+            $menu->setTitle($menuRow['title']);
             $menus[] = $menu;
         }
 
@@ -53,10 +57,10 @@ class Menu extends \Ilch\Mapper
     /**
      * Gets the menu for the given id.
      *
-     * @param $menuId
-     * @return \Modules\Admin\Models\Menu
+     * @param int $menuId
+     * @return MenuModel
      */
-    public function getMenu($menuId)
+    public function getMenu(int $menuId): MenuModel
     {
         $menu = new MenuModel();
         
@@ -74,10 +78,10 @@ class Menu extends \Ilch\Mapper
 
     /**
      * Gets all menu items by menu id.
-     * @param $menuId
+     * @param int $menuId
      * @return array|[]
      */
-    public function getMenuItems($menuId)
+    public function getMenuItems(int $menuId): array
     {
         $items = [];
         $itemRows = $this->db()->select('*')
@@ -113,11 +117,11 @@ class Menu extends \Ilch\Mapper
 
     /**
      * Gets all menu items by parent item id.
-     * @param $menuId
-     * @param $itemId
+     * @param int $menuId
+     * @param int $itemId
      * @return array|null
      */
-    public function getMenuItemsByParent($menuId, $itemId)
+    public function getMenuItemsByParent(int $menuId, int $itemId): ?array
     {
         $items = [];
         $itemRows = $this->db()->select('*')
@@ -155,9 +159,9 @@ class Menu extends \Ilch\Mapper
      * Save one menu item.
      *
      * @param MenuItem $menuItem
-     * @return integer
+     * @return int
      */
-    public function saveItem(MenuItem $menuItem)
+    public function saveItem(MenuItem $menuItem): int
     {
         $fields = [
             'href' => $menuItem->getHref(),
@@ -201,8 +205,8 @@ class Menu extends \Ilch\Mapper
     /**
      * Get last menu id.
      *
-     * @return int|string|null
-     * @throws \Ilch\Database\Exception
+     * @return false|string|null
+     * @throws Exception
      */
     public function getLastMenuId()
     {
@@ -215,8 +219,8 @@ class Menu extends \Ilch\Mapper
     /**
      * Get last menu item id.
      *
-     * @return int|string|null
-     * @throws \Ilch\Database\Exception
+     * @return false|string|null
+     * @throws Exception
      */
     public function getLastMenuItemId()
     {
@@ -230,9 +234,9 @@ class Menu extends \Ilch\Mapper
      * Save one menu.
      *
      * @param MenuModel $menu
-     * @return integer
+     * @return int
      */
-    public function save(MenuModel $menu)
+    public function save(MenuModel $menu): int
     {
         $menuId = (int)$this->db()->select('id', 'menu', ['id' => $menu->getId()])
             ->execute()
@@ -252,7 +256,7 @@ class Menu extends \Ilch\Mapper
      *
      * @param MenuItem $menuItem
      */
-    public function deleteItem($menuItem)
+    public function deleteItem(MenuItem $menuItem)
     {
         $this->db()->delete('menu_items')
             ->where(['id' => $menuItem->getId()])
@@ -263,9 +267,9 @@ class Menu extends \Ilch\Mapper
      * Delete items for the given modulkey.
      *
      * @param string $moduleKey
-     * @param int $parentID
+     * @param int|null $parentID
      */
-    public function deleteItemsByModuleKey($moduleKey, $parentID = null)
+    public function deleteItemsByModuleKey(string $moduleKey, int $parentID = null)
     {
         if ($parentID === null) {
             $itemRows = $this->db()->select('*')
@@ -292,9 +296,9 @@ class Menu extends \Ilch\Mapper
     /**
      * Delete the given menu.
      *
-     * @param integer $id
+     * @param int $id
      */
-    public function delete($id)
+    public function delete(int $id)
     {
         $this->db()->delete('menu')
             ->where(['id' => $id])
@@ -304,9 +308,9 @@ class Menu extends \Ilch\Mapper
     /**
      * Delete all items with a specific menu id.
      *
-     * @param integer $menuId
+     * @param int $menuId
      */
-    public function deleteItemsByMenuId($menuId)
+    public function deleteItemsByMenuId(int $menuId)
     {
         $this->db()->delete('menu_items')
             ->where(['menu_id' => $menuId])
@@ -316,9 +320,9 @@ class Menu extends \Ilch\Mapper
     /**
      * Delete menu item by the box id.
      *
-     * @param integer $boxId
+     * @param int $boxId
      */
-    public function deleteItemByBoxId($boxId)
+    public function deleteItemByBoxId(int $boxId)
     {
         $this->db()->delete('menu_items')
             ->where(['box_id' => $boxId])
@@ -328,9 +332,9 @@ class Menu extends \Ilch\Mapper
     /**
      * Delete menu item by the page id.
      *
-     * @param integer $pageId
+     * @param int $pageId
      */
-    public function deleteItemByPageId($pageId)
+    public function deleteItemByPageId(int $pageId)
     {
         $this->db()->delete('menu_items')
             ->where(['page_id' => $pageId])


### PR DESCRIPTION
# Description
- Improve getMenus function. It unnecessarily called getMenu() inside a for loop multiple times when the menus could have been got from the database with one query.
- Some smaller code style improvements.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
