### PR TITLE
HTMLPurifier: Remove form, tokenfield and savebar

### DIFF
--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -75,7 +75,7 @@ return [
     'htmlPurifierSettings' => 'HTMLPurifier-Einstellungen',
     'showHtmlPurifierSettings' => 'Anzeigen der Einstellungen',
     'menuHtmlPurifier' => 'HTMLPurifier-Einstellungen',
-    'htmlPurifierSafeUrlsAddOwnDomain' => 'Eigene Domain hinzufügen',
+    'htmlPurifierOwnDomain' => 'Eigene Domain',
     'htmlPurifierOwnDomainHelp' => 'Stellen Sie bitte sicher, dass dies die richtige Domain ist. Sie wird automatisch als sicher angesehen.',
     'htmlPurifierUrlsConsideredSafe' => 'Als sicher angesehene Adressen',
     'timezone' => 'Zeitzone',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -75,7 +75,7 @@ return [
     'htmlPurifierSettings' => 'HTMLPurifier settings',
     'showHtmlPurifierSettings' => 'Show the settings',
     'menuHtmlPurifier' => 'HTMLPurifier settings',
-    'htmlPurifierSafeUrlsAddOwnDomain' => 'Add own domain',
+    'htmlPurifierOwnDomain' => 'Own domain',
     'htmlPurifierOwnDomainHelp' => 'Please make sure that this is the correct domain. It is automatically considered as safe.',
     'htmlPurifierUrlsConsideredSafe' => 'URLs considered safe',
     'timezone' => 'timezone',

--- a/application/modules/admin/views/admin/settings/htmlpurifier.php
+++ b/application/modules/admin/views/admin/settings/htmlpurifier.php
@@ -1,31 +1,27 @@
 <h1><?= $this->getTrans('htmlPurifierSettings') ?></h1>
-<form method="POST">
-    <?= $this->getTokenField() ?>
-    <div id="htmlPurifierSafeUrlsAddOwnDomain" class="row mb-3">
-        <label class="col-xl-2 col-form-label" for="ownDomain">
-            <?= $this->getTrans('htmlPurifierSafeUrlsAddOwnDomain') ?>:
-        </label>
-        <div class="col-xl-4">
-            <input type="text"
-                   class="form-control"
-                   id="ownDomain"
-                   name="ownDomain"
-                   value="<?= $this->escape($this->get('domain')) ?>"
-                   disabled />
-            <div id="htmlPurifierOwnDomainHelp" class="form-text"><?= $this->getTrans('htmlPurifierOwnDomainHelp') ?></div>
-        </div>
+<div id="htmlPurifierOwnDomain" class="row mb-3">
+    <label class="col-xl-2 col-form-label" for="ownDomain">
+        <?= $this->getTrans('htmlPurifierOwnDomain') ?>:
+    </label>
+    <div class="col-xl-4">
+        <input type="text"
+               class="form-control"
+               id="ownDomain"
+               name="ownDomain"
+               value="<?= $this->escape($this->get('domain')) ?>"
+               disabled />
+        <div id="htmlPurifierOwnDomainHelp" class="form-text"><?= $this->getTrans('htmlPurifierOwnDomainHelp') ?></div>
     </div>
-    <div id="htmlPurifierUrlsConsideredSafe" class="row mb-3">
-        <label class="col-xl-2 col-form-label">
-            <?= $this->getTrans('htmlPurifierUrlsConsideredSafe') ?>:
-        </label>
-        <div class="col-xl-4">
-            <ul class="list-group">
-                <?php foreach ($this->get('urlsConsideredSafe') as $url): ?>
-                    <li class="list-group-item"><?= $url ?></li>
-                <?php endforeach; ?>
-            </ul>
-        </div>
+</div>
+<div id="htmlPurifierUrlsConsideredSafe" class="row mb-3">
+    <label class="col-xl-2 col-form-label">
+        <?= $this->getTrans('htmlPurifierUrlsConsideredSafe') ?>:
+    </label>
+    <div class="col-xl-4">
+        <ul class="list-group">
+            <?php foreach ($this->get('urlsConsideredSafe') as $url): ?>
+                <li class="list-group-item"><?= $url ?></li>
+            <?php endforeach; ?>
+        </ul>
     </div>
-    <?= $this->getSaveBar() ?>
-</form>
+</div>


### PR DESCRIPTION
# Description
- Removed form, tokenfield and savebar
- Changed translation

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
