### PR TITLE
Update MysqlCollector used in the DebugBar (PHP 8.4 support)

### DIFF
--- a/application/libraries/Ilch/DebugBar/DataCollector/MysqlCollector.php
+++ b/application/libraries/Ilch/DebugBar/DataCollector/MysqlCollector.php
@@ -24,7 +24,7 @@ class MysqlCollector extends DataCollector implements Renderable, AssetProvider
      */
     private $timeCollector;
 
-    public function __construct(MysqlDebug $mysqlDebug, TimeDataCollector $timeCollector = null)
+    public function __construct(MysqlDebug $mysqlDebug, ?TimeDataCollector $timeCollector = null)
     {
         $this->mysqlDebug = $mysqlDebug;
         $this->timeCollector = $timeCollector;


### PR DESCRIPTION
# Description
Update MysqlCollector used in the DebugBar. This is a custom class and not part of DebugBar.

Fixes #917

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
