### PR TITLE
Admincenter notifications clarification

### DIFF
--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -1023,6 +1023,14 @@ class Config extends \Ilch\Config\Install
                     ->where(['url' => 'https://www.ilch.de/ilch2_updates/stable/'])
                     ->execute();
                 break;
+            case "2.2.2":
+                // Grant permission for notifications of the admin module. This is for example a notification of the
+                // type 'adminModuleUpdatesAvailable', which notifies the admin of available module updates.
+                // Doing this now as some users might have unintentionally disabled these important notifications.
+                $this->db()->delete('admin_notifications_permission')
+                    ->where(['module' => 'admin'])
+                    ->execute();
+                break;
         }
 
         return 'Update function executed.';

--- a/application/modules/admin/views/admin/index/index.php
+++ b/application/modules/admin/views/admin/index/index.php
@@ -134,7 +134,7 @@ $accesses = $this->get('accesses');
                             <tr>
                                 <td><?=$this->getDeleteCheckbox('check_notifications', $notification->getId()) ?></td>
                                 <td><?=$this->getDeleteIcon(['action' => 'delete', 'id' => $notification->getId()]) ?></td>
-                                <td><a href="<?=$this->getUrl(['action' => 'revokePermission', 'key' => $notification->getModule()], null, true) ?>" title="<?=$this->getTrans('revokePermission') ?>"><i class="fa-solid fa-check text-success"></i></a></td>
+                                <td><a href="<?=$this->getUrl(['action' => 'revokePermission', 'key' => $notification->getModule()], null, true) ?>" title="<?=$this->getTrans('revokePermission') ?>"><i class="fa-solid fa-bell-slash"></i></a></td>
                                 <td><?=$date->format('d.m.Y', true) ?></td>
                                 <td><a href="<?=$notification->getURL() ?>" target="_blank" rel="noopener" title="<?=$this->escape($notification->getModule()) ?>"><?=$this->escape($notification->getModule()) ?></a></td>
                                 <td><?=$this->escape($notification->getMessage()) ?></td>

--- a/application/modules/admin/views/admin/settings/notifications.php
+++ b/application/modules/admin/views/admin/settings/notifications.php
@@ -36,11 +36,11 @@
                         if ($notificationPermission->getGranted()) {
                             $value = 'true';
                             $translation = 'revokePermission';
-                            $icon = 'fa-solid fa-check text-success';
+                            $icon = 'fa-solid fa-bell';
                         } else {
                             $value = 'false';
                             $translation = 'grantPermission';
-                            $icon = 'fa-regular fa-square';
+                            $icon = 'fa-solid fa-bell-slash';
                         }
                         ?>
                         <tr>


### PR DESCRIPTION
# Description
- Admincenter notifications clarification
- Permission for admin module granted in case the user unintentionally revoked it

Now icons are used that are more commonly associated with (enabled, disabled, muted, ...) notifications.

Button for disabling/muting notifications of this module on the admincenter startpage is now using the bell-slash icon.
![grafik](https://github.com/user-attachments/assets/cdec443d-6e37-4e8a-93ec-ebcec6b48eac)

Buttons for changing the permission now dispaly the current state with the bell icons.
![grafik](https://github.com/user-attachments/assets/ae432f79-f1d4-4cf8-a1de-c6c7c60c9455)


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
