### PR TITLE
HTML Purifier: Allow mailto

### DIFF
--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -172,7 +172,7 @@ abstract class Base
         // $this->purifierConfig->set('Cache.DefinitionImpl', null);
         $this->purifierConfig->set('Filter.YouTube', true);
         $this->purifierConfig->set('HTML.SafeIframe', true);
-        $this->purifierConfig->set('URI.AllowedSchemes', ['data' => true, 'src' => true, 'http' => true, 'https' => true]);
+        $this->purifierConfig->set('URI.AllowedSchemes', ['data' => true, 'http' => true, 'https' => true, 'mailto' => true, 'src' => true]);
         $this->purifierConfig->set('URI.SafeIframeRegexp', '%(?|(^(http://|https://)localhost)|(^https://(youtube.com/|www.youtube.com/|www.youtube.com/embed/|www.youtube-nocookie.com/embed/|youtu.be/|vimeo.com/|player.vimeo.com/video/|open.spotify.com/artist/|open.spotify.com/album/|open.spotify.com/track/|open.spotify.com/embed/|www.dailymotion.com/video/|www.dailymotion.com/embed/video/|dai.ly/)))%');
         $this->purifierConfig->set('Attr.AllowedFrameTargets', '_blank, _self, _target, _parent');
         $this->purifierConfig->set('Attr.EnableID', true);

--- a/tests/libraries/ilch/Design/BasePurifyTest.php
+++ b/tests/libraries/ilch/Design/BasePurifyTest.php
@@ -273,6 +273,17 @@ class BasePurifyTest extends TestCase
     }
 
     /**
+     * hyperlink with href mailto
+     *
+     * @return void
+     */
+    public function testPurifyHyperLinkMailto()
+    {
+        $output = $this->view->purify('<p><a href="mailto:test@test.test">mailto:test@test.test</a></p>');
+        self::assertEquals('<p><a href="mailto:test@test.test">mailto:test@test.test</a></p>', $output);
+    }
+
+    /**
      * anchor
      *
      * @return void


### PR DESCRIPTION
# Description
HTML Purifier: Allow mailto

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
