### PR TITLE
Events: Fix "explode(): Passing null to parameter of type string is deprecated"

### DIFF
--- a/application/modules/events/config/config.php
+++ b/application/modules/events/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'events',
-        'version' => '1.23.1',
+        'version' => '1.23.2',
         'icon_small' => 'fa-solid fa-ticket',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/events/views/show/event.php
+++ b/application/modules/events/views/show/event.php
@@ -20,7 +20,7 @@ $user = null;
 if (!empty($event)) {
     $start = new \Ilch\Date($event->getStart());
     $end = new \Ilch\Date($event->getEnd());
-    $latLong = explode(',', $event->getLatLong());
+    $latLong = $event->getLatLong() ? explode(',', $event->getLatLong()) : '';
 
     if ($event->getUserId()) {
         $user = $userDetails[$event->getUserId()] ?? $userMapper->getUserById($event->getUserId());


### PR DESCRIPTION
# Description
- Fixed "explode(): Passing null to parameter of type string is deprecated"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
