### PR TITLE
Linkus: Use "bg-body-tertiary" for textareas

### DIFF
--- a/application/modules/linkus/config/config.php
+++ b/application/modules/linkus/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'linkus',
-        'version' => '1.7.0',
+        'version' => '1.7.1',
         'icon_small' => 'fa-solid fa-link',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/linkus/views/index/index.php
+++ b/application/modules/linkus/views/index/index.php
@@ -16,7 +16,7 @@ $config = \Ilch\Registry::get('config');
               <?php if ($config->get('linkus_html') == 1): ?>
                   <div class="col-xl-6 text-center">
                       <?=$this->getTrans('htmlForWebsite') ?>
-                      <textarea class="form-control bg-light"
+                      <textarea class="form-control bg-body-tertiary"
                                 style="resize: vertical"
                                 name="text"
                                 type="text"
@@ -28,7 +28,7 @@ $config = \Ilch\Registry::get('config');
               <?php if ($config->get('linkus_bbcode') == 1): ?>
                   <div class="col-xl-6 text-center">
                       <?=$this->getTrans('bbcodeForForum') ?>
-                      <textarea class="form-control bg-light"
+                      <textarea class="form-control bg-body-tertiary"
                                 style="resize: vertical"
                                 name="text"
                                 rows="4"


### PR DESCRIPTION
# Description
- Use "bg-body-tertiary" for textareas

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge