### PR TITLE
Userdefined profile fields on registration

### DIFF
--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -668,8 +668,8 @@ class Config extends \Ilch\Config\Install
                 break;
             case "2.2.3":
                 // Add new registration and private column.
-                $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `registration` TEXT NOT NULL DEFAULT \'0\' AFTER `hidden`;');
-                $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `private` TEXT NOT NULL DEFAULT \'0\' AFTER `registration`;');
+                $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `registration` TINYINT(1) NOT NULL DEFAULT 0 AFTER `hidden`;');
+                $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `private` TINYINT(1) NOT NULL DEFAULT 0 AFTER `registration`;');
                 break;
         }
 

--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -139,6 +139,7 @@ class Config extends \Ilch\Config\Install
                 `options` TEXT NOT NULL DEFAULT \'\',
                 `show` TINYINT(1) NOT NULL DEFAULT 1,
                 `hidden` TINYINT(1) NOT NULL DEFAULT 0,
+                `registration` TINYINT(1) NOT NULL DEFAULT 0,
                 `position` INT(11) UNSIGNED NOT NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
@@ -663,6 +664,10 @@ class Config extends \Ilch\Config\Install
                             ->execute();
                     }
                 }
+                break;
+            case "2.2.3":
+                // Add new registration column.
+                $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `registration` TEXT NOT NULL DEFAULT \'0\' AFTER `hidden`;');
                 break;
         }
 

--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -140,7 +140,6 @@ class Config extends \Ilch\Config\Install
                 `show` TINYINT(1) NOT NULL DEFAULT 1,
                 `hidden` TINYINT(1) NOT NULL DEFAULT 0,
                 `registration` TINYINT(1) NOT NULL DEFAULT 0,
-                `private` TINYINT(1) NOT NULL DEFAULT 0,
                 `position` INT(11) UNSIGNED NOT NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
@@ -667,9 +666,8 @@ class Config extends \Ilch\Config\Install
                 }
                 break;
             case "2.2.3":
-                // Add new registration and private column.
+                // Add new registration column.
                 $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `registration` TINYINT(1) NOT NULL DEFAULT 0 AFTER `hidden`;');
-                $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `private` TINYINT(1) NOT NULL DEFAULT 0 AFTER `registration`;');
                 break;
         }
 

--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -140,6 +140,7 @@ class Config extends \Ilch\Config\Install
                 `show` TINYINT(1) NOT NULL DEFAULT 1,
                 `hidden` TINYINT(1) NOT NULL DEFAULT 0,
                 `registration` TINYINT(1) NOT NULL DEFAULT 0,
+                `private` TINYINT(1) NOT NULL DEFAULT 0,
                 `position` INT(11) UNSIGNED NOT NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
@@ -666,8 +667,9 @@ class Config extends \Ilch\Config\Install
                 }
                 break;
             case "2.2.3":
-                // Add new registration column.
+                // Add new registration and private column.
                 $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `registration` TEXT NOT NULL DEFAULT \'0\' AFTER `hidden`;');
+                $this->db()->query('ALTER TABLE `[prefix]_profile_fields` ADD COLUMN `private` TEXT NOT NULL DEFAULT \'0\' AFTER `registration`;');
                 break;
         }
 

--- a/application/modules/user/controllers/Regist.php
+++ b/application/modules/user/controllers/Regist.php
@@ -103,7 +103,7 @@ class Regist extends \Ilch\Controller\Frontend
 
             foreach ($profileFields as $profileField) {
                 if ($profileField->getType() != 1) {
-                    $index = 'profileField'.$profileField->getId();
+                    $index = 'profileField' . $profileField->getId();
                     if ($this->getRequest()->getPost($index) === null) {
                         // This is for example the case if an external module added a profile field.
                         // Skip this profile field so the value doesn't get deleted.
@@ -113,6 +113,9 @@ class Regist extends \Ilch\Controller\Frontend
                         $post[$index] = json_encode($this->getRequest()->getPost($index));
                     } else {
                         $post[$index] = trim($this->getRequest()->getPost($index));
+                    }
+                    if ($profileField->getRegistration() === 2) {
+                        $validationRules[$index] = 'required';
                     }
                 }
             }
@@ -144,14 +147,14 @@ class Regist extends \Ilch\Controller\Frontend
                     ->setLocale($this->getTranslator()->getLocale())
                     ->setDateCreated($currentDate->format('Y-m-d H:i:s', true))
                     ->addGroup($userGroup);
-                $registMapper->save($model);
+                $userId = $registMapper->save($model);
 
                 foreach ($profileFields as $profileField) {
                     if ($profileField->getType() != 1) {
                         $index = 'profileField'.$profileField->getId();
                         $profileFieldsContent = new ProfileFieldContentModel();
                         $profileFieldsContent->setFieldId($profileField->getId())
-                            ->setUserId($this->getUser()->getId())
+                            ->setUserId($userId)
                             ->setValue($post[$index]);
                         $profileFieldsContentMapper->save($profileFieldsContent);
                     }

--- a/application/modules/user/controllers/Regist.php
+++ b/application/modules/user/controllers/Regist.php
@@ -6,8 +6,12 @@
 
 namespace Modules\User\Controllers;
 
+use Modules\User\Mappers\ProfileFields as ProfileFieldsMapper;
+use Modules\User\Mappers\ProfileFieldsContent as ProfileFieldsContentMapper;
+use Modules\User\Mappers\ProfileFieldsTranslation as ProfileFieldsTranslationMapper;
 use Modules\User\Mappers\User as UserMapper;
 use Modules\User\Mappers\Group as GroupMapper;
+use Modules\User\Models\ProfileFieldContent as ProfileFieldContentModel;
 use Modules\User\Models\User as UserModel;
 use Modules\User\Service\Password as PasswordService;
 use Modules\Admin\Mappers\Emails as EmailsMapper;
@@ -58,7 +62,26 @@ class Regist extends \Ilch\Controller\Frontend
             ->add($this->getTranslator()->trans('menuRegist'), ['action' => 'index'])
             ->add($this->getTranslator()->trans('step2to3'), ['action' => 'input']);
 
+        $profileFieldsContentMapper = new ProfileFieldsContentMapper();
+        $profileFieldsMapper = new ProfileFieldsMapper();
+        $profileFieldsTranslationMapper = new ProfileFieldsTranslationMapper();
+
+        $profileFields = $profileFieldsMapper->getProfileFields(['hidden' => 0, 'registration >' => 0]);
+        $profileFieldsTranslation = $profileFieldsTranslationMapper->getProfileFieldTranslationByLocale($this->getTranslator()->getLocale());
+
+        $this->getView()->set('profileFields', $profileFields)
+            ->set('profileFieldsTranslation', $profileFieldsTranslation);
+
         if ($this->getRequest()->isPost() && $this->getRequest()->getPost('bot') === '') {
+            $post = [
+                'name' => $this->getRequest()->getPost('name'),
+                'password' => $this->getRequest()->getPost('password'),
+                'password2' => $this->getRequest()->getPost('password2'),
+                'email' => $this->getRequest()->getPost('email'),
+                'captcha' => $this->getRequest()->getPost('captcha'),
+                'token' => $this->getRequest()->getPost('token'),
+            ];
+
             Validation::setCustomFieldAliases([
                 'grecaptcha' => 'token',
             ]);
@@ -75,6 +98,22 @@ class Regist extends \Ilch\Controller\Frontend
                     $validationRules['token'] = 'required|grecaptcha:saveRegist';
                 } else {
                     $validationRules['captcha'] = 'required|captcha';
+                }
+            }
+
+            foreach ($profileFields as $profileField) {
+                if ($profileField->getType() != 1) {
+                    $index = 'profileField'.$profileField->getId();
+                    if ($this->getRequest()->getPost($index) === null) {
+                        // This is for example the case if an external module added a profile field.
+                        // Skip this profile field so the value doesn't get deleted.
+                        continue;
+                    }
+                    if ($profileField->getType() == 4) {
+                        $post[$index] = json_encode($this->getRequest()->getPost($index));
+                    } else {
+                        $post[$index] = trim($this->getRequest()->getPost($index));
+                    }
                 }
             }
 
@@ -106,6 +145,17 @@ class Regist extends \Ilch\Controller\Frontend
                     ->setDateCreated($currentDate->format('Y-m-d H:i:s', true))
                     ->addGroup($userGroup);
                 $registMapper->save($model);
+
+                foreach ($profileFields as $profileField) {
+                    if ($profileField->getType() != 1) {
+                        $index = 'profileField'.$profileField->getId();
+                        $profileFieldsContent = new ProfileFieldContentModel();
+                        $profileFieldsContent->setFieldId($profileField->getId())
+                            ->setUserId($this->getUser()->getId())
+                            ->setValue($post[$index]);
+                        $profileFieldsContentMapper->save($profileFieldsContent);
+                    }
+                }
 
                 $_SESSION['name'] = $this->getRequest()->getPost('name');
                 $_SESSION['email'] = $this->getRequest()->getPost('email');

--- a/application/modules/user/controllers/admin/Profilefields.php
+++ b/application/modules/user/controllers/admin/Profilefields.php
@@ -118,7 +118,7 @@ class ProfileFields extends \Ilch\Controller\Admin
         $profileFieldsMapper = new ProfileFieldsMapper();
         $profileFieldsTranslationMapper = new ProfileFieldsTranslationMapper();
 
-        if ($profileFieldsMapper->profileFieldWithIdExists($profileFieldId)) {
+        if ($profileFieldId && $profileFieldsMapper->profileFieldWithIdExists($profileFieldId)) {
             $profileField = $profileFieldsMapper->getProfileFieldById($profileFieldId);
         } else {
             $profileField = new ProfileFieldModel();

--- a/application/modules/user/controllers/admin/Profilefields.php
+++ b/application/modules/user/controllers/admin/Profilefields.php
@@ -127,13 +127,13 @@ class ProfileFields extends \Ilch\Controller\Admin
         if ($this->getRequest()->isPost()) {
             $postData = $this->getRequest()->getPost();
             $profileFieldData = $postData['profileField'];
+            $profileFieldData['registration'] = $profileFieldData['showOnRegistration'] + $profileFieldData['showOnRegistrationRequired'];
             if ($profileFieldData['type'] != 2) {
                 $profileFieldData['icon'] = '';
                 $profileFieldData['addition'] = '';
             }
 
             if (in_array($profileFieldData['type'], $multiTypes)) {
-
                 $profileFieldData['options'] = json_encode(array_filter($postData['profileFieldOptions']));
             } else {
                 $profileFieldData['options'] = '';

--- a/application/modules/user/controllers/admin/Profilefields.php
+++ b/application/modules/user/controllers/admin/Profilefields.php
@@ -7,12 +7,13 @@
 
 namespace Modules\User\Controllers\Admin;
 
+use Ilch\Controller\Admin;
 use Modules\User\Mappers\ProfileFields as ProfileFieldsMapper;
 use Modules\User\Mappers\ProfileFieldsContent as ProfileFieldsContentMapper;
 use Modules\User\Models\ProfileField as ProfileFieldModel;
 use Modules\User\Mappers\ProfileFieldsTranslation as ProfileFieldsTranslationMapper;
 
-class ProfileFields extends \Ilch\Controller\Admin
+class ProfileFields extends Admin
 {
     public function init()
     {
@@ -177,7 +178,7 @@ class ProfileFields extends \Ilch\Controller\Admin
             $this->redirect(['action' => 'treat', 'id' => $profileFieldId]);
         }
 
-        $profileFieldsTranslation = $profileFieldsTranslationMapper->getProfileFieldTranslationByFieldId($profileFieldId);
+        $profileFieldsTranslation = ($profileFieldId) ? $profileFieldsTranslationMapper->getProfileFieldTranslationByFieldId($profileFieldId) : [];
         if (count($profileFieldsTranslation) == 0) {
             $profileFieldsTranslation[] = $profileFieldsTranslationMapper->loadFromArray();
         }

--- a/application/modules/user/mappers/ProfileFields.php
+++ b/application/modules/user/mappers/ProfileFields.php
@@ -113,6 +113,7 @@ class ProfileFields extends \Ilch\Mapper
             $fields['options'] = $profileField->getOptions();
             $fields['show'] = $profileField->getShow();
             $fields['registration'] = $profileField->getRegistration();
+            $fields['private'] = $profileField->getPrivate();
             $fields['position'] = $profileField->getPosition();
         }
 
@@ -250,6 +251,10 @@ class ProfileFields extends \Ilch\Mapper
 
         if (isset($profileFieldRow['registration'])) {
             $profileField->setRegistration($profileFieldRow['registration']);
+        }
+
+        if (isset($profileFieldRow['private'])) {
+            $profileField->setPrivate($profileFieldRow['private']);
         }
 
         if (isset($profileFieldRow['position'])) {

--- a/application/modules/user/mappers/ProfileFields.php
+++ b/application/modules/user/mappers/ProfileFields.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -13,10 +14,10 @@ class ProfileFields extends \Ilch\Mapper
     /**
      * Returns all profile-fields.
      *
-     * @param  array $where
+     * @param array $where
      * @return array()|\Modules\User\Models\ProfileField
      */
-    public function getProfileFields($where = [])
+    public function getProfileFields(array $where = []): array
     {
         $profileFieldRows = $this->db()->select('*')
             ->from('profile_fields')
@@ -38,10 +39,10 @@ class ProfileFields extends \Ilch\Mapper
     /**
      * Returns a ProfileField model found by the id.
      *
-     * @param  int $id
+     * @param int $id
      * @return null|ProfileFieldModel
      */
-    public function getProfileFieldById($id)
+    public function getProfileFieldById(int $id): ?ProfileFieldModel
     {
         $profileFieldRow = $this->db()->select('*')
             ->from('profile_fields')
@@ -59,10 +60,10 @@ class ProfileFields extends \Ilch\Mapper
     /**
      * Returns a ProfileField model found by the key.
      *
-     * @param  int $key
+     * @param int $key
      * @return null|ProfileFieldModel
      */
-    public function getProfileFieldIdByKey($key)
+    public function getProfileFieldIdByKey(int $key): ?ProfileFieldModel
     {
         $profileFieldRow = $this->db()->select('*')
             ->from('profile_fields')
@@ -84,7 +85,7 @@ class ProfileFields extends \Ilch\Mapper
      * @param int $position
      *
      */
-    public function updatePositionById($id, $position)
+    public function updatePositionById(int $id, int $position)
     {
         $this->db()->update('profile_fields')
             ->values(['position' => $position])
@@ -99,7 +100,7 @@ class ProfileFields extends \Ilch\Mapper
      *
      * @return int The id of the updated or inserted profile-field.
      */
-    public function save(ProfileFieldModel $profileField)
+    public function save(ProfileFieldModel $profileField): int
     {
         $fields = [];
         $key = $profileField->getKey();
@@ -142,7 +143,7 @@ class ProfileFields extends \Ilch\Mapper
      *
      * @param int $id
      */
-    public function update($id)
+    public function update(int $id)
     {
         $show = (int) $this->db()->select('show')
             ->from('profile_fields')
@@ -166,11 +167,11 @@ class ProfileFields extends \Ilch\Mapper
     /**
      * Deletes a given profile-field with the given id.
      *
-     * @param  int $id
+     * @param int $id
      *
      * @return bool True if success, otherwise false.
      */
-    public function deleteProfileField($id)
+    public function deleteProfileField(int $id): bool
     {
         return $this->db()->delete('profile_fields')
             ->where(['id' => $id])
@@ -180,11 +181,11 @@ class ProfileFields extends \Ilch\Mapper
     /**
      * Returns whether a profile-field exists.
      *
-     * @param  int $id
+     * @param int $id
      *
      * @return bool True if a profile-field with this id exists, false otherwise.
      */
-    public function profileFieldWithIdExists($id)
+    public function profileFieldWithIdExists(int $id): bool
     {
         return (boolean) $this->db()->select('COUNT(*)', 'profile_fields', ['id' => (int)$id])
             ->execute()
@@ -197,7 +198,7 @@ class ProfileFields extends \Ilch\Mapper
      *
      * @return int The count of profile-fields.
      */
-    public function getCountOfProfileFields()
+    public function getCountOfProfileFields(): int
     {
         return $this->db()->select('*')
             ->from('profile_fields')
@@ -211,11 +212,11 @@ class ProfileFields extends \Ilch\Mapper
      * @param array $profileFieldRow
      * @return ProfileFieldModel
      */
-    public function loadFromArray($profileFieldRow = [])
+    public function loadFromArray(array $profileFieldRow = []): ProfileFieldModel
     {
         $profileField = new ProfileFieldModel();
 
-        if (isset($profileFieldRow['id'])) {
+        if (!empty($profileFieldRow['id'])) {
             $profileField->setId($profileFieldRow['id']);
         }
 

--- a/application/modules/user/mappers/ProfileFields.php
+++ b/application/modules/user/mappers/ProfileFields.php
@@ -20,7 +20,7 @@ class ProfileFields extends \Ilch\Mapper
     {
         $profileFieldRows = $this->db()->select('*')
             ->from('profile_fields')
-            ->where($where, 'or')
+            ->where($where)
             ->order(['position' => 'ASC'])
             ->execute()
             ->fetchRows();
@@ -111,6 +111,7 @@ class ProfileFields extends \Ilch\Mapper
             $fields['addition'] = $profileField->getAddition();
             $fields['options'] = $profileField->getOptions();
             $fields['show'] = $profileField->getShow();
+            $fields['registration'] = $profileField->getRegistration();
             $fields['position'] = $profileField->getPosition();
         }
 
@@ -121,17 +122,13 @@ class ProfileFields extends \Ilch\Mapper
             ->fetchCell();
 
         if ($id) {
-            /*
-             * ProfileField does exist already, update.
-             */
+            // ProfileField does exist already, update.
             $this->db()->update('profile_fields')
                 ->values($fields)
                 ->where(['id' => $id])
                 ->execute();
         } else {
-            /*
-             * ProfileField does not exist yet, insert.
-             */
+            // ProfileField does not exist yet, insert.
             $id = $this->db()->insert('profile_fields')
                 ->values($fields)
                 ->execute();
@@ -248,6 +245,10 @@ class ProfileFields extends \Ilch\Mapper
 
         if (isset($profileFieldRow['hidden'])) {
             $profileField->setHidden($profileFieldRow['hidden']);
+        }
+
+        if (isset($profileFieldRow['registration'])) {
+            $profileField->setRegistration($profileFieldRow['registration']);
         }
 
         if (isset($profileFieldRow['position'])) {

--- a/application/modules/user/mappers/ProfileFields.php
+++ b/application/modules/user/mappers/ProfileFields.php
@@ -113,7 +113,6 @@ class ProfileFields extends \Ilch\Mapper
             $fields['options'] = $profileField->getOptions();
             $fields['show'] = $profileField->getShow();
             $fields['registration'] = $profileField->getRegistration();
-            $fields['private'] = $profileField->getPrivate();
             $fields['position'] = $profileField->getPosition();
         }
 
@@ -251,10 +250,6 @@ class ProfileFields extends \Ilch\Mapper
 
         if (isset($profileFieldRow['registration'])) {
             $profileField->setRegistration($profileFieldRow['registration']);
-        }
-
-        if (isset($profileFieldRow['private'])) {
-            $profileField->setPrivate($profileFieldRow['private']);
         }
 
         if (isset($profileFieldRow['position'])) {

--- a/application/modules/user/mappers/ProfileFieldsContent.php
+++ b/application/modules/user/mappers/ProfileFieldsContent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -13,10 +14,10 @@ class ProfileFieldsContent extends \Ilch\Mapper
     /**
      * Returns a ProfileFieldContent model found by the userid.
      *
-     * @param  int $userId
+     * @param int $userId
      * @return array()|\Modules\User\Models\ProfileFieldContent
      */
-    public function getProfileFieldContentByUserId($userId)
+    public function getProfileFieldContentByUserId(int $userId): array
     {
         $profileFieldContentRows = $this->db()->select('*')
             ->from('profile_content')
@@ -40,7 +41,7 @@ class ProfileFieldsContent extends \Ilch\Mapper
      * @param array $profileFieldRow
      * @return ProfileFieldContentModel
      */
-    public function loadFromArray($profileFieldRow = [])
+    public function loadFromArray(array $profileFieldRow = []): ProfileFieldContentModel
     {
         $profileFieldContent = new ProfileFieldContentModel();
 
@@ -62,10 +63,10 @@ class ProfileFieldsContent extends \Ilch\Mapper
     /**
      * Deletes the profile-content for a user with the given id.
      *
-     * @param  int $userId
+     * @param int $userId
      * @return bool True if success, otherwise false.
      */
-    public function deleteProfileFieldContentByUserId($userId)
+    public function deleteProfileFieldContentByUserId(int $userId): bool
     {
         return $this->db()->delete('profile_content')
             ->where(['user_id' => $userId])
@@ -75,10 +76,10 @@ class ProfileFieldsContent extends \Ilch\Mapper
     /**
      * Deletes the profile-content with a given field-id.
      *
-     * @param  int $fieldId
+     * @param int $fieldId
      * @return bool True if success, otherwise false.
      */
-    public function deleteProfileFieldContentByFieldId($fieldId)
+    public function deleteProfileFieldContentByFieldId(int $fieldId): bool
     {
         return $this->db()->delete('profile_content')
             ->where(['field_id' => $fieldId])
@@ -88,12 +89,12 @@ class ProfileFieldsContent extends \Ilch\Mapper
     /**
      * Delete the value of a specific profile field for a specific user.
      *
-     * @param $userId
-     * @param $fieldId
-     * @return \Ilch\Database\Mysql\Result|int
+     * @param int $userId
+     * @param int $fieldId
+     * @return int affected rows
      * @since 2.1.32
      */
-    public function deleteProfileFieldContentByUserAndFieldId($userId, $fieldId)
+    public function deleteProfileFieldContentByUserAndFieldId(int $userId, int $fieldId): int
     {
         return $this->db()->delete('profile_content')
             ->where(['user_id' => $userId, 'field_id' => $fieldId])
@@ -123,17 +124,13 @@ class ProfileFieldsContent extends \Ilch\Mapper
             ->fetchCell();
 
         if ($fieldId) {
-            /*
-             * profileFieldContent does exist already, update.
-             */
+            // profileFieldContent does exist already, update.
             $this->db()->update('profile_content')
                 ->values($fields)
                 ->where(['user_id' => $userId, 'field_id' => $fieldId])
                 ->execute();
         } else {
-            /*
-             * profileFieldContent does not exist yet, insert.
-             */
+            // profileFieldContent does not exist yet, insert.
             $this->db()->insert('profile_content')
                 ->values($fields)
                 ->execute();

--- a/application/modules/user/mappers/ProfileFieldsTranslation.php
+++ b/application/modules/user/mappers/ProfileFieldsTranslation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch
@@ -13,10 +14,10 @@ class ProfileFieldsTranslation extends \Ilch\Mapper
     /**
      * Returns all ProfileFieldTranslation found by the locale.
      *
-     * @param  string $locale
+     * @param string $locale
      * @return array()|\Modules\User\Models\ProfileFieldTranslation
      */
-    public function getProfileFieldTranslationByLocale($locale)
+    public function getProfileFieldTranslationByLocale(string $locale): array
     {
         $profileFieldTranslationRows = $this->db()->select('*')
             ->from('profile_trans')
@@ -37,10 +38,10 @@ class ProfileFieldsTranslation extends \Ilch\Mapper
     /**
      * Returns a ProfileFieldTranslation model found by the fieldid.
      *
-     * @param  int $fieldId
+     * @param int $fieldId
      * @return array()|\Modules\User\Models\ProfileFieldTranslation
      */
-    public function getProfileFieldTranslationByFieldId($fieldId)
+    public function getProfileFieldTranslationByFieldId(int $fieldId): array
     {
         $profileFieldTranslationRows = $this->db()->select('*')
             ->from('profile_trans')
@@ -64,7 +65,7 @@ class ProfileFieldsTranslation extends \Ilch\Mapper
      * @param array $profileFieldRow
      * @return ProfileFieldTranslationModel
      */
-    public function loadFromArray($profileFieldRow = [])
+    public function loadFromArray(array $profileFieldRow = []): ProfileFieldTranslationModel
     {
         $profileFieldTranslation = new ProfileFieldTranslationModel();
 
@@ -88,11 +89,11 @@ class ProfileFieldsTranslation extends \Ilch\Mapper
      * Use this function when a profilefield got deleted and it's
      * translations are no longer needed.
      *
-     * @param  int $fieldId
+     * @param int $fieldId
      *
      * @return bool True if success, otherwise false.
      */
-    public function deleteProfileFieldTranslationsByFieldId($fieldId)
+    public function deleteProfileFieldTranslationsByFieldId(int $fieldId): bool
     {
         return $this->db()->delete('profile_trans')
             ->where(['field_id' => $fieldId])
@@ -102,12 +103,12 @@ class ProfileFieldsTranslation extends \Ilch\Mapper
     /**
      * Deletes the profilefield-translation with a given locale and fieldid.
      *
-     * @param  string $locale
-     * @param  int $fieldId
+     * @param string $locale
+     * @param int $fieldId
      *
      * @return bool True if success, otherwise false.
      */
-    public function deleteProfileFieldTranslation($locale, $fieldId)
+    public function deleteProfileFieldTranslation(string $locale, int $fieldId): bool
     {
         return $this->db()->delete('profile_trans')
             ->where(['locale' => $locale, 'field_id' => $fieldId])
@@ -137,17 +138,13 @@ class ProfileFieldsTranslation extends \Ilch\Mapper
             ->fetchCell();
 
         if ($fieldId) {
-            /*
-             * profileFieldTranslation does exist already, update.
-             */
+            // profileFieldTranslation does exist already, update.
             $this->db()->update('profile_trans')
                 ->values($fields)
                 ->where(['field_id' => $fieldId, 'locale' => $profileFieldTranslation->getLocale()])
                 ->execute();
         } else {
-            /*
-             * profileFieldTranslation does not exist yet, insert.
-             */
+            // profileFieldTranslation does not exist yet, insert.
             $this->db()->insert('profile_trans')
                 ->values($fields)
                 ->execute();

--- a/application/modules/user/models/ProfileField.php
+++ b/application/modules/user/models/ProfileField.php
@@ -64,6 +64,14 @@ class ProfileField extends \Ilch\Model
      */
     protected $hidden;
 
+
+    /**
+     * Registration flag to mark a profile field as to be shown on registration and optionally be required.
+     *
+     * @var int
+     */
+    protected $registration;
+
     /**
      * The position of the profile-field.
      *
@@ -254,6 +262,29 @@ class ProfileField extends \Ilch\Model
     {
         $this->hidden = (int)$hidden;
 
+        return $this;
+    }
+
+    /**
+     * Get value of registration.
+     * 0: disabled, 1: enabled, 2: enabled and required
+     *
+     * @return int
+     */
+    public function getRegistration(): int
+    {
+        return $this->registration;
+    }
+
+    /**
+     * Set value of registration.
+     *
+     * @param int $registration 0: disabled, 1: enabled, 2: enabled and required
+     * @return ProfileField
+     */
+    public function setRegistration(int $registration): ProfileField
+    {
+        $this->registration = $registration;
         return $this;
     }
 

--- a/application/modules/user/models/ProfileField.php
+++ b/application/modules/user/models/ProfileField.php
@@ -75,13 +75,6 @@ class ProfileField extends Model
     protected int $registration = 0;
 
     /**
-     * Determines if a profile field is private or public.
-     *
-     * @var int
-     */
-    protected int $private = 0;
-
-    /**
      * The position of the profile-field.
      *
      * @var int
@@ -294,28 +287,6 @@ class ProfileField extends Model
     public function setRegistration(int $registration): ProfileField
     {
         $this->registration = $registration;
-        return $this;
-    }
-
-    /**
-     * Get the value to determine if this profile field is private or public.
-     *
-     * @return int
-     */
-    public function getPrivate(): int
-    {
-        return $this->private;
-    }
-
-    /**
-     * Set the value to mark this profile field as private or public.
-     *
-     * @param int $private
-     * @return $this
-     */
-    public function setPrivate(int $private): ProfileField
-    {
-        $this->private = $private;
         return $this;
     }
 

--- a/application/modules/user/models/ProfileField.php
+++ b/application/modules/user/models/ProfileField.php
@@ -7,7 +7,9 @@
 
 namespace Modules\User\Models;
 
-class ProfileField extends \Ilch\Model
+use Ilch\Model;
+
+class ProfileField extends Model
 {
     /**
      * The id of the profile-field.

--- a/application/modules/user/models/ProfileField.php
+++ b/application/modules/user/models/ProfileField.php
@@ -73,6 +73,13 @@ class ProfileField extends \Ilch\Model
     protected int $registration = 0;
 
     /**
+     * Determines if a profile field is private or public.
+     *
+     * @var int
+     */
+    protected int $private = 0;
+
+    /**
      * The position of the profile-field.
      *
      * @var int
@@ -285,6 +292,28 @@ class ProfileField extends \Ilch\Model
     public function setRegistration(int $registration): ProfileField
     {
         $this->registration = $registration;
+        return $this;
+    }
+
+    /**
+     * Get the value to determine if this profile field is private or public.
+     *
+     * @return int
+     */
+    public function getPrivate(): int
+    {
+        return $this->private;
+    }
+
+    /**
+     * Set the value to mark this profile field as private or public.
+     *
+     * @param int $private
+     * @return $this
+     */
+    public function setPrivate(int $private): ProfileField
+    {
+        $this->private = $private;
         return $this;
     }
 

--- a/application/modules/user/models/ProfileField.php
+++ b/application/modules/user/models/ProfileField.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -11,80 +12,79 @@ class ProfileField extends \Ilch\Model
     /**
      * The id of the profile-field.
      *
-     * @var int
+     * @var int|null
      */
-    protected $id;
+    protected ?int $id = null;
 
     /**
      * The key of the profile-field.
      *
      * @var string
      */
-    protected $key;
+    protected string $key = '';
 
     /**
      * The type of the profile-field.
      *
-     * @var int
+     * @var int|null
      */
-    protected $type;
+    protected ?int $type = null;
 
     /**
      * The icon of the profile-field.
      *
      * @var string
      */
-    protected $icon;
+    protected string $icon = '';
 
     /**
      * The addition of the profile-field.
      *
      * @var string
      */
-    protected $addition;
+    protected string $addition = '';
 
     /**
      * The options of the profile-field.
      *
      * @var string
      */
-    protected $options;
+    protected string $options = '';
 
     /**
      * The show status of the profile-field.
      *
      * @var int
      */
-    protected $show;
+    protected int $show = 1;
 
     /**
      * The hidden status of the profile-field.
      *
      * @var int
      */
-    protected $hidden;
-
+    protected int $hidden = 0;
 
     /**
      * Registration flag to mark a profile field as to be shown on registration and optionally be required.
      *
      * @var int
      */
-    protected $registration;
+    protected int $registration = 0;
 
     /**
      * The position of the profile-field.
      *
      * @var int
      */
-    protected $position;
+    protected int $position;
 
     /**
      * Returns the id of the profile-field.
      *
-     * @return int
+     * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -95,9 +95,9 @@ class ProfileField extends \Ilch\Model
      * @param int $id
      * @return ProfileField
      */
-    public function setId($id)
+    public function setId(int $id): ProfileField
     {
-        $this->id = (int)$id;
+        $this->id = $id;
 
         return $this;
     }
@@ -107,7 +107,7 @@ class ProfileField extends \Ilch\Model
      *
      * @return string
      */
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -118,7 +118,7 @@ class ProfileField extends \Ilch\Model
      * @param string $key
      * @return ProfileField
      */
-    public function setKey($key)
+    public function setKey(string $key): ProfileField
     {
         $this->key = $key;
 
@@ -128,9 +128,9 @@ class ProfileField extends \Ilch\Model
     /**
      * Returns the type of the profile-field.
      *
-     * @return int
+     * @return int|null
      */
-    public function getType()
+    public function getType(): ?int
     {
         return $this->type;
     }
@@ -141,9 +141,9 @@ class ProfileField extends \Ilch\Model
      * @param int $type
      * @return ProfileField
      */
-    public function setType($type)
+    public function setType(int $type): ProfileField
     {
-        $this->type = (int)$type;
+        $this->type = $type;
 
         return $this;
     }
@@ -153,7 +153,7 @@ class ProfileField extends \Ilch\Model
      *
      * @return string
      */
-    public function getIcon()
+    public function getIcon(): string
     {
         return $this->icon;
     }
@@ -164,7 +164,7 @@ class ProfileField extends \Ilch\Model
      * @param string $icon
      * @return ProfileField
      */
-    public function setIcon($icon)
+    public function setIcon(string $icon): ProfileField
     {
         $this->icon = $icon;
 
@@ -176,7 +176,7 @@ class ProfileField extends \Ilch\Model
      *
      * @return string
      */
-    public function getAddition()
+    public function getAddition(): string
     {
         return $this->addition;
     }
@@ -187,7 +187,7 @@ class ProfileField extends \Ilch\Model
      * @param string $addition
      * @return ProfileField
      */
-    public function setAddition($addition)
+    public function setAddition(string $addition): ProfileField
     {
         $this->addition = $addition;
 
@@ -224,7 +224,7 @@ class ProfileField extends \Ilch\Model
      *
      * @return int
      */
-    public function getShow()
+    public function getShow(): int
     {
         return $this->show;
     }
@@ -235,9 +235,9 @@ class ProfileField extends \Ilch\Model
      * @param int $show
      * @return ProfileField
      */
-    public function setShow($show)
+    public function setShow(int $show): ProfileField
     {
-        $this->show = (int)$show;
+        $this->show = $show;
 
         return $this;
     }
@@ -247,7 +247,7 @@ class ProfileField extends \Ilch\Model
      *
      * @return int
      */
-    public function getHidden()
+    public function getHidden(): int
     {
         return $this->hidden;
     }
@@ -258,9 +258,9 @@ class ProfileField extends \Ilch\Model
      * @param int $hidden
      * @return ProfileField
      */
-    public function setHidden($hidden)
+    public function setHidden(int $hidden): ProfileField
     {
-        $this->hidden = (int)$hidden;
+        $this->hidden = $hidden;
 
         return $this;
     }
@@ -293,7 +293,7 @@ class ProfileField extends \Ilch\Model
      *
      * @return int
      */
-    public function getPosition()
+    public function getPosition(): int
     {
         return $this->position;
     }
@@ -304,9 +304,9 @@ class ProfileField extends \Ilch\Model
      * @param int $position
      * @return ProfileField
      */
-    public function setPosition($position)
+    public function setPosition(int $position): ProfileField
     {
-        $this->position = (int)$position;
+        $this->position = $position;
 
         return $this;
     }

--- a/application/modules/user/models/ProfileFieldContent.php
+++ b/application/modules/user/models/ProfileFieldContent.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -13,28 +14,28 @@ class ProfileFieldContent extends \Ilch\Model
      *
      * @var int
      */
-    protected $fieldId;
+    protected int $fieldId;
 
     /**
      * The user-id of the ProfileFieldContent.
      *
      * @var int
      */
-    protected $userId;
+    protected int $userId;
 
     /**
      * The value of the ProfileFieldContent.
      *
      * @var string
      */
-    protected $value;
+    protected string $value;
 
     /**
      * Returns the field-id of the ProfileFieldContent.
      *
      * @return int
      */
-    public function getFieldId()
+    public function getFieldId(): int
     {
         return $this->fieldId;
     }
@@ -45,9 +46,9 @@ class ProfileFieldContent extends \Ilch\Model
      * @param int $fieldId
      * @return ProfileFieldContent
      */
-    public function setFieldId($fieldId)
+    public function setFieldId(int $fieldId): ProfileFieldContent
     {
-        $this->fieldId = (int)$fieldId;
+        $this->fieldId = $fieldId;
 
         return $this;
     }
@@ -57,7 +58,7 @@ class ProfileFieldContent extends \Ilch\Model
      *
      * @return int
      */
-    public function getUserId()
+    public function getUserId(): int
     {
         return $this->userId;
     }
@@ -68,9 +69,9 @@ class ProfileFieldContent extends \Ilch\Model
      * @param int $userId
      * @return ProfileFieldContent
      */
-    public function setUserId($userId)
+    public function setUserId(int $userId): ProfileFieldContent
     {
-        $this->userId = (int)$userId;
+        $this->userId = $userId;
 
         return $this;
     }
@@ -80,7 +81,7 @@ class ProfileFieldContent extends \Ilch\Model
      *
      * @return string
      */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }
@@ -91,7 +92,7 @@ class ProfileFieldContent extends \Ilch\Model
      * @param string $value
      * @return ProfileFieldContent
      */
-    public function setValue($value)
+    public function setValue(string $value): ProfileFieldContent
     {
         $this->value = $value;
 

--- a/application/modules/user/models/ProfileFieldTranslation.php
+++ b/application/modules/user/models/ProfileFieldTranslation.php
@@ -1,40 +1,43 @@
 <?php
+
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
 namespace Modules\User\Models;
 
-class ProfileFieldTranslation extends \Ilch\Model
+use Ilch\Model;
+
+class ProfileFieldTranslation extends Model
 {
     /**
      * The field-id of the ProfileFieldTranslation.
      *
      * @var int
      */
-    protected $fieldId;
+    protected int $fieldId;
 
     /**
      * The locale of the ProfileFieldTranslation.
      *
      * @var string
      */
-    protected $locale;
+    protected string $locale = '';
 
     /**
      * The name of the ProfileFieldTranslation.
      *
      * @var string
      */
-    protected $name;
+    protected string $name = '';
 
     /**
      * Returns the field-id of the ProfileFieldTranslation.
      *
      * @return int
      */
-    public function getFieldId()
+    public function getFieldId(): int
     {
         return $this->fieldId;
     }
@@ -45,9 +48,9 @@ class ProfileFieldTranslation extends \Ilch\Model
      * @param int $fieldId
      * @return ProfileFieldTranslation
      */
-    public function setFieldId($fieldId)
+    public function setFieldId(int $fieldId): ProfileFieldTranslation
     {
-        $this->fieldId = (int)$fieldId;
+        $this->fieldId = $fieldId;
 
         return $this;
     }
@@ -57,7 +60,7 @@ class ProfileFieldTranslation extends \Ilch\Model
      *
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->locale;
     }
@@ -68,7 +71,7 @@ class ProfileFieldTranslation extends \Ilch\Model
      * @param string $locale
      * @return ProfileFieldTranslation
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): ProfileFieldTranslation
     {
         $this->locale = $locale;
 
@@ -80,7 +83,7 @@ class ProfileFieldTranslation extends \Ilch\Model
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -91,7 +94,7 @@ class ProfileFieldTranslation extends \Ilch\Model
      * @param string $name
      * @return ProfileFieldTranslation
      */
-    public function setName($name)
+    public function setName(string $name): ProfileFieldTranslation
     {
         $this->name = $name;
 

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -306,6 +306,7 @@ return [
     'profileFieldName' => 'Name',
     'profileFieldType' => 'Typ',
     'profileFieldRegistration' => 'Registrierung',
+    'profileFieldPrivate' => 'Privat',
     'profileFieldField' => 'Textfeld',
     'profileFieldCat' => 'Kategorie',
     'profileFieldIcon' => 'Icon',
@@ -341,6 +342,7 @@ return [
     'profileFieldShowTitle' => 'Profil-Feld anzeigen',
     'profileFieldHideTitle' => 'Profil-Feld verstecken',
     'profileFieldRegistrationTitle' => 'Wird bei der Registrierung abgefragt.',
+    'profileFieldPrivateTitle' => 'Dieses Profil-Feld ist privat und wird nicht öffentlich angezeigt.',
 
     'picturesPerPage' => 'Bilder pro Seite',
 

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -305,6 +305,7 @@ return [
     'profileFieldKey' => 'Key',
     'profileFieldName' => 'Name',
     'profileFieldType' => 'Typ',
+    'profileFieldRegistration' => 'Registrierung',
     'profileFieldField' => 'Textfeld',
     'profileFieldCat' => 'Kategorie',
     'profileFieldIcon' => 'Icon',
@@ -326,6 +327,8 @@ return [
     'profileFieldHidden' => 'Feld vom Administrator ausgeblendet.',
     'chooseIcon' => 'Wählen Sie ein Symbol',
     'noIcon' => 'Kein Symbol',
+    'profileFieldShowOnRegistration' => 'Feld bei der Registrierung abfragen?',
+    'profileFieldShowOnRegistrationRequired' => 'Feld bei der Registrierung als Pflichtfeld markieren?',
     'profileFieldKeyDesc' => 'Ein Schlüsselname für die Datenbank. Es sollte ein zuordenbarer und klein geschriebener Name für dieses Profilfeld sein.',
     'profileFieldTypeDesc0' => 'Das Textfeld erlaubt es Nutzern in einer einzelnen Zeile einen Text einzugeben.',
     'profileFieldTypeDesc1' => 'Die Kategorie ist eine nur lesbare Überschrift. Dies ist nützlich um eigene Profilfelder zu organisieren.',
@@ -335,6 +338,9 @@ return [
     'profileFieldTypeDesc5' => 'Das Dropdownfeld enthält vorgegebene Einträge zur Auswahl. Nutzer können hier nur eine Option auswählen.',
     'profileFieldTypeDesc6' => 'Das Datumsfeld erlaubt es Nutzern ein Datum aus einem Dropdown Kalender auszuwählen oder ihn manuell einzugeben.',
     'profileFieldOptions' => 'Auswahloptionen',
+    'profileFieldShowTitle' => 'Profil-Feld anzeigen',
+    'profileFieldHideTitle' => 'Profil-Feld verstecken',
+    'profileFieldRegistrationTitle' => 'Wird bei der Registrierung abgefragt.',
 
     'picturesPerPage' => 'Bilder pro Seite',
 

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -306,7 +306,6 @@ return [
     'profileFieldName' => 'Name',
     'profileFieldType' => 'Typ',
     'profileFieldRegistration' => 'Registrierung',
-    'profileFieldPrivate' => 'Privat',
     'profileFieldField' => 'Textfeld',
     'profileFieldCat' => 'Kategorie',
     'profileFieldIcon' => 'Icon',
@@ -342,7 +341,6 @@ return [
     'profileFieldShowTitle' => 'Profil-Feld anzeigen',
     'profileFieldHideTitle' => 'Profil-Feld verstecken',
     'profileFieldRegistrationTitle' => 'Wird bei der Registrierung abgefragt.',
-    'profileFieldPrivateTitle' => 'Dieses Profil-Feld ist privat und wird nicht öffentlich angezeigt.',
 
     'picturesPerPage' => 'Bilder pro Seite',
 

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -305,6 +305,7 @@ return [
     'profileFieldKey' => 'Key',
     'profileFieldName' => 'Name',
     'profileFieldType' => 'Type',
+    'profileFieldRegistration' => 'Registration',
     'profileFieldField' => 'Text field',
     'profileFieldCat' => 'Category',
     'profileFieldIcon' => 'Icon',
@@ -326,6 +327,8 @@ return [
     'profileFieldHidden' => 'Field hidden by the administrator.',
     'chooseIcon' => 'Choose a symbol',
     'noIcon' => 'No symbol',
+    'profileFieldShowOnRegistration' => 'Query field on registration?',
+    'profileFieldShowOnRegistrationRequired' => 'Mark field as required on registration?',
     'profileFieldKeyDesc' => 'A key for the database. It should be a relatable and lowercase name for this profile field.',
     'profileFieldTypeDesc0' => 'The text field allows users to enter text in a single line.',
     'profileFieldTypeDesc1' => 'The category is a read-only heading. This is useful for organizing your own profile fields.',
@@ -335,6 +338,9 @@ return [
     'profileFieldTypeDesc5' => 'The drop-down box contains default entries to choose from. Users can only select one option here.',
     'profileFieldTypeDesc6' => 'The date field allows users to select a date from a drop-down calendar or enter it manually.',
     'profileFieldOptions' => 'Selection options',
+    'profileFieldShowTitle' => 'Show profile field',
+    'profileFieldHideTitle' => 'Hide profile field',
+    'profileFieldRegistrationTitle' => 'Will be requested during registration.',
 
     'picturesPerPage' => 'Pictures per page',
 

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -306,7 +306,6 @@ return [
     'profileFieldName' => 'Name',
     'profileFieldType' => 'Type',
     'profileFieldRegistration' => 'Registration',
-    'profileFieldPrivate' => 'Private',
     'profileFieldField' => 'Text field',
     'profileFieldCat' => 'Category',
     'profileFieldIcon' => 'Icon',
@@ -342,7 +341,6 @@ return [
     'profileFieldShowTitle' => 'Show profile field',
     'profileFieldHideTitle' => 'Hide profile field',
     'profileFieldRegistrationTitle' => 'Will be requested during registration.',
-    'profileFieldPrivateTitle' => 'This profile field is private and not shown publicly.',
 
     'picturesPerPage' => 'Pictures per page',
 

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -306,6 +306,7 @@ return [
     'profileFieldName' => 'Name',
     'profileFieldType' => 'Type',
     'profileFieldRegistration' => 'Registration',
+    'profileFieldPrivate' => 'Private',
     'profileFieldField' => 'Text field',
     'profileFieldCat' => 'Category',
     'profileFieldIcon' => 'Icon',
@@ -341,6 +342,7 @@ return [
     'profileFieldShowTitle' => 'Show profile field',
     'profileFieldHideTitle' => 'Hide profile field',
     'profileFieldRegistrationTitle' => 'Will be requested during registration.',
+    'profileFieldPrivateTitle' => 'This profile field is private and not shown publicly.',
 
     'picturesPerPage' => 'Pictures per page',
 

--- a/application/modules/user/views/admin/index/treatProfile.php
+++ b/application/modules/user/views/admin/index/treatProfile.php
@@ -52,9 +52,6 @@ $profileFieldsContent = $this->get('profileFieldsContent');
 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 
 foreach ($profileFields as $profileField) {
-    if (!$profileField->getShow()) {
-        continue;
-    }
     $profileFieldName = $profileField->getKey();
     $value = '';
     foreach ($profileFieldsContent as $profileFieldContent) {

--- a/application/modules/user/views/admin/profilefields/index.php
+++ b/application/modules/user/views/admin/profilefields/index.php
@@ -20,6 +20,7 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                 <col class="icon_width" />
                 <col />
                 <col />
+                <col />
                 <col class="icon_width" />
             </colgroup>
             <thead>
@@ -30,6 +31,7 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                     <th></th>
                     <th><?=$this->getTrans('profileFieldName') ?></th>
                     <th><?=$this->getTrans('profileFieldType') ?></th>
+                    <th><?=$this->getTrans('profileFieldRegistration') ?></th>
                     <th></th>
                 </tr>
             </thead>
@@ -51,11 +53,11 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                     <?php endif; ?>
                     <td>
                         <?php if ($profileField->getShow() == 1): ?>
-                            <a href="<?=$this->getUrl(['action' => 'update', 'id' => $profileField->getId()], null, true) ?>">
+                            <a href="<?=$this->getUrl(['action' => 'update', 'id' => $profileField->getId()], null, true) ?>" title="<?=$this->getTrans('profileFieldHideTitle') ?>">
                                 <span class="fa-regular fa-square-check text-info"></span>
                             </a>
                         <?php else: ?>
-                            <a href="<?=$this->getUrl(['action' => 'update', 'id' => $profileField->getId()], null, true) ?>">
+                            <a href="<?=$this->getUrl(['action' => 'update', 'id' => $profileField->getId()], null, true) ?>" title="<?=$this->getTrans('profileFieldShowTitle') ?>">
                                 <span class="fa-regular fa-square text-info"></span>
                             </a>
                         <?php endif; ?>
@@ -84,6 +86,7 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                         <td><b><?=$this->escape($profileFieldName) ?></b></td>
                         <td><b><i class="<?=$iconArray[$profileField->getType()] ?>"></i>&nbsp;&nbsp;<?=$this->getTrans($typeArray[$profileField->getType()]) ?></b></td>
                     <?php endif; ?>
+                        <td><?= ($profileField->getRegistration() === 2) ? '<i class="fa-solid fa-user-plus" title="' . $this->getTrans('profileFieldRegistrationTitle') . '"></i>' : '' ?></td>
                         <td><i class="fa-solid fa-up-down"></i></td>
                 </tr>
                 <?php endforeach; ?>

--- a/application/modules/user/views/admin/profilefields/index.php
+++ b/application/modules/user/views/admin/profilefields/index.php
@@ -1,4 +1,8 @@
 <?php
+
+use Modules\User\Models\ProfileField;
+use Modules\User\Models\ProfileFieldTranslation;
+
 $typeArray = ['profileFieldField', 'profileFieldCat', 'profileFieldIcon', 'profileFieldRadio', 'profileFieldCheck', 'profileFieldDrop', 'profileFieldDate'];
 $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa-icons', 'fa-regular fa-circle-check', 'fa-regular fa-square-check', 'fa-regular fa-square-caret-down', 'fa-regular fa-calendar-days'];
 ?>
@@ -39,7 +43,9 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
             </thead>
             <tbody id="sortable">
                 <?php
+                /** @var ProfileField[] $profileFields */
                 $profileFields = $this->get('profileFields');
+                /** @var ProfileFieldTranslation[] $profileFieldsTranslation */
                 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 
                 foreach ($profileFields as $profileField):

--- a/application/modules/user/views/admin/profilefields/index.php
+++ b/application/modules/user/views/admin/profilefields/index.php
@@ -46,7 +46,7 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                 ?>
                 <tr id="<?=$profileField->getId() ?>">
 
-                    <?php if ($profileField->getHidden() == 0): ?>
+                    <?php if ($profileField->getHidden() == 0) : ?>
                         <td><?=$this->getDeleteCheckbox('check_users', $profileField->getId()) ?></td>
                         <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $profileField->getId()]) ?></td>
                         <td><?=$this->getDeleteIcon(['action' => 'delete', 'id' => $profileField->getId()]) ?></td>
@@ -54,11 +54,11 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                         <td colspan="3"></td>
                     <?php endif; ?>
                     <td>
-                        <?php if ($profileField->getShow() == 1): ?>
+                        <?php if ($profileField->getShow() == 1) : ?>
                             <a href="<?=$this->getUrl(['action' => 'update', 'id' => $profileField->getId()], null, true) ?>" title="<?=$this->getTrans('profileFieldHideTitle') ?>">
                                 <span class="fa-regular fa-square-check text-info"></span>
                             </a>
-                        <?php else: ?>
+                        <?php else : ?>
                             <a href="<?=$this->getUrl(['action' => 'update', 'id' => $profileField->getId()], null, true) ?>" title="<?=$this->getTrans('profileFieldShowTitle') ?>">
                                 <span class="fa-regular fa-square text-info"></span>
                             </a>
@@ -84,7 +84,7 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                     <?php if ($profileField->getType() != 1) : ?>
                         <td><?=$this->escape($profileFieldName) ?></td>
                         <td><i class="<?=$iconArray[$profileField->getType()] ?>"></i>&nbsp;&nbsp;<?=$this->getTrans($typeArray[$profileField->getType()]) ?></td>
-                    <?php else: ?>
+                    <?php else : ?>
                         <td><b><?=$this->escape($profileFieldName) ?></b></td>
                         <td><b><i class="<?=$iconArray[$profileField->getType()] ?>"></i>&nbsp;&nbsp;<?=$this->getTrans($typeArray[$profileField->getType()]) ?></b></td>
                     <?php endif; ?>

--- a/application/modules/user/views/admin/profilefields/index.php
+++ b/application/modules/user/views/admin/profilefields/index.php
@@ -92,7 +92,7 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                         <td><b><?=$this->escape($profileFieldName) ?></b></td>
                         <td><b><i class="<?=$iconArray[$profileField->getType()] ?>"></i>&nbsp;&nbsp;<?=$this->getTrans($typeArray[$profileField->getType()]) ?></b></td>
                     <?php endif; ?>
-                        <td><?= ($profileField->getRegistration() === 2) ? '<i class="fa-solid fa-user-plus" title="' . $this->getTrans('profileFieldRegistrationTitle') . '"></i>' : '' ?></td>
+                        <td><?= ($profileField->getRegistration() >= 1) ? '<i class="fa-solid fa-user-plus" title="' . $this->getTrans('profileFieldRegistrationTitle') . '"></i>' : '' ?></td>
                         <td><i class="fa-solid fa-up-down"></i></td>
                 </tr>
                 <?php endforeach; ?>

--- a/application/modules/user/views/admin/profilefields/index.php
+++ b/application/modules/user/views/admin/profilefields/index.php
@@ -21,6 +21,7 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                 <col />
                 <col />
                 <col />
+                <col />
                 <col class="icon_width" />
             </colgroup>
             <thead>
@@ -32,6 +33,7 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                     <th><?=$this->getTrans('profileFieldName') ?></th>
                     <th><?=$this->getTrans('profileFieldType') ?></th>
                     <th><?=$this->getTrans('profileFieldRegistration') ?></th>
+                    <th><?=$this->getTrans('profileFieldPrivate') ?></th>
                     <th></th>
                 </tr>
             </thead>
@@ -87,6 +89,7 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                         <td><b><i class="<?=$iconArray[$profileField->getType()] ?>"></i>&nbsp;&nbsp;<?=$this->getTrans($typeArray[$profileField->getType()]) ?></b></td>
                     <?php endif; ?>
                         <td><?= ($profileField->getRegistration() === 2) ? '<i class="fa-solid fa-user-plus" title="' . $this->getTrans('profileFieldRegistrationTitle') . '"></i>' : '' ?></td>
+                        <td><?= ($profileField->getPrivate()) ? '<i class="fa-solid fa-lock" title="' . $this->getTrans('profileFieldPrivateTitle') . '"></i>' : '' ?></td>
                         <td><i class="fa-solid fa-up-down"></i></td>
                 </tr>
                 <?php endforeach; ?>

--- a/application/modules/user/views/admin/profilefields/index.php
+++ b/application/modules/user/views/admin/profilefields/index.php
@@ -25,7 +25,6 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                 <col />
                 <col />
                 <col />
-                <col />
                 <col class="icon_width" />
             </colgroup>
             <thead>
@@ -37,7 +36,6 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                     <th><?=$this->getTrans('profileFieldName') ?></th>
                     <th><?=$this->getTrans('profileFieldType') ?></th>
                     <th><?=$this->getTrans('profileFieldRegistration') ?></th>
-                    <th><?=$this->getTrans('profileFieldPrivate') ?></th>
                     <th></th>
                 </tr>
             </thead>
@@ -95,7 +93,6 @@ $iconArray = ['fa-regular fa-pen-to-square', 'fa-solid fa-heading', 'fa-solid fa
                         <td><b><i class="<?=$iconArray[$profileField->getType()] ?>"></i>&nbsp;&nbsp;<?=$this->getTrans($typeArray[$profileField->getType()]) ?></b></td>
                     <?php endif; ?>
                         <td><?= ($profileField->getRegistration() === 2) ? '<i class="fa-solid fa-user-plus" title="' . $this->getTrans('profileFieldRegistrationTitle') . '"></i>' : '' ?></td>
-                        <td><?= ($profileField->getPrivate()) ? '<i class="fa-solid fa-lock" title="' . $this->getTrans('profileFieldPrivateTitle') . '"></i>' : '' ?></td>
                         <td><i class="fa-solid fa-up-down"></i></td>
                 </tr>
                 <?php endforeach; ?>

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -1,12 +1,15 @@
 <?php
 
-/** @var \Ilch\View $this */
+use Ilch\View;
+use Modules\User\Models\ProfileField;
+use Modules\User\Models\ProfileFieldTranslation;
 
+/** @var View $this */
 /** @var int $countOfProfileFields */
 $countOfProfileFields = $this->get('countOfProfileFields');
-/** @var \Modules\User\Models\ProfileField $profileField */
+/** @var ProfileField $profileField */
 $profileField = $this->get('profileField');
-/** @var \Modules\User\Models\ProfileFieldTranslation[] $profileFieldsTranslation */
+/** @var ProfileFieldTranslation[] $profileFieldsTranslation */
 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 /** @var string[] $localeList */
 $localeList = $this->get('localeList');

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -121,6 +121,22 @@ $iconArray = [
         </div>
     </div>
 
+    <!-- private -->
+    <div class="row mb-3">
+        <label for="profileFieldPrivate" class="col-lg-2 col-form-label">
+            <?=$this->getTrans('profileFieldPrivate') ?>
+        </label>
+        <div class="col-xl-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="private-yes" name="profileField[private]" value="1"<?=($profileField->getPrivate()) ? ' checked="checked"' : '' ?> />
+                <label for="private-yes" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('yes') ?></label>
+                <input type="radio" class="flipswitch-input" id="private-no" name="profileField[private]" value="0"<?=(!$profileField->getPrivate()) ? ' checked="checked"' : '' ?> />
+                <label for="private-no" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('no') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+        </div>
+    </div>
+
     <!-- icon selection -->
     <div class="row mb-3" id="profileFieldIcons" <?=($profileField->getType() == 2) ? '' : 'hidden' ?>>
         <?php

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -91,6 +91,36 @@ $iconArray = [
         </div>
     </div>
 
+    <!-- registration settings -->
+    <div class="row mb-3">
+        <label for="profileFieldShowOnRegistration" class="col-lg-2 col-form-label">
+            <?=$this->getTrans('profileFieldShowOnRegistration') ?>
+        </label>
+        <div class="col-xl-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="showOnRegistration-yes" name="profileField[showOnRegistration]" value="1" <?=($profileField->getRegistration() >= '1') ? 'checked="checked"' : '' ?> />
+                <label for="showOnRegistration-yes" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('yes') ?></label>
+                <input type="radio" class="flipswitch-input" id="showOnRegistration-no" name="profileField[showOnRegistration]" value="0" <?=($profileField->getRegistration() == '0') ? 'checked="checked"' : '' ?> />
+                <label for="showOnRegistration-no" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('no') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+        </div>
+    </div>
+    <div class="row mb-3" id="showOnRegistrationRequired"<?=($profileField->getRegistration() == '0') ? ' hidden' : '' ?>>
+        <label for="profileFieldShowOnRegistrationRequired" class="col-lg-2 col-form-label">
+            <?=$this->getTrans('profileFieldShowOnRegistrationRequired') ?>
+        </label>
+        <div class="col-xl-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="showOnRegistrationRequired-yes" name="profileField[showOnRegistrationRequired]" value="1" <?=($profileField->getRegistration() == '2') ? 'checked="checked"' : '' ?> />
+                <label for="showOnRegistrationRequired-yes" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('yes') ?></label>
+                <input type="radio" class="flipswitch-input" id="showOnRegistrationRequired-no" name="profileField[showOnRegistrationRequired]" value="0" <?=($profileField->getRegistration() != '2') ? 'checked="checked"' : '' ?> />
+                <label for="showOnRegistrationRequired-no" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('no') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+        </div>
+    </div>
+
     <!-- icon selection -->
     <div class="row mb-3" id="profileFieldIcons" <?=($profileField->getType() == 2) ? '' : 'hidden' ?>>
         <?php
@@ -391,5 +421,16 @@ $iconArray = [
         }
 
         updateRemoveButtons();
+    });
+
+    $('[name="profileField[showOnRegistration]"').click(function () {
+        let showOnRegistrationRequired = $('#showOnRegistrationRequired');
+        if ($(this).val() == "1") {
+            showOnRegistrationRequired.removeAttr('hidden');
+        } else {
+            showOnRegistrationRequired.attr('hidden', '');
+        }
+        $('#showOnRegistrationRequired-yes').removeAttr('checked');
+        $('#showOnRegistrationRequired-no').attr('checked');
     });
 </script>

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -98,9 +98,9 @@ $iconArray = [
         </label>
         <div class="col-xl-4">
             <div class="flipswitch">
-                <input type="radio" class="flipswitch-input" id="showOnRegistration-yes" name="profileField[showOnRegistration]" value="1" <?=($profileField->getRegistration() >= '1') ? 'checked="checked"' : '' ?> />
+                <input type="radio" class="flipswitch-input" id="showOnRegistration-yes" name="profileField[showOnRegistration]" value="1"<?=($profileField->getRegistration() >= '1') ? ' checked="checked"' : '' ?> />
                 <label for="showOnRegistration-yes" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('yes') ?></label>
-                <input type="radio" class="flipswitch-input" id="showOnRegistration-no" name="profileField[showOnRegistration]" value="0" <?=($profileField->getRegistration() == '0') ? 'checked="checked"' : '' ?> />
+                <input type="radio" class="flipswitch-input" id="showOnRegistration-no" name="profileField[showOnRegistration]" value="0"<?=($profileField->getRegistration() == '0') ? ' checked="checked"' : '' ?> />
                 <label for="showOnRegistration-no" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('no') ?></label>
                 <span class="flipswitch-selection"></span>
             </div>
@@ -112,9 +112,9 @@ $iconArray = [
         </label>
         <div class="col-xl-4">
             <div class="flipswitch">
-                <input type="radio" class="flipswitch-input" id="showOnRegistrationRequired-yes" name="profileField[showOnRegistrationRequired]" value="1" <?=($profileField->getRegistration() == '2') ? 'checked="checked"' : '' ?> />
+                <input type="radio" class="flipswitch-input" id="showOnRegistrationRequired-yes" name="profileField[showOnRegistrationRequired]" value="1"<?=($profileField->getRegistration() == '2') ? ' checked="checked"' : '' ?> />
                 <label for="showOnRegistrationRequired-yes" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('yes') ?></label>
-                <input type="radio" class="flipswitch-input" id="showOnRegistrationRequired-no" name="profileField[showOnRegistrationRequired]" value="0" <?=($profileField->getRegistration() != '2') ? 'checked="checked"' : '' ?> />
+                <input type="radio" class="flipswitch-input" id="showOnRegistrationRequired-no" name="profileField[showOnRegistrationRequired]" value="0"<?=($profileField->getRegistration() != '2') ? ' checked="checked"' : '' ?> />
                 <label for="showOnRegistrationRequired-no" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('no') ?></label>
                 <span class="flipswitch-selection"></span>
             </div>
@@ -126,7 +126,7 @@ $iconArray = [
         <?php
         $icon = '';
         if ($profileField->getType() == 2) {
-            $icon = ($profileField->getIcon() !== '') ? $profileField->getIcon() : $this->get('post')['symbol'];
+            $icon = ($profileField->getIcon() !== '') ? $profileField->getIcon() : $this->get('post')['symbol'] ?? '';
         }
         ?>
         <label for="profileFieldIcon" class="col-xl-2 col-form-label">
@@ -425,7 +425,7 @@ $iconArray = [
 
     $('[name="profileField[showOnRegistration]"').click(function () {
         let showOnRegistrationRequired = $('#showOnRegistrationRequired');
-        if ($(this).val() == "1") {
+        if ($(this).val() === "1") {
             showOnRegistrationRequired.removeAttr('hidden');
         } else {
             showOnRegistrationRequired.attr('hidden', '');

--- a/application/modules/user/views/admin/profilefields/treat.php
+++ b/application/modules/user/views/admin/profilefields/treat.php
@@ -124,22 +124,6 @@ $iconArray = [
         </div>
     </div>
 
-    <!-- private -->
-    <div class="row mb-3">
-        <label for="profileFieldPrivate" class="col-lg-2 col-form-label">
-            <?=$this->getTrans('profileFieldPrivate') ?>
-        </label>
-        <div class="col-xl-4">
-            <div class="flipswitch">
-                <input type="radio" class="flipswitch-input" id="private-yes" name="profileField[private]" value="1"<?=($profileField->getPrivate()) ? ' checked="checked"' : '' ?> />
-                <label for="private-yes" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('yes') ?></label>
-                <input type="radio" class="flipswitch-input" id="private-no" name="profileField[private]" value="0"<?=(!$profileField->getPrivate()) ? ' checked="checked"' : '' ?> />
-                <label for="private-no" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('no') ?></label>
-                <span class="flipswitch-selection"></span>
-            </div>
-        </div>
-    </div>
-
     <!-- icon selection -->
     <div class="row mb-3" id="profileFieldIcons" <?=($profileField->getType() == 2) ? '' : 'hidden' ?>>
         <?php

--- a/application/modules/user/views/index/index.php
+++ b/application/modules/user/views/index/index.php
@@ -4,7 +4,7 @@ $profileFieldsContentMapper = $this->get('profileFieldsContentMapper');
 $profileIconFields = $this->get('profileIconFields');
 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 $group = $this->get('group');
-$groupText = (!empty($group)) ? ' ('.$this->getTrans('group').': '.$this->escape($group->getName()).')' : '';
+$groupText = (!empty($group)) ? ' ('.$this->getTrans('group') . ': ' . $this->escape($group->getName()) . ')' : '';
 $userGroupList_allowed = $this->get('userGroupList_allowed');
 $userAvatarList_allowed = $this->get('userAvatarList_allowed');
 
@@ -12,7 +12,7 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
 
     <link href="<?=$this->getModuleUrl('static/css/user.css') ?>" rel="stylesheet">
 
-    <h1><?=$this->getTrans('menuUserList').$groupText ?></h1>
+    <h1><?=$this->getTrans('menuUserList') . $groupText ?></h1>
 <?=$this->get('pagination')->getHtml($this, ['action' => 'index']) ?>
     <div class="userlist">
         <div class="row">
@@ -21,22 +21,21 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                     <table class="table table-hover table-bordered">
                         <thead>
                         <tr>
-                            <?php if ($userAvatarList_allowed == 1): ?>
+                            <?php if ($userAvatarList_allowed == 1) : ?>
                             <th><?=$this->getTrans('userAvatars') ?></th>
                             <?php endif; ?>
                             <th><?=$this->getTrans('userlistName') ?></th>
                             <th><?=$this->getTrans('userlistRegist') ?></th>
                             <th><?=$this->getTrans('userDateLastActivity') ?></th>
                             <th><?=$this->getTrans('userlistContact') ?></th>
-                            <?php if ($userGroupList_allowed == 1): ?>
+                            <?php if ($userGroupList_allowed == 1) : ?>
                             <th><?=$this->getTrans('userGroups') ?></th>
                             <?php endif; ?>
                         </tr>
                         </thead>
                         <tbody>
-                        <?php foreach ($this->get('userList') as $userlist):
-
-                            // Gruppenliste laden um mit Komma trennen
+                        <?php foreach ($this->get('userList') as $userlist) :
+                            // Load grouplist and separate by comma.
                             $groups = '';
 
                             foreach ($userlist->getGroups() as $group) {
@@ -46,9 +45,6 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
 
                                 $groups .= $group->getName();
                             }?>
-                            <!-- Laden Ende -->
-
-
                             <?php $ilchDate = new Ilch\Date($userlist->getDateCreated()); ?>
                             <?php $ilchLastDate = (!empty($userlist->getDateLastActivity())) ? new Ilch\Date($userlist->getDateLastActivity()) : ''; ?>
                             <?php $profileFieldsContent = $profileFieldsContentMapper->getProfileFieldContentByUserId($userlist->getId()); ?>
@@ -62,16 +58,16 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                                     <a href="<?=$this->getUrl(['controller' => 'profil', 'action' => 'index', 'user' => $userlist->getId()]) ?>" title="<?=$this->escape($userlist->getName()) ?>s <?=$this->getTrans('profile') ?>" class="user-link"><?=$this->escape($userlist->getName()) ?></a>
                                 </td>
                                 <td>
-                                    <?=substr($this->getTrans($ilchDate->format('l')), 0, 2).', '.$ilchDate->format('d. ').$this->getTrans($ilchDate->format('M')).$ilchDate->format(' Y') ?>
+                                    <?=substr($this->getTrans($ilchDate->format('l')), 0, 2) . ', ' . $ilchDate->format('d. ') . $this->getTrans($ilchDate->format('M')) . $ilchDate->format(' Y') ?>
                                 </td>
                                 <td>
-                                    <?=(!empty($ilchLastDate)) ? substr($this->getTrans($ilchLastDate->format('l')), 0, 2).', '.$ilchLastDate->format('d. ').$this->getTrans($ilchLastDate->format('M')).$ilchLastDate->format(' Y') : '' ?>
+                                    <?=(!empty($ilchLastDate)) ? substr($this->getTrans($ilchLastDate->format('l')), 0, 2) . ', ' . $ilchLastDate->format('d. ') . $this->getTrans($ilchLastDate->format('M')) . $ilchLastDate->format(' Y') : '' ?>
                                 </td>
                                 <td>
-                                    <?php if ($this->getUser() && $this->getUser()->getId() != $this->escape($userlist->getID())): ?>
+                                    <?php if ($this->getUser() && $this->getUser()->getId() != $this->escape($userlist->getID())) : ?>
                                         <a href="<?=$this->getUrl(['controller' => 'panel', 'action' => 'dialognew', 'id' => $userlist->getId()]) ?>" class="fa-solid fa-comment fa-lg user-link" title="<?=$this->getTrans('privateMessage') ?>"></a>
                                     <?php endif; ?>
-                                    <?php if ($userlist->getOptMail() == 1 && $this->getUser() && $this->getUser()->getId() != $userlist->getID()): ?>
+                                    <?php if ($userlist->getOptMail() == 1 && $this->getUser() && $this->getUser()->getId() != $userlist->getID()) : ?>
                                         <a href="<?=$this->getUrl(['controller' => 'mail', 'action' => 'index', 'user' => $userlist->getId()]) ?>" class="fa-solid fa-envelope fa-lg user-link" title="<?=$this->getTrans('email') ?>"></a>
                                     <?php endif; ?>
 
@@ -90,7 +86,7 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                                                 }
                                             }
 
-                                            echo '<a href="'.$profileIconField->getAddition().$profileFieldContent->getValue().'" target="_blank" rel="noopener" class="'.$profileIconField->getIcon().' fa-lg user-link" title="'.$profileFieldName.'"></a>';
+                                            echo '<a href="' . $profileIconField->getAddition().$profileFieldContent->getValue() . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
                                             break;
                                         }
                                     }
@@ -98,7 +94,7 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                             }
                                     ?>
                                 </td>
-                                <?php if ($userGroupList_allowed):?>
+                                <?php if ($userGroupList_allowed) : ?>
                                 <td>
                                     <?=$this->escape($groups) ?>
                                 </td>

--- a/application/modules/user/views/index/index.php
+++ b/application/modules/user/views/index/index.php
@@ -78,6 +78,9 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                                     <?php foreach ($profileIconFields as $profileIconField) {
                                 if ($profileIconField->getShow()) {
                                     foreach ($profileFieldsContent as $profileFieldContent) {
+                                        if (($profileIconField->getPrivate() && $profileFieldContent->getUserId() !== $this->getUser()->getId()) || !$this->getUser()->isAdmin()) {
+                                            continue 2;
+                                        }
                                         if ($profileFieldContent->getValue() && $profileIconField->getId() == $profileFieldContent->getFieldId()) {
                                             $profileFieldName = $profileIconField->getKey();
                                             foreach ($profileFieldsTranslation as $profileFieldTrans) {

--- a/application/modules/user/views/index/index.php
+++ b/application/modules/user/views/index/index.php
@@ -1,13 +1,26 @@
 <?php
+
+use Modules\User\Mappers\ProfileFieldsContent;
+use Modules\User\Mappers\User;
+use Modules\User\Models\ProfileField;
+use Modules\User\Models\ProfileFieldContent;
+use Modules\User\Models\ProfileFieldTranslation;
+
+/** @var User $userMapper */
 $userMapper = $this->get('userMapper');
+
+/** @var ProfileFieldsContent $profileFieldsContentMapper */
 $profileFieldsContentMapper = $this->get('profileFieldsContentMapper');
+
+/** @var ProfileField[] $profileIconFields */
 $profileIconFields = $this->get('profileIconFields');
+
+/** @var ProfileFieldTranslation[] $profileFieldsTranslation */
 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 $group = $this->get('group');
 $groupText = (!empty($group)) ? ' ('.$this->getTrans('group') . ': ' . $this->escape($group->getName()) . ')' : '';
 $userGroupList_allowed = $this->get('userGroupList_allowed');
 $userAvatarList_allowed = $this->get('userAvatarList_allowed');
-
 ?>
 
     <link href="<?=$this->getModuleUrl('static/css/user.css') ?>" rel="stylesheet">
@@ -47,7 +60,10 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                             }?>
                             <?php $ilchDate = new Ilch\Date($userlist->getDateCreated()); ?>
                             <?php $ilchLastDate = (!empty($userlist->getDateLastActivity())) ? new Ilch\Date($userlist->getDateLastActivity()) : ''; ?>
-                            <?php $profileFieldsContent = $profileFieldsContentMapper->getProfileFieldContentByUserId($userlist->getId()); ?>
+                            <?php
+                            /** @var ProfileFieldContent[] $profileFieldsContent */
+                            $profileFieldsContent = $profileFieldsContentMapper->getProfileFieldContentByUserId($userlist->getId());
+                            ?>
                             <tr>
                                 <?php if ($userAvatarList_allowed): ?>
                                 <td>
@@ -86,7 +102,7 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                                                 }
                                             }
 
-                                            echo '<a href="' . $profileIconField->getAddition().$profileFieldContent->getValue() . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
+                                            echo '<a href="' . $profileIconField->getAddition() . $profileFieldContent->getValue() . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
                                             break;
                                         }
                                     }

--- a/application/modules/user/views/index/index.php
+++ b/application/modules/user/views/index/index.php
@@ -90,9 +90,6 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                                     <?php foreach ($profileIconFields as $profileIconField) {
                                 if ($profileIconField->getShow()) {
                                     foreach ($profileFieldsContent as $profileFieldContent) {
-                                        if (($profileIconField->getPrivate() && $profileFieldContent->getUserId() !== $this->getUser()->getId()) || !$this->getUser()->isAdmin()) {
-                                            continue 2;
-                                        }
                                         if ($profileFieldContent->getValue() && $profileIconField->getId() == $profileFieldContent->getFieldId()) {
                                             $profileFieldName = $profileIconField->getKey();
                                             foreach ($profileFieldsTranslation as $profileFieldTrans) {

--- a/application/modules/user/views/panel/profile.php
+++ b/application/modules/user/views/panel/profile.php
@@ -257,6 +257,27 @@ $(document).ready(function() {
         }
     });
 
+    let datetimeElements = document.getElementsByClassName('form_datetime');
+    Array.from(datetimeElements).forEach((datetimeElement) => {
+        new tempusDominus.TempusDominus(datetimeElement, {
+            display: {
+                calendarWeeks: true,
+                buttons: {
+                    today: true,
+                    close: true
+                },
+                components: {
+                    clock: false
+                }
+            },
+            localization: {
+                locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
+                startOfTheWeek: 1,
+                format: "dd.MM.yyyy"
+            }
+        });
+    });
+
     $("[rel='tooltip']").tooltip();
 });
 </script>

--- a/application/modules/user/views/profil/index.php
+++ b/application/modules/user/views/profil/index.php
@@ -81,9 +81,6 @@ foreach ($profil->getGroups() as $group) {
                 <?php foreach ($profileIconFields as $profileIconField) {
     if ($profileIconField->getShow()) {
         foreach ($profileFieldsContent as $profileFieldContent) {
-            if (($profileIconField->getPrivate() && $profileFieldContent->getUserId() !== $this->getUser()->getId()) || !$this->getUser()->isAdmin()) {
-                continue 2;
-            }
             if ($profileFieldContent->getValue() && $profileIconField->getId() == $profileFieldContent->getFieldId()) {
                 $profileFieldName = $profileIconField->getKey();
                 foreach ($profileFieldsTranslation as $profileFieldTrans) {
@@ -164,9 +161,6 @@ foreach ($profil->getGroups() as $group) {
             $profileFieldName = $profileField->getKey();
             $value = '';
             foreach ($profileFieldsContent as $profileFieldContent) {
-                if (($profileField->getPrivate() && $profileFieldContent->getUserId() !== $this->getUser()->getId()) || !$this->getUser()->isAdmin()) {
-                    continue 2;
-                }
                 if ($profileFieldContent->getValue() && $profileField->getId() == $profileFieldContent->getFieldId()) {
                     if ($profileField->getType() == 4) {
                         $value = implode(', ', json_decode($profileFieldContent->getValue(), true));

--- a/application/modules/user/views/profil/index.php
+++ b/application/modules/user/views/profil/index.php
@@ -1,14 +1,33 @@
 <?php
+
+use Ilch\Date;
+use Modules\User\Mappers\User;
+use Modules\User\Models\ProfileField;
+use Modules\User\Models\ProfileFieldContent;
+use Modules\User\Models\ProfileFieldTranslation;
+
+/** @var User $userMapper */
 $userMapper = $this->get('userMapper');
+
+/** @var \Modules\User\Models\User $profil */
 $profil = $this->get('profil');
+
 $birthday = '';
 if ($profil->getBirthday()) {
-    $birthday = new \Ilch\Date($profil->getBirthday());
+    $birthday = new Date($profil->getBirthday());
 }
-$date = new \Ilch\Date();
+$date = new Date();
+
+/** @var ProfileField[] $profileIconFields */
 $profileIconFields = $this->get('profileIconFields');
+
+/** @var ProfileField[] $profileFields */
 $profileFields = $this->get('profileFields');
+
+/** @var ProfileFieldContent[] $profileFieldsContent */
 $profileFieldsContent = $this->get('profileFieldsContent');
+
+/** @var ProfileFieldTranslation[] $profileFieldsTranslation */
 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 
 $groups = '';

--- a/application/modules/user/views/profil/index.php
+++ b/application/modules/user/views/profil/index.php
@@ -27,7 +27,7 @@ foreach ($profil->getGroups() as $group) {
     <div class="profil-header">
         <div class="row">
             <div class="col-xl-3">
-                <img class="img-thumbnail" src="<?=$this->getStaticUrl().'../'.$this->escape($profil->getAvatar()) ?>" title="<?=$this->escape($profil->getName()) ?>" alt="<?=$this->getTrans('avatar') ?>">
+                <img class="img-thumbnail" src="<?=$this->getStaticUrl() . '../' . $this->escape($profil->getAvatar()) ?>" title="<?=$this->escape($profil->getName()) ?>" alt="<?=$this->getTrans('avatar') ?>">
                 <?php if ($profil->getId() != $this->getUser()->getId()) : ?>
                 <div style="margin-top: 5px">
                     <?php if ($this->get('isFriend')) : ?>
@@ -43,19 +43,19 @@ foreach ($profil->getGroups() as $group) {
                 <div class="detail">
                     <i class="fa-solid fa-right-to-bracket" title="<?=$this->getTrans('regist') ?>"></i> <?=$this->escape($profil->getDateCreated()) ?><br />
                     <?php $dateLastActivity = $profil->getDateLastActivity(); ?>
-                    <?php if ($dateLastActivity != ''): ?>
+                    <?php if ($dateLastActivity != '') : ?>
                         <i class="fa-solid fa-eye" title="<?=$this->getTrans('dateLastVisited') ?>"></i> <?=$this->escape($profil->getDateLastActivity()) ?>
                     <?php endif; ?>
                 </div>
             </div>
             <div class="col-xl-4 d-none d-sm-block concatLinks-lg">
-                <?php if ($this->getUser() && $this->getUser()->getId() != $this->getRequest()->getParam('user')): ?>
+                <?php if ($this->getUser() && $this->getUser()->getId() != $this->getRequest()->getParam('user')) : ?>
                     <a href="<?=$this->getUrl(['controller' => 'panel', 'action' => 'dialognew', 'id' => $profil->getId()]) ?>" class="fa-solid fa-comment" title="<?=$this->getTrans('privateMessage') ?>"></a>
                 <?php endif; ?>
-                <?php if ($this->getUser() && $profil->getOptMail() == 1 && $this->getUser()->getId() != $this->getRequest()->getParam('user')): ?>
+                <?php if ($this->getUser() && $profil->getOptMail() == 1 && $this->getUser()->getId() != $this->getRequest()->getParam('user')) : ?>
                     <a href="<?=$this->getUrl(['controller' => 'mail', 'action' => 'index', 'user' => $profil->getId()]) ?>" class="fa-solid fa-envelope" title="<?=$this->getTrans('email') ?>"></a>
                 <?php endif; ?>
-                <?php if ($this->get('gallery') != 0 && $profil->getOptGallery() != 0 && $this->get('galleryAllowed') != 0): ?>
+                <?php if ($this->get('gallery') != 0 && $profil->getOptGallery() != 0 && $this->get('galleryAllowed') != 0) : ?>
                     <a href="<?=$this->getUrl(['controller' => 'gallery', 'action' => 'index', 'user' => $profil->getId()]) ?>" class="fa-regular fa-image" title="<?=$this->getTrans('gallery') ?>"></a>
                 <?php endif; ?>
 
@@ -133,7 +133,7 @@ foreach ($profil->getGroups() as $group) {
             </div>
             <div class="col-xl-9 detail">
                 <?php if ($profil->getBirthday() != '') {
-                    echo $birthday->format('d-m-Y', true).' ('.floor(($date->format('Ymd') - str_replace("-", "", $this->escape($profil->getBirthday()))) / 10000).')';
+                    echo $birthday->format('d-m-Y', true) . ' (' . floor(($date->format('Ymd') - str_replace("-", "", $this->escape($profil->getBirthday()))) / 10000) . ')';
                 } ?>
             </div>
         </div>

--- a/application/modules/user/views/profil/index.php
+++ b/application/modules/user/views/profil/index.php
@@ -62,6 +62,9 @@ foreach ($profil->getGroups() as $group) {
                 <?php foreach ($profileIconFields as $profileIconField) {
     if ($profileIconField->getShow()) {
         foreach ($profileFieldsContent as $profileFieldContent) {
+            if (($profileIconField->getPrivate() && $profileFieldContent->getUserId() !== $this->getUser()->getId()) || !$this->getUser()->isAdmin()) {
+                continue 2;
+            }
             if ($profileFieldContent->getValue() && $profileIconField->getId() == $profileFieldContent->getFieldId()) {
                 $profileFieldName = $profileIconField->getKey();
                 foreach ($profileFieldsTranslation as $profileFieldTrans) {
@@ -142,6 +145,9 @@ foreach ($profil->getGroups() as $group) {
             $profileFieldName = $profileField->getKey();
             $value = '';
             foreach ($profileFieldsContent as $profileFieldContent) {
+                if (($profileField->getPrivate() && $profileFieldContent->getUserId() !== $this->getUser()->getId()) || !$this->getUser()->isAdmin()) {
+                    continue 2;
+                }
                 if ($profileFieldContent->getValue() && $profileField->getId() == $profileFieldContent->getFieldId()) {
                     if ($profileField->getType() == 4) {
                         $value = implode(', ', json_decode($profileFieldContent->getValue(), true));

--- a/application/modules/user/views/regist/input.php
+++ b/application/modules/user/views/regist/input.php
@@ -1,5 +1,9 @@
 <?php
 $errors = $this->get('errors');
+$profil = $this->get('profil');
+$profileFields = $this->get('profileFields');
+$profileFieldsContent = $this->get('profileFieldsContent');
+$profileFieldsTranslation = $this->get('profileFieldsTranslation');
 ?>
 
 <?php include APPLICATION_PATH.'/modules/user/views/regist/navi.php'; ?>
@@ -73,6 +77,106 @@ $errors = $this->get('errors');
                            value="<?= $this->originalInput('email') ?>" />
                 </div>
             </div>
+            <?php foreach ($profileFields as $profileField) :
+                $profileFieldName = $profileField->getKey();
+                foreach ($profileFieldsTranslation as $profileFieldTranslation) {
+                    if ($profileField->getId() == $profileFieldTranslation->getFieldId()) {
+                        $profileFieldName = $profileFieldTranslation->getName();
+                        break;
+                    }
+                }
+                if ($profileField->getType() != 1) :
+                    $value = ($profileField->getType() == 4) ? [] : '';
+                    $index = 'profileField'.$profileField->getId();
+                    $value = $this->escape($this->originalInput($index));
+                    ?>
+                    <div class="row mb-3">
+                        <label class="col-xl-2 col-form-label" for="<?=$index ?>">
+                            <?=$this->escape($profileFieldName) ?><?=($profileField->getRegistration() === 2) ? ' *' : '' ?>
+                        </label>
+                        <div class="col-xl-8">
+                        <!-- radio -->
+                        <?php if ($profileField->getType() == 3) :
+                            $options = json_decode($profileField->getOptions(), true);
+                            foreach ($options as $optValue): ?>
+                                <?=($profileField->getShow() == 0) ? '<div class="input-group">' : '<div class="form-check">' ?>
+                                    <input type="radio" name="<?=$index ?>" id="<?=$optValue ?>" value="<?=$optValue ?>" class="form-check-input" <?=($optValue == $value) ? 'checked' : '' ?> <?= ($profileField->getRegistration() === 2) ? 'required' : '' ?> />
+                                    <label class="form-check-label" for="<?=$optValue ?>"><?=$this->escape($optValue) ?></label>
+                                    <?php if ($profileField->getShow() == 0) : ?>
+                                        <span class="input-group-text check" rel="tooltip" title="<?=$this->getTrans('profileFieldHidden') ?>">
+                                            <span class="fa-solid fa-eye-slash"></span>
+                                        </span>
+                                    <?php endif; ?>
+                                </div>
+                            <?php endforeach; ?>
+                        <!-- check -->
+                        <?php elseif ($profileField->getType() == 4) :
+                            $options = json_decode($profileField->getOptions(), true);
+                            foreach ($options as $optKey => $optValue) : ?>
+                                <?=($profileField->getShow() == 0) ? '<div class="input-group">' : '<div class="form-check">' ?>
+                                    <input type="checkbox" name="<?=$index ?>[<?=$optKey ?>]" id="<?=$optValue ?>" value="<?=$optValue ?>" class="form-check-input" <?=in_array($optValue, $value) ? 'checked' : '' ?> <?= ($profileField->getRegistration() === 2) ? 'required' : '' ?> />
+                                    <label class="form-check-label" for="<?=$optValue ?>"><?=$this->escape($optValue) ?></label>
+                                    <?php if ($profileField->getShow() == 0) : ?>
+                                        <span class="input-group-text check" rel="tooltip" title="<?=$this->getTrans('profileFieldHidden') ?>">
+                                            <span class="fa-solid fa-eye-slash"></span>
+                                        </span>
+                                    <?php endif; ?>
+                                </div>
+                            <?php endforeach; ?>
+                        <!-- drop -->
+                        <?php elseif ($profileField->getType() == 5) :
+                            $options = json_decode($profileField->getOptions(), true);?>
+                            <?=($profileField->getShow() == 0) ? '<div class="input-group">' : '<div class="form-check">' ?>
+                                <select class="form-select" id="<?=$index ?>" name="<?=$index ?>"<?= ($profileField->getRegistration() === 2) ? 'required' : '' ?>>
+                                    <?php foreach ($options as $optValue) : ?>
+                                        <option value="<?=$optValue ?>" <?=($optValue == $value) ? 'selected' : '' ?>><?=$this->escape($optValue) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            <?php if ($profileField->getShow() == 0) : ?>
+                                <span class="input-group-text" rel="tooltip" title="<?=$this->getTrans('profileFieldHidden') ?>">
+                                    <span class="fa-solid fa-eye-slash"></span>
+                                </span>
+                            <?php endif; ?>
+                            </div>
+                        <!-- date -->
+                        <?php elseif ($profileField->getType() == 6) : ?>
+                            <?=($profileField->getShow() == 0) ? '<div class="input-group">' : '' ?>
+                                <input type="text"
+                                       class="form-control ilch-date date form_datetime"
+                                       name="<?=$index ?>"
+                                       id="<?=$index ?>"
+                                       placeholder="<?=$value ?>"
+                                       value="<?=$value ?>"
+                                       <?= ($profileField->getRegistration() === 2) ? 'required' : '' ?> />
+                            <?php if ($profileField->getShow() == 0) : ?>
+                                <span class="input-group-text" rel="tooltip" title="<?=$this->getTrans('profileFieldHidden') ?>">
+                                    <span class="fa-solid fa-eye-slash"></span>
+                                </span>
+                            </div>
+                            <?php endif; ?>
+                        <!-- field -->
+                        <?php else : ?>
+                            <?=($profileField->getShow() == 0) ? '<div class="input-group">' : '' ?>
+                            <input type="text"
+                                   class="form-control"
+                                   name="<?=$index ?>"
+                                   id="<?=$index ?>"
+                                   placeholder="<?=$value ?>"
+                                   value="<?=$value ?>"
+                                   <?= ($profileField->getRegistration() === 2) ? 'required' : '' ?> />
+                            <?php if ($profileField->getShow() == 0) : ?>
+                                <span class="input-group-text" rel="tooltip" title="<?=$this->getTrans('profileFieldHidden') ?>">
+                                    <span class="fa-solid fa-eye-slash"></span>
+                                </span>
+                            </div>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                        </div>
+                    </div>
+                <?php else : ?>
+                    <h1><?=$this->escape($profileFieldName) ?></h1>
+                <?php endif; ?>
+            <?php endforeach; ?>
             <?php if ($this->get('captchaNeeded') && $this->get('defaultcaptcha')) : ?>
                 <?=$this->get('defaultcaptcha')->getCaptcha($this) ?>
             <?php endif; ?>

--- a/application/modules/user/views/regist/input.php
+++ b/application/modules/user/views/regist/input.php
@@ -1,8 +1,12 @@
 <?php
-$errors = $this->get('errors');
-$profil = $this->get('profil');
+
+use Modules\User\Models\ProfileField;
+use Modules\User\Models\ProfileFieldTranslation;
+
+/** @var ProfileField[] $profileFields */
 $profileFields = $this->get('profileFields');
-$profileFieldsContent = $this->get('profileFieldsContent');
+
+/** @var ProfileFieldTranslation[] $profileFieldsTranslation */
 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 ?>
 

--- a/application/modules/user/views/regist/input.php
+++ b/application/modules/user/views/regist/input.php
@@ -6,7 +6,7 @@ $profileFieldsContent = $this->get('profileFieldsContent');
 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 ?>
 
-<?php include APPLICATION_PATH.'/modules/user/views/regist/navi.php'; ?>
+<?php include APPLICATION_PATH . '/modules/user/views/regist/navi.php'; ?>
 
 <form id="registForm" name="registForm" method="POST">
     <?=$this->getTokenField() ?>
@@ -87,7 +87,7 @@ $profileFieldsTranslation = $this->get('profileFieldsTranslation');
                 }
                 if ($profileField->getType() != 1) :
                     $value = ($profileField->getType() == 4) ? [] : '';
-                    $index = 'profileField'.$profileField->getId();
+                    $index = 'profileField' . $profileField->getId();
                     $value = $this->escape($this->originalInput($index));
                     ?>
                     <div class="row mb-3">
@@ -98,7 +98,7 @@ $profileFieldsTranslation = $this->get('profileFieldsTranslation');
                         <!-- radio -->
                         <?php if ($profileField->getType() == 3) :
                             $options = json_decode($profileField->getOptions(), true);
-                            foreach ($options as $optValue): ?>
+                            foreach ($options as $optValue) : ?>
                                 <?=($profileField->getShow() == 0) ? '<div class="input-group">' : '<div class="form-check">' ?>
                                     <input type="radio" name="<?=$index ?>" id="<?=$optValue ?>" value="<?=$optValue ?>" class="form-check-input" <?=($optValue == $value) ? 'checked' : '' ?> <?= ($profileField->getRegistration() === 2) ? 'required' : '' ?> />
                                     <label class="form-check-label" for="<?=$optValue ?>"><?=$this->escape($optValue) ?></label>

--- a/application/modules/user/views/regist/input.php
+++ b/application/modules/user/views/regist/input.php
@@ -96,7 +96,7 @@ $profileFieldsTranslation = $this->get('profileFieldsTranslation');
                     ?>
                     <div class="row mb-3">
                         <label class="col-xl-2 col-form-label" for="<?=$index ?>">
-                            <?=$this->escape($profileFieldName) ?><?=($profileField->getRegistration() === 2) ? ' *' : '' ?>
+                            <?=$this->escape($profileFieldName) ?><?=($profileField->getRegistration() === 2) ? '*' : '' ?>:
                         </label>
                         <div class="col-xl-8">
                         <!-- radio -->

--- a/application/modules/user/views/regist/input.php
+++ b/application/modules/user/views/regist/input.php
@@ -10,6 +10,7 @@ $profileFields = $this->get('profileFields');
 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 ?>
 
+<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 <?php include APPLICATION_PATH . '/modules/user/views/regist/navi.php'; ?>
 
 <form id="registForm" name="registForm" method="POST">
@@ -204,6 +205,11 @@ $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 </form>
 
 <script src="<?=$this->getStaticUrl('../application/modules/user/static/js/pStrength.jquery.js') ?>"></script>
+<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
+<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
+<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
+    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
+<?php endif; ?>
 <script>
 $(document).ready(function() {
     $('#password').pStrength({
@@ -215,6 +221,32 @@ $(document).ready(function() {
         'passwordValidFrom': 60, // 60% // If you define a onValidatePassword function, this will be called only if the passwordStrength is bigger than passwordValidFrom. In that case you can use the percentage argument as you wish;
         'onValidatePassword': function(percentage) { }, // Define a function which will be called each time the password becomes valid;
         'onPasswordStrengthChanged' : function(passwordStrength, percentage) { } // Define a function which will be called each time the password strength is recalculated. You can use passwordStrength and percentage arguments for designing your own password meter
+    });
+
+    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
+        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
+        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
+    }
+
+    let datetimeElements = document.getElementsByClassName('form_datetime');
+    Array.from(datetimeElements).forEach((datetimeElement) => {
+        new tempusDominus.TempusDominus(datetimeElement, {
+            display: {
+                calendarWeeks: true,
+                buttons: {
+                    today: true,
+                    close: true
+                },
+                components: {
+                    clock: false
+                }
+            },
+            localization: {
+                locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
+                startOfTheWeek: 1,
+                format: "dd.MM.yyyy"
+            }
+        });
     });
 });
 </script>


### PR DESCRIPTION
# Description
- Add feature to optionally query for additional profile fields on registration. They can be set to required as well.
- Profilefields-Mapper, getProfileFields(): Changed where clause to use the default "and" instead of "or". Possible breaking change.
- Added missing tooltip for the profile field list.
- Fix broken date fields in user panel profile. They broke when switching to TempusDominus with Ilch 2.2.0.
- Code style improvements

Fixes #619

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
