### PR TITLE
Fix "instance of HTMLPurifier, null returned"

### DIFF
--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -96,6 +96,7 @@ abstract class Base
             $baseUrl = BASE_URL;
         }
         $this->baseUrl = $baseUrl;
+        $this->initializeHtmlPurifier();
     }
 
     /**

--- a/application/libraries/Ilch/Page.php
+++ b/application/libraries/Ilch/Page.php
@@ -110,7 +110,9 @@ class Page
             $this->plugin->addPluginData('translator', $this->translator);
             $this->plugin->execute('AfterDatabaseLoad');
             $this->router->defineStartPage($databaseConfig->get('start_page'), $this->translator);
-            $this->view->initializeHtmlPurifier($databaseConfig);
+            if ($databaseConfig->get('domain')) {
+                $this->view->initializeHtmlPurifier($databaseConfig);
+            }
         } else {
             // Cms not installed yet.
             $this->request->setModuleName('install');


### PR DESCRIPTION
# Description
- Fix "Return value of Ilch\Design\Base::getPurifier() must be an instance of HTMLPurifier, null returned"

```
Uncaught TypeError: Return value of Ilch\Design\Base::getPurifier() must be an instance of HTMLPurifier, null returned in application/libraries/Ilch/Design/Base.php:191

Stack trace:
#0 application/libraries/Ilch/Design/Base.php(210): Ilch\Design\Base->getPurifier()
#1 application/modules/user/controllers/Regist.php(188): Ilch\Design\Base->purify()
#2 application/libraries/Ilch/Page.php(242): Modules\User\Controllers\Regist->inputAction()
#3 application/libraries/Ilch/Page.php(136): Ilch\Page->loadController()
#4 index.php(68): Ilch\Page->loadPage()
#5 {main} thrown in application/libraries/Ilch/Design/Base.php on line 191
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
