### PR TITLE
Add importing of a database dump

### DIFF
--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -161,7 +161,8 @@ return [
     'menuBackup' => 'Backup',
     'createBackupInfoText' => '<p>"CREATE DATABASE-Befehl hinzufügen" möchte man aktiviert haben, wenn beim Import die Datenbank mit gleicher Bezeichnung erstellt werden soll.
                                Die Einstellung sollte deaktiviert sein, wenn die Datenbank danach eine andere Bezeichnung haben soll.</p>
-                               <p>"DROP TABLE-Befehle hinzufügen" löscht beim Import bereits vorhandene Tabellen, um diese dann neu zu erstellen.</p>',
+                               <p>"DROP TABLE-Befehle hinzufügen" löscht beim Import bereits vorhandene Tabellen, um diese dann neu zu erstellen.</p>
+                               <p>Wenn Sie später Ilch zum Importieren eines Backups nutzen möchten, sollten diese beiden Optionen für das Backup aktiviert werden. Die Komprimierung dagegen deaktiviert.</p>',
     'compress' => 'Komprimierung',
     'compressNone' => 'keine',
     'skipComments' => 'Kommentare anzeigen',
@@ -170,6 +171,8 @@ return [
     'noBackups' => 'Keine Backups vorhanden',
     'backupNotFound' => 'Das Backup wurde nicht gefunden oder konnte nicht geöffnet werden.',
     'backupFilesize' => 'Dateigröße',
+    'backupImport' => 'Importieren',
+    'backupImportSuccess' => 'Backup wurde erfolgreich importiert.',
     'menuCustomCSS' => 'Benutzerdefinierte CSS',
     'menuHtaccess' => 'htaccess',
     'modrewriteLinesAdded' => 'Einträge für Mod-Rewrite hinzugefügt.',

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -172,6 +172,7 @@ return [
     'backupNotFound' => 'Das Backup wurde nicht gefunden oder konnte nicht geöffnet werden.',
     'backupFilesize' => 'Dateigröße',
     'backupImport' => 'Importieren',
+    'backupConfirmImport' => 'Wollen Sie das Backup (${name}) wirklich importieren?',
     'backupImportSuccess' => 'Backup wurde erfolgreich importiert.',
     'menuCustomCSS' => 'Benutzerdefinierte CSS',
     'menuHtaccess' => 'htaccess',

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -172,6 +172,7 @@ return [
     'backupNotFound' => 'Das Backup wurde nicht gefunden oder konnte nicht geöffnet werden.',
     'backupFilesize' => 'Dateigröße',
     'backupImport' => 'Importieren',
+    'backupCannotImport' => 'Dieses Backup kann von Ilch nicht importiert werden.',
     'backupConfirmImport' => 'Wollen Sie das Backup (${name}) wirklich importieren?',
     'backupImportSuccess' => 'Backup wurde erfolgreich importiert.',
     'menuCustomCSS' => 'Benutzerdefinierte CSS',

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -158,11 +158,11 @@ return [
     'menuLayouts' => 'Layouts',
     'menuSettings' => 'Einstellungen',
     'menuMaintenance' => 'Wartungsarbeiten',
-    'menuBackup' => 'Backup',
+    'menuBackup' => 'Datenbank-Backup',
     'createBackupInfoText' => '<p>"CREATE DATABASE-Befehl hinzufügen" möchte man aktiviert haben, wenn beim Import die Datenbank mit gleicher Bezeichnung erstellt werden soll.
                                Die Einstellung sollte deaktiviert sein, wenn die Datenbank danach eine andere Bezeichnung haben soll.</p>
                                <p>"DROP TABLE-Befehle hinzufügen" löscht beim Import bereits vorhandene Tabellen, um diese dann neu zu erstellen.</p>
-                               <p>Wenn Sie später Ilch zum Importieren eines Backups nutzen möchten, sollten diese beiden Optionen für das Backup aktiviert werden. Die Komprimierung dagegen deaktiviert.</p>',
+                               <p>Wenn Sie später Ilch zum Importieren eines Backups nutzen möchten, sollten Sie die "DROP TABLE-Befehle hinzufügen"-Option für das Backup aktiviert werden. Die Komprimierung dagegen deaktiviert.</p>',
     'compress' => 'Komprimierung',
     'compressNone' => 'keine',
     'skipComments' => 'Kommentare anzeigen',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -161,7 +161,8 @@ return [
     'menuBackup' => 'Backup',
     'createBackupInfoText' => '<p>Enable "Add CREATE DATABASE statement" to create the database with the previous name on import.
                                Disable this if the database should have a different name.</p>
-                               <p>"Add DROP TABLE statements" should be enabled if you wish to drop/delete existing tables on import.</p>',
+                               <p>"Add DROP TABLE statements" should be enabled if you wish to drop/delete existing tables on import.</p>
+                               <p>If you later want to use Ilch to import a backup then these two options should be enabled for the backup. The compression on the other hand disabled.</p>',
     'compress' => 'Compression',
     'compressNone' => 'None',
     'skipComments' => 'Display comments',
@@ -170,6 +171,8 @@ return [
     'noBackups' => 'No backups available',
     'backupNotFound' => 'The backup was not found or could not be opened.',
     'backupFilesize' => 'Filesize',
+    'backupImport' => 'Import',
+    'backupImportSuccess' => 'Backup was successfully imported.',
     'menuCustomCSS' => 'Custom CSS',
     'menuHtaccess' => 'htaccess',
     'modrewriteLinesAdded' => 'Added lines for mod rewrite.',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -172,6 +172,7 @@ return [
     'backupNotFound' => 'The backup was not found or could not be opened.',
     'backupFilesize' => 'Filesize',
     'backupImport' => 'Import',
+    'backupCannotImport' => 'This backup cannot be imported from Ilch.',
     'backupConfirmImport' => 'Do you really want to import the backup (${name})?',
     'backupImportSuccess' => 'Backup was successfully imported.',
     'menuCustomCSS' => 'Custom CSS',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -172,6 +172,7 @@ return [
     'backupNotFound' => 'The backup was not found or could not be opened.',
     'backupFilesize' => 'Filesize',
     'backupImport' => 'Import',
+    'backupConfirmImport' => 'Do you really want to import the backup (${name})?',
     'backupImportSuccess' => 'Backup was successfully imported.',
     'menuCustomCSS' => 'Custom CSS',
     'menuHtaccess' => 'htaccess',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -158,11 +158,11 @@ return [
     'menuLayouts' => 'Layouts',
     'menuSettings' => 'Settings',
     'menuMaintenance' => 'Maintenance',
-    'menuBackup' => 'Backup',
+    'menuBackup' => 'Database backup',
     'createBackupInfoText' => '<p>Enable "Add CREATE DATABASE statement" to create the database with the previous name on import.
                                Disable this if the database should have a different name.</p>
                                <p>"Add DROP TABLE statements" should be enabled if you wish to drop/delete existing tables on import.</p>
-                               <p>If you later want to use Ilch to import a backup then these two options should be enabled for the backup. The compression on the other hand disabled.</p>',
+                               <p>If you later want to use Ilch to import a backup then the "Add DROP TABLE statements" option should be enabled for the backup. The compression on the other hand disabled.</p>',
     'compress' => 'Compression',
     'compressNone' => 'None',
     'skipComments' => 'Display comments',

--- a/application/modules/admin/views/admin/backup/index.php
+++ b/application/modules/admin/views/admin/backup/index.php
@@ -1,7 +1,7 @@
 <h1><?=$this->getTrans('menuBackup') ?></h1>
 <form method="POST">
     <?=$this->getTokenField() ?>
-    <?php if ($this->get('backups') != ''): ?>
+    <?php if ($this->get('backups') != '') : ?>
     <div class="table-responsive">
         <table class="table table-hover table-striped">
             <colgroup>
@@ -25,7 +25,7 @@
                 </tr>
             </thead>
             <tbody>
-            <?php foreach ($this->get('backups') as $backup): ?>
+            <?php foreach ($this->get('backups') as $backup) : ?>
                 <?php $backupPublicName = $this->escape(preg_replace('/_[^_.]*\./', '.', $backup->getName())); ?>
                 <tr>
                     <td><?=$this->getDeleteCheckbox('id', $backup->getId()) ?></td>
@@ -37,14 +37,14 @@
                     <?php endif; ?>
                     <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $backup->getId()]) ?></td>
                     <td><?=$this->escape($backup->getDate()) ?></td>
-                    <td><?=formatBytes(filesize(ROOT_PATH . '/backups/' . $backup->getName())) ?></td>
+                    <td><?=(file_exists(ROOT_PATH . '/backups/' . $backup->getName())) ? formatBytes(filesize(ROOT_PATH . '/backups/' . $backup->getName())) : '' ?></td>
                     <td><?=$backupPublicName ?></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
         </table>
     </div>
-    <?php else: ?>
+    <?php else : ?>
         <tr>
             <td colspan="5"><?=$this->getTrans('noBackups') ?></td>
         </tr>

--- a/application/modules/admin/views/admin/backup/index.php
+++ b/application/modules/admin/views/admin/backup/index.php
@@ -8,6 +8,7 @@
                 <col class="icon_width">
                 <col class="icon_width">
                 <col class="icon_width">
+                <col class="icon_width">
                 <col class="col-lg-2">
                 <col class="col-lg-2">
                 <col>
@@ -15,6 +16,7 @@
             <thead>
                 <tr>
                     <th><?=$this->getCheckAllCheckbox('id') ?></th>
+                    <th></th>
                     <th></th>
                     <th></th>
                     <th><?=$this->getTrans('date') ?></th>
@@ -27,6 +29,7 @@
                 <tr>
                     <td><?=$this->getDeleteCheckbox('id', $backup->getId()) ?></td>
                     <td><a href="<?=$this->getUrl(['action' => 'download', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('download') ?>"><span class="fa-solid fa-download"></span></a></td>
+                    <td><a href="<?=$this->getUrl(['action' => 'import', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('backupImport') ?>"><span class="fa-solid fa-database"></span></a></td>
                     <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $backup->getId()]) ?></td>
                     <td><?=$this->escape($backup->getDate()) ?></td>
                     <td><?=formatBytes(filesize(ROOT_PATH . '/backups/' . $backup->getName())) ?></td>

--- a/application/modules/admin/views/admin/backup/index.php
+++ b/application/modules/admin/views/admin/backup/index.php
@@ -26,14 +26,15 @@
             </thead>
             <tbody>
             <?php foreach ($this->get('backups') as $backup): ?>
+                <?php $backupPublicName = $this->escape(preg_replace('/_[^_.]*\./', '.', $backup->getName())) ?>
                 <tr>
                     <td><?=$this->getDeleteCheckbox('id', $backup->getId()) ?></td>
                     <td><a href="<?=$this->getUrl(['action' => 'download', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('download') ?>"><span class="fa-solid fa-download"></span></a></td>
-                    <td><a href="<?=$this->getUrl(['action' => 'import', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('backupImport') ?>"><span class="fa-solid fa-database"></span></a></td>
+                    <td><a href="<?=$this->getUrl(['action' => 'import', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('backupImport') ?>" id="backupImport" data-name="<?=$backupPublicName ?>"><span class="fa-solid fa-database"></span></a></td>
                     <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $backup->getId()]) ?></td>
                     <td><?=$this->escape($backup->getDate()) ?></td>
                     <td><?=formatBytes(filesize(ROOT_PATH . '/backups/' . $backup->getName())) ?></td>
-                    <td><?=$this->escape(preg_replace('/_[^_.]*\./', '.', $backup->getName())) ?></td>
+                    <td><?=$backupPublicName ?></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
@@ -46,3 +47,14 @@
     <?php endif; ?>
     <?=$this->getListBar(['delete' => 'delete']) ?>
 </form>
+
+<script>
+    $("#backupImport").on("click", function(event) {
+        let name = $(this).data("name");
+
+        if (!confirm(`<?=$this->getTrans('backupConfirmImport') ?>`)) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    });
+</script>

--- a/application/modules/admin/views/admin/backup/index.php
+++ b/application/modules/admin/views/admin/backup/index.php
@@ -26,11 +26,15 @@
             </thead>
             <tbody>
             <?php foreach ($this->get('backups') as $backup): ?>
-                <?php $backupPublicName = $this->escape(preg_replace('/_[^_.]*\./', '.', $backup->getName())) ?>
+                <?php $backupPublicName = $this->escape(preg_replace('/_[^_.]*\./', '.', $backup->getName())); ?>
                 <tr>
                     <td><?=$this->getDeleteCheckbox('id', $backup->getId()) ?></td>
                     <td><a href="<?=$this->getUrl(['action' => 'download', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('download') ?>"><span class="fa-solid fa-download"></span></a></td>
-                    <td><a href="<?=$this->getUrl(['action' => 'import', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('backupImport') ?>" id="backupImport" data-name="<?=$backupPublicName ?>"><span class="fa-solid fa-database"></span></a></td>
+                    <?php if (strpos($backupPublicName, '.sql.gz') === false) : ?>
+                        <td><a href="<?=$this->getUrl(['action' => 'import', 'id' => $backup->getId()], null, true) ?>" title="<?=$this->getTrans('backupImport') ?>" id="backupImport" data-name="<?=$backupPublicName ?>"><span class="fa-solid fa-database"></span></a></td>
+                    <?php else : ?>
+                        <td><span class="fa-solid fa-database text-danger" title="<?=$this->getTrans('backupCannotImport') ?>"></span></td>
+                    <?php endif; ?>
                     <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $backup->getId()]) ?></td>
                     <td><?=$this->escape($backup->getDate()) ?></td>
                     <td><?=formatBytes(filesize(ROOT_PATH . '/backups/' . $backup->getName())) ?></td>


### PR DESCRIPTION
# Description
- Add importing of a database dump.

Fixes #416

Remarks:
- The import button is red and disabled if the database backup is gzip compressed as importing these is currently not supported.
- Trying to import a backup with already existing tables throws an exception that is handled.
- > mysqldump-php error: SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'ilch_admin_layoutadvsettings' already exists
- Obviously Ilch loses track of all kind of files (downloads, media, backups, ...) if a backup gets imported that was created before these files got added.

![grafik](https://github.com/user-attachments/assets/06c84dbf-5d09-4e8d-b75d-e008ff54c557)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
