### PR TITLE
Vagrant: Box "debian/contrib-bullseye64" existiert nicht mehr, Build-Skript wurde umbenannt

### DIFF
--- a/development/bin/setup.sh
+++ b/development/bin/setup.sh
@@ -19,7 +19,7 @@ cd ..
 echo "--- Update System Vendor"
 php development/bin/composer.phar install
 
-php build/optimize_vendor.php
+php build/optimize_build.php
 
 
 cd ${START_PWD}

--- a/development/vagrant/Vagrantfile
+++ b/development/vagrant/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if Vagrant.has_plugin?("vagrant-vbguest")
     config.vm.box = "generic/debian11"
   else
-    config.vm.box = "debian/contrib-bullseye64"
+    config.vm.box = "debian/bullseye64"
   end
 
   config.vm.network "forwarded_port", guest: 80, host: 8080


### PR DESCRIPTION
Die VM "debian/contrib-bullseye64" gibt es nicht und das build-Script wurde geändert