### PR TITLE
Update function: Use json files directly

### DIFF
--- a/application/modules/admin/controllers/admin/Index.php
+++ b/application/modules/admin/controllers/admin/Index.php
@@ -37,7 +37,7 @@ class Index extends \Ilch\Controller\Admin
         $authTokenMapper->deleteExpiredAuthTokens();
         // Check if Ilch is up to date
         $update = new \Ilch\Transfer();
-        $update->setTransferUrl($this->getConfig()->get('updateserver') . 'updates2.php');
+        $update->setTransferUrl($this->getConfig()->get('updateserver') . 'updates.json');
         $update->setVersionNow($this->getConfig()->get('version'));
         $update->setCurlOpt(CURLOPT_SSL_VERIFYPEER, true);
         $update->setCurlOpt(CURLOPT_SSL_VERIFYHOST, 2);
@@ -53,7 +53,7 @@ class Index extends \Ilch\Controller\Admin
         } else {
             // If check for an ilch update didn't already failed then check for module updates
             $countOfUpdatesAvailable = 0;
-            $modulesList = url_get_contents($this->getConfig()->get('updateserver') . 'modules.php');
+            $modulesList = url_get_contents($this->getConfig()->get('updateserver') . 'modules.json');
             $modulesOnUpdateServer = json_decode($modulesList);
             $versionsOfModules = $moduleMapper->getVersionsOfModules();
             foreach ($modulesOnUpdateServer as $moduleOnUpdateServer) {
@@ -91,7 +91,7 @@ class Index extends \Ilch\Controller\Admin
 
         // Check if there are notifications, which need to be shown
         $notificationsMapper = new NotificationsMapper();
-        $this->getView()->set('ilchNewsList', $this->getConfig()->get('updateserver') . 'ilchNews.php');
+        $this->getView()->set('ilchNewsList', $this->getConfig()->get('updateserver') . 'ilchNews.json');
         $this->getView()->set('version', $this->getConfig()->get('version'));
         $this->getView()->set('notifications', $notificationsMapper->getNotifications());
         $this->getView()->set('accesses', $this->getAccesses());

--- a/application/modules/admin/controllers/admin/Layouts.php
+++ b/application/modules/admin/controllers/admin/Layouts.php
@@ -97,7 +97,7 @@ class Layouts extends \Ilch\Controller\Admin
             }
         }
 
-        $this->getView()->set('updateserver', $this->getConfig()->get('updateserver') . 'layouts2.php')
+        $this->getView()->set('updateserver', $this->getConfig()->get('updateserver') . 'layouts.json')
             ->set('defaultLayout', $this->getConfig()->get('default_layout'))
             ->set('layouts', $layouts)
             ->set('modulesNotInstalled', $modulesNotInstalled)
@@ -415,7 +415,7 @@ class Layouts extends \Ilch\Controller\Admin
 
     public function refreshURLAction()
     {
-        if (!empty(url_get_contents($this->getConfig()->get('updateserver') . 'layouts2.php', true, true))) {
+        if (!empty(url_get_contents($this->getConfig()->get('updateserver') . 'layouts.json', true, true))) {
             $this->redirect()
                 ->withMessage('updateSuccess')
                 ->to(['action' => $this->getRequest()->getParam('from')]);

--- a/application/modules/admin/controllers/admin/Modules.php
+++ b/application/modules/admin/controllers/admin/Modules.php
@@ -89,7 +89,7 @@ class Modules extends \Ilch\Controller\Admin
             }
         }
 
-        $this->getView()->set('updateserver', $this->getConfig()->get('updateserver').'modules.php')
+        $this->getView()->set('updateserver', $this->getConfig()->get('updateserver') . 'modules.json')
             ->set('modules', $moduleMapper->getModules())
             ->set('versionsOfModules', $moduleMapper->getVersionsOfModules())
             ->set('dependencies', $dependencies)
@@ -129,7 +129,7 @@ class Modules extends \Ilch\Controller\Admin
             }
         }
 
-        $this->getView()->set('updateserver', $this->getConfig()->get('updateserver').'modules.php')
+        $this->getView()->set('updateserver', $this->getConfig()->get('updateserver') . 'modules.json')
             ->set('versionsOfModules', $moduleMapper->getVersionsOfModules())
             ->set('modulesNotInstalled', $modulesNotInstalled)
             ->set('dependencies', $dependencies)
@@ -207,7 +207,7 @@ class Modules extends \Ilch\Controller\Admin
                 }
             }
 
-            $this->getView()->set('updateserver', $this->getConfig()->get('updateserver').'modules.php')
+            $this->getView()->set('updateserver', $this->getConfig()->get('updateserver') . 'modules.json')
                 ->set('versionsOfModules', $moduleMapper->getVersionsOfModules())
                 ->set('modules', $modulesDir)
                 ->set('dependencies', $dependencies)
@@ -244,7 +244,7 @@ class Modules extends \Ilch\Controller\Admin
             }
         }
 
-        $this->getView()->set('updateserver', $this->getConfig()->get('updateserver').'modules.php')
+        $this->getView()->set('updateserver', $this->getConfig()->get('updateserver') . 'modules.json')
             ->set('modules', $moduleMapper->getModules())
             ->set('versionsOfModules', $moduleMapper->getVersionsOfModules())
             ->set('dependencies', $dependencies)
@@ -452,7 +452,7 @@ class Modules extends \Ilch\Controller\Admin
 
     public function refreshURLAction()
     {
-        if (!empty(url_get_contents($this->getConfig()->get('updateserver').'modules.php', true, true))) {
+        if (!empty(url_get_contents($this->getConfig()->get('updateserver') . 'modules.json', true, true))) {
             $this->redirect()
                 ->withMessage('updateSuccess')
                 ->to(['action' => $this->getRequest()->getParam('from')]);

--- a/application/modules/admin/controllers/admin/Settings.php
+++ b/application/modules/admin/controllers/admin/Settings.php
@@ -295,7 +295,7 @@ HTACCESS;
         $this->getView()->set('version', $version);
 
         $update = new IlchTransfer();
-        $update->setTransferUrl($this->getConfig()->get('updateserver').'updates2.php');
+        $update->setTransferUrl($this->getConfig()->get('updateserver') . 'updates.json');
         $update->setVersionNow($version);
         $update->setCurlOpt(CURLOPT_SSL_VERIFYPEER, TRUE);
         $update->setCurlOpt(CURLOPT_SSL_VERIFYHOST, 2); 

--- a/application/modules/admin/views/admin/layouts/search.php
+++ b/application/modules/admin/views/admin/layouts/search.php
@@ -2,10 +2,10 @@
 
 <h1><?=$this->getTrans('search') ?></h1>
 <?php
-$layoutsList = url_get_contents($this->get('updateserver').'layouts2.php');
+$layoutsList = url_get_contents($this->get('updateserver') . 'layouts.json');
 $layoutsOnUpdateServer = json_decode($layoutsList);
 $versionsOfLayouts = $this->get('versionsOfLayouts');
-$cacheFilename = ROOT_PATH.'/cache/'.md5($this->get('updateserver').'layouts2.php').'.cache';
+$cacheFilename = ROOT_PATH.'/cache/'.md5($this->get('updateserver') . 'layouts.json').'.cache';
 $cacheFileDate = null;
 if (file_exists($cacheFilename)) {
     $cacheFileDate = new \Ilch\Date(date('Y-m-d H:i:s.', filemtime($cacheFilename)));

--- a/application/modules/admin/views/admin/layouts/show.php
+++ b/application/modules/admin/views/admin/layouts/show.php
@@ -1,5 +1,5 @@
 <?php
-$layoutsList = url_get_contents($this->get('updateserver').'layouts2.php');
+$layoutsList = url_get_contents($this->get('updateserver') . 'layouts.json');
 $layouts = json_decode($layoutsList);
 ?>
 

--- a/application/modules/admin/views/admin/modules/show.php
+++ b/application/modules/admin/views/admin/modules/show.php
@@ -1,5 +1,5 @@
 <?php
-$modulesList = url_get_contents($this->get('updateserver').'modules.php');
+$modulesList = url_get_contents($this->get('updateserver') . 'modules.json');
 $modules = json_decode($modulesList);
 $versionsOfModules = $this->get('versionsOfModules');
 $coreVersion = $this->get('coreVersion');


### PR DESCRIPTION
# Description
Use json files directly. This has the advantage that the updateserver no longer needs to run PHP.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
