### PR TITLE
Cache news for 6 hours, but add refresh button

### DIFF
--- a/application/modules/admin/controllers/admin/Index.php
+++ b/application/modules/admin/controllers/admin/Index.php
@@ -84,7 +84,7 @@ class Index extends \Ilch\Controller\Admin
             }
 
             // Load the latest news.
-            $ilchNewsList = url_get_contents($this->getConfig()->get('updateserver') . 'ilchNews.json', true, false, 120);
+            $ilchNewsList = url_get_contents($this->getConfig()->get('updateserver') . 'ilchNews.json');
         }
 
         if ($update->newVersionFound()) {
@@ -123,5 +123,18 @@ class Index extends \Ilch\Controller\Admin
         }
 
         $this->redirect(['action' => 'index']);
+    }
+
+    public function refreshNewsAction()
+    {
+        if (!empty(url_get_contents($this->getConfig()->get('updateserver') . 'ilchNews.json', true, true))) {
+            $this->redirect()
+                ->withMessage('updateSuccess')
+                ->to(['action' => 'index']);
+        }
+
+        $this->redirect()
+            ->withMessage('lastUpdateError', 'danger')
+            ->to(['action' => 'index']);
     }
 }

--- a/application/modules/admin/static/css/admin.css
+++ b/application/modules/admin/static/css/admin.css
@@ -1558,3 +1558,7 @@ table tbody i.fa.fa-sort {
     z-index: 2147483647;
     opacity: 1;
 }
+
+#refreshNews {
+    cursor: pointer;
+}

--- a/application/modules/admin/views/admin/index/index.php
+++ b/application/modules/admin/views/admin/index/index.php
@@ -79,7 +79,7 @@ $accesses = $this->get('accesses');
             </table>
         </div>
         <?php if (!empty($ilchNews)) : ?>
-            <h1>ilch <?=$this->getTrans('news') ?></h1>
+            <h1>ilch <?=$this->getTrans('news') ?> <i id="refreshNews" class="fa-solid fa-arrows-rotate"></i></h1>
             <div class="table-responsive">
                 <table class="table table-hover table-striped">
                     <colgroup>
@@ -150,3 +150,9 @@ $accesses = $this->get('accesses');
     <?=$this->getListBar(['delete' => 'delete']) ?>
 </form>
 <?php endif; ?>
+
+<script>
+    $("#refreshNews").click(function(){
+        location.href="<?=$this->getUrl(['action' => 'refreshnews', 'from' => 'index']) ?>";
+    });
+</script>


### PR DESCRIPTION
# Description
- Cache news for the current default of 6 hours, but add refresh button.

Previously this was only cached for 2 minutes, which probably lead to a lot of unnecessary loads. Added a refresh button to allow the user to get the latest news immediately.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
