### PR TITLE
HTMLPurifier: Fix syntax error in safeIframeRegexp

### DIFF
--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -142,7 +142,7 @@ abstract class Base
         $this->purifierConfig->set('URI.AllowedSchemes', ['data' => true, 'http' => true, 'https' => true, 'mailto' => true, 'src' => true]);
 
         if ($databaseConfig && $databaseConfig->get('domain')) {
-            $safeIframeRegexp = str_replace('^(http://|https://)localhost)', '^(http://|https://)localhost)|^(http://|https://)' . $databaseConfig->get('domain') . ')' , $safeIframeRegexp);
+            $safeIframeRegexp = str_replace('^(http://|https://)localhost)', '^(http://|https://)localhost)|^(http://|https://)' . $databaseConfig->get('domain'), $safeIframeRegexp);
         }
         $this->purifierConfig->set('URI.SafeIframeRegexp', $safeIframeRegexp);
         $this->purifierConfig->set('Attr.AllowedFrameTargets', '_blank, _self, _target, _parent');


### PR DESCRIPTION
# Description
- Fix syntax error in safeIframeRegexp

```
preg_match(): Compilation failed: unmatched closing parenthesis at offset 371 in application/libraries/Ilch/HTMLPurifier/EmbedUrlDef.php:18
preg_match(): Compilation failed: unmatched closing parenthesis at offset 371 in vendor/ezyang/htmlpurifier/library/HTMLPurifier/URIFilter/SafeIframe.php:64
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
