### PR TITLE
Update ci.yaml to add PHP 8.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         mysql-versions: ['5.7']
 
     services:


### PR DESCRIPTION
# Description
Update ci.yaml to add PHP 8.4. Possible release date for PHP 8.4 is Nov 21 2024.
