### PR TITLE
Fix "Implicitly marking a parameter as nullable"

### DIFF
--- a/build/optimize_build.php
+++ b/build/optimize_build.php
@@ -124,7 +124,7 @@ $directoriesStaticJs = [
  * @param array|null $filter if given only directories in the array are scanned
  * @return array
  */
-function getFilesRecursive(string $dirname, array $filter = null): array
+function getFilesRecursive(string $dirname, ?array $filter = null): array
 {
     $files = [];
     foreach (scandir($dirname) as $item) {

--- a/development/README.md
+++ b/development/README.md
@@ -125,6 +125,9 @@ phpcs -p ./application/modules/* --standard=PHPCompatibility --report=summary --
 phpcs -p ./application/modules/* --standard=PHPCompatibility --runtime-set testVersion 7.3-
 
 phpcs ./* --standard=PHPCompatibility --runtime-set testVersion 7.4- --report-file=/home/vagrant/output.txt --report-full=/home/vagrant/full.txt --report-summary=/home/vagrant/summary.txt
+
+// Nur Dateien mit der Endung php überprüfen. Angabe von mehreren Pfaden.
+phpcs --extensions=php ./application/* ./admin/* ./build/* ./tests/* --standard=PHPCompatibility --runtime-set testVersion 7.4- --report-file=/home/vagrant/output.txt --report-full=/home/vagrant/full.txt --report-summary=/home/vagrant/summary.txt
 ```
 
 Siehe auch die Dokumentation zu PHP CodeSniffer: [Dokumentation auf github.com/squizlabs/PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/wiki)

--- a/tests/libraries/ilch/Database/Mysql/SelectTest.php
+++ b/tests/libraries/ilch/Database/Mysql/SelectTest.php
@@ -147,7 +147,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * @param string $expectedSqlPart
      * @param string|null $type
      */
-    public function testGenerateSqlForWhere($where, string $expectedSqlPart, string $type = null)
+    public function testGenerateSqlForWhere($where, string $expectedSqlPart, ?string $type = null)
     {
         if (\is_callable($where)) {
             $where = $where($this->out);

--- a/tests/libraries/ilch/Validation/Validators/ExistsTest.php
+++ b/tests/libraries/ilch/Validation/Validators/ExistsTest.php
@@ -132,7 +132,7 @@ class ExistsTest extends DatabaseTestCase
      * @param bool $invertResult
      * @return stdClass
      */
-    private function createData(array $parameter = [], string $value = null, bool $invertResult = false): stdClass
+    private function createData(array $parameter = [], ?string $value = null, bool $invertResult = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/SameTest.php
+++ b/tests/libraries/ilch/Validation/Validators/SameTest.php
@@ -76,7 +76,7 @@ class SameTest extends TestCase
      * @param bool $invertResult
      * @return stdClass
      */
-    private function createData(string $firstField, $valueFirstField, string $secondField, $valueSecondField, bool $strict = null, bool $invertResult = false): stdClass
+    private function createData(string $firstField, $valueFirstField, string $secondField, $valueSecondField, ?bool $strict = null, bool $invertResult = false): stdClass
     {
         $data = new stdClass();
         $data->field = $firstField;

--- a/tests/libraries/ilch/Validation/Validators/UniqueTest.php
+++ b/tests/libraries/ilch/Validation/Validators/UniqueTest.php
@@ -103,7 +103,7 @@ class UniqueTest extends DatabaseTestCase
      * @param bool $invertResult
      * @return stdClass
      */
-    private function createData(array $parameter = [], string $value = null, bool $invertResult = false): stdClass
+    private function createData(array $parameter = [], ?string $value = null, bool $invertResult = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'name';


### PR DESCRIPTION
# Description
- Fix "Implicitly marking a parameter as nullable".
- Add another PHPCompatibility command example.

Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
