### PR TITLE
Rebuild CKEditor 5: Fixed security issue in ws

### DIFF
--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@ header('Content-Type: text/html; charset=utf-8');
 $serverTimeZone = @date_default_timezone_get();
 date_default_timezone_set('UTC');
 
-define('VERSION', '2.2.0');
+define('VERSION', '2.2.1');
 define('SERVER_TIMEZONE', $serverTimeZone);
 define('DEFAULT_MODULE', 'page');
 define('DEFAULT_LAYOUT', 'index');

--- a/static/js/ckeditor5/package-lock.json
+++ b/static/js/ckeditor5/package-lock.json
@@ -40,18 +40,18 @@
       },
       "devDependencies": {
         "@ckeditor/ckeditor5-core": "41.4.2",
-        "@ckeditor/ckeditor5-dev-translations": "^40.0.0",
-        "@ckeditor/ckeditor5-dev-utils": "^40.0.0",
+        "@ckeditor/ckeditor5-dev-translations": "^40.2.2",
+        "@ckeditor/ckeditor5-dev-utils": "^40.2.2",
         "@ckeditor/ckeditor5-theme-lark": "41.4.2",
-        "css-loader": "^7.1.1",
+        "css-loader": "^7.1.2",
         "postcss": "^8.4.38",
         "postcss-loader": "^8.1.1",
         "raw-loader": "^4.0.2",
         "style-loader": "^4.0.0",
         "terser-webpack-plugin": "^4.2.3",
         "ts-loader": "^9.5.1",
-        "typescript": "5.4.5",
-        "webpack": "^5.91.0",
+        "typescript": "5.5.2",
+        "webpack": "^5.92.1",
         "webpack-cli": "^5.1.4"
       }
     },
@@ -619,10 +619,11 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-translations": {
-      "version": "40.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-translations/-/ckeditor5-dev-translations-40.0.0.tgz",
-      "integrity": "sha512-iRniAJEiAuNwZS7Co3uh9Ce77X19CGkghOUt0RXCJst+B+QqRnRg51G4pcC5Go+74lUaU4hyeqq1v6JQ4ui8yQ==",
+      "version": "40.2.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-translations/-/ckeditor5-dev-translations-40.2.2.tgz",
+      "integrity": "sha512-Do3KCWV6V7loW0n28I9rWTAKRPPp7IlBlnVJLJw++tVvzoyZGajgVILb5JfkIOmXLIY2NeWQcgfBvfFPVny6gg==",
       "dev": true,
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/parser": "^7.18.9",
         "@babel/traverse": "^7.18.9",
@@ -637,12 +638,13 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-utils": {
-      "version": "40.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-utils/-/ckeditor5-dev-utils-40.0.0.tgz",
-      "integrity": "sha512-hXz8Gyfc4lwKQET5xRFCgykLdjylR6rCsOG8kYXTeNsEggI9nV6DYfKS0zMD1DFe3CIUbWV2HT4R6B2j/YOZBg==",
+      "version": "40.2.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-utils/-/ckeditor5-dev-utils-40.2.2.tgz",
+      "integrity": "sha512-AZPuHtT9XpLpxeb0sDeOwsFJbs1d2wiZwpsb1WCNYRuyN+WDGNAmmNMMYa6/DvOLiwftXfaZrxhMADZeaSrv5Q==",
       "dev": true,
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-dev-translations": "^40.0.0",
+        "@ckeditor/ckeditor5-dev-translations": "^40.2.2",
         "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
         "cli-spinners": "^2.6.1",
@@ -2006,11 +2008,12 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -2192,12 +2195,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2612,10 +2616,11 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.1.tgz",
-      "integrity": "sha512-OxIR5P2mjO1PSXk44bWuQ8XtMK4dpEqpIyERCx3ewOo3I8EmbcxMPUc5ScLtQfgXtOojoMv57So4V/C02HQLsw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
+      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.1.0",
         "postcss": "^8.4.33",
@@ -2993,10 +2998,11 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
-      "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
+      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -3283,10 +3289,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3698,6 +3705,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -5810,6 +5818,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -5893,10 +5902,11 @@
       "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6039,10 +6049,11 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.91.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-      "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+      "version": "5.92.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.1.tgz",
+      "integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
@@ -6050,10 +6061,10 @@
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.16.0",
+        "enhanced-resolve": "^5.17.0",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -6322,9 +6333,10 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },

--- a/static/js/ckeditor5/package.json
+++ b/static/js/ckeditor5/package.json
@@ -39,18 +39,18 @@
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-core": "41.4.2",
-    "@ckeditor/ckeditor5-dev-translations": "^40.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^40.0.0",
+    "@ckeditor/ckeditor5-dev-translations": "^40.2.2",
+    "@ckeditor/ckeditor5-dev-utils": "^40.2.2",
     "@ckeditor/ckeditor5-theme-lark": "41.4.2",
-    "css-loader": "^7.1.1",
+    "css-loader": "^7.1.2",
     "postcss": "^8.4.38",
     "postcss-loader": "^8.1.1",
     "raw-loader": "^4.0.2",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^4.2.3",
     "ts-loader": "^9.5.1",
-    "typescript": "5.4.5",
-    "webpack": "^5.91.0",
+    "typescript": "5.5.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^5.1.4"
   },
   "scripts": {


### PR DESCRIPTION
# Description
- Rebuild CKEditor 5
- Bumps ws from 7.5.9 to 7.5.10.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
