### PR TITLE
Betatest 2.2.2

### DIFF
--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -1003,7 +1003,7 @@ class Config extends \Ilch\Config\Install
                 removeDir(APPLICATION_PATH . '/libraries/Ilch/BBCode');
                 
                 // Add second updateserver.
-                $this->db()->insert('updateservers')
+                $this->db()->insert('admin_updateservers')
                     ->values(['url' => 'https://ilch.blackcoder.de/stable/', 'operator' => 'ilch', 'country' => 'Germany'])
                     ->execute();
 
@@ -1018,7 +1018,7 @@ class Config extends \Ilch\Config\Install
                 }
 
                 // Fix server information. There have been cases "in the wild" where this was altered.
-                $this->db()->update('updateservers')
+                $this->db()->update('admin_updateservers')
                     ->values(['operator' => 'ilch', 'country' => 'Germany'])
                     ->where(['url' => 'https://www.ilch.de/ilch2_updates/stable/'])
                     ->execute();

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@
 
 define('PHPVERSION', '7.4');
 if (!version_compare(PHP_VERSION, PHPVERSION, '>=')) {
-    die('Ilch CMS 2 needs at least php version 7.4');
+    die('Ilch CMS 2 needs at least php version ' . PHPVERSION);
 }
 
 @ini_set('display_errors', 'on');
@@ -31,7 +31,7 @@ header('Content-Type: text/html; charset=utf-8');
 $serverTimeZone = @date_default_timezone_get();
 date_default_timezone_set('UTC');
 
-define('VERSION', '2.2.1');
+define('VERSION', '2.2.2');
 define('SERVER_TIMEZONE', $serverTimeZone);
 define('DEFAULT_MODULE', 'page');
 define('DEFAULT_LAYOUT', 'index');


### PR DESCRIPTION
**Version 2.2.2**  
Dies ist die erste Version, die kein PHP 7.3 mehr unterstützt. Als eine der letzten offiziell unterstützten Versionen von Linux-Distributionen mit PHP 7.3 hat Debian 10 am 30. Juni 2024 den Support eingestellt. Diesen Zeitpunkt haben wir genommen um auch die Unterstützung von Ilch für PHP 7.3 einzustellen.  
  
Außerdem wird das BBCode-Konvertierung-Modul nicht mehr gepflegt. Sollten Sie noch Inhalte im BBCode-Format haben, wird empfohlen diese vor dem Update auf Ilch 2.2.2 zu konvertieren.  
  
Mit dieser Version wird ebenfalls ein neues Zertifikat verteilt. Installieren Sie das Update idealerweise zeitnah, um weiterhin wie bisher Module und Layouts installieren oder aktualisieren zu können, spätestens jedoch bis zum 31.01.2025, da Ilch ab diesen Zeitpunkt ansonsten keine Updates, Module oder Layouts vom Updateserver akzeptiert.  
  
<a href="https://github.com/IlchCMS/Ilch-2.0/wiki/Hinweise-f%C3%BCr-Entwickler" target="_blank">Hinweise für Entwickler</a>  
**Ilch:**  
- Unterstützung für PHP 7.3 entfernt.  
- Unterstützung für BBCode entfernt.  
- JBBCode entfernt.  
- Zertifikat aktualisiert.  
- Änderungen an der Update-Funktion.  
- Einen zweiten Updateserver hinzugefügt. Dieser kann z.B. bei Problemen mit den ersten Updateserver in den Einstellungen ausgewählt werden. Sollte der bisherige offizielle Updateserver ausgewählt sein, wird beim Update zufällig einer der beiden offiziellen Updateserver gewählt. Dies dient der gleichmäßigen Verteilung auf die beiden offiziellen Updateserver.  
- Modul-Suche vereinheitlicht.  
- Das URI-Schema für E-Mail-Adressen ("mailto") in HTML Purifier zugelassen.  
   
**Benutzer-Modul:**  
- Übersicht der Benutzer im Admincenter lässt sich nun sortieren und filtern.</p>

**Prüfung des Zertifikats**  
https://github.com/IlchCMS/Ilch-2.0/wiki/Doku-Benutzer-Zertifikat-%C3%BCberpr%C3%BCfen

**Fehlermeldung “Layout/Modul war beschädigt oder manipuliert. Layout/Modul verworfen.”**  
https://github.com/IlchCMS/Ilch-2.0/wiki/Doku-Benutzer-Layout-Modul-Fehler

**Fehlermeldung “Zertifikat fehlt oder ist abgelaufen.”**  
https://github.com/IlchCMS/Ilch-2.0/wiki/Doku-Benutzer-Zertifikat-Fehler

**Galerie-Modules (1.23.1):**  
- Darstellungsfehler in der Galerie behoben.

**Team-Modules (1.3.1):**  
- Mitglieder eines Teams wurde nicht mehr nebeneinander, sondern untereinander angezeigt.

**Shop-Modules (1.3.1):**  
- Anpassung des Filters für Produkte.  
  
**Wie halte ich Ilch auf den aktuellen Stand?**  
<a href="https://github.com/IlchCMS/Ilch-2.0/wiki/Doku-Benutzer-Ilch-aktuell-halten" target="_blank">Doku Benutzer Ilch aktuell halten</a>