### PR TITLE
Fix "database is already a registered collector"

### DIFF
--- a/application/libraries/Ilch/Database/Factory.php
+++ b/application/libraries/Ilch/Database/Factory.php
@@ -56,7 +56,11 @@ class Factory
         $db->setPrefix($dbData['dbPrefix']);
 
         if ($addDebugCollector) {
-            DebugBar::getInstance()->addCollector(new DebugBar\DataCollector\MysqlCollector($db));
+            $collector = new DebugBar\DataCollector\MysqlCollector($db);
+
+            if (!DebugBar::getInstance()->hasCollector($collector->getName())) {
+                DebugBar::getInstance()->addCollector($collector);
+            }
         }
 
         return $db;


### PR DESCRIPTION
# Description
- Fix "database is already a registered collector"

This error was triggered by the ilch1importer module.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
