### PR TITLE
User module: Add several FKCs

### DIFF
--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -116,8 +116,12 @@ class Config extends \Ilch\Config\Install
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_users_groups` (
-                `user_id` INT(11) NOT NULL,
-                `group_id` INT(11) NOT NULL
+                `user_id` INT(11) UNSIGNED NOT NULL,
+                `group_id` INT(11) NOT NULL,
+                INDEX `FK_[prefix]_users_groups_[prefix]_users` (`user_id`) USING BTREE,
+                INDEX `FK_[prefix]_users_groups_[prefix]_groups` (`group_id`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_users_groups_[prefix]_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                CONSTRAINT `FK_[prefix]_users_groups_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_groups_access` (
@@ -164,10 +168,14 @@ class Config extends \Ilch\Config\Install
 
             CREATE TABLE IF NOT EXISTS `[prefix]_user_friends` (
                 `id` INT(11) NOT NULL AUTO_INCREMENT,
-                `user_id` INT(11) NOT NULL,
-                `friend_user_id` INT(11) NOT NULL,
+                `user_id` INT(11) UNSIGNED NOT NULL,
+                `friend_user_id` INT(11) UNSIGNED NOT NULL,
                 `approved` TINYINT(1) NOT NULL DEFAULT 2,
-                PRIMARY KEY (`id`)
+                PRIMARY KEY (`id`) USING BTREE,
+                INDEX `FK_[prefix]_user_friends_[prefix]_users` (`user_id`) USING BTREE,
+                INDEX `FK_[prefix]_user_friends_[prefix]_users_2` (`friend_user_id`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_user_friends_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                CONSTRAINT `FK_[prefix]_user_friends_[prefix]_users_2` FOREIGN KEY (`friend_user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_user_menu` (
@@ -190,13 +198,19 @@ class Config extends \Ilch\Config\Install
                 `user_one` INT(11) UNSIGNED NOT NULL,
                 `user_two` INT(11) UNSIGNED NOT NULL,
                 `time` DATETIME NOT NULL,
-                PRIMARY KEY (`c_id`)
+                PRIMARY KEY (`c_id`) USING BTREE,
+                INDEX `FK_[prefix]_users_dialog_[prefix]_users` (`user_one`) USING BTREE,
+                INDEX `FK_[prefix]_users_dialog_[prefix]_users_2` (`user_two`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_users_dialog_[prefix]_users` FOREIGN KEY (`user_one`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                CONSTRAINT `FK_[prefix]_users_dialog_[prefix]_users_2` FOREIGN KEY (`user_two`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_users_dialog_hidden` (
                 `c_id` INT(11) UNSIGNED NOT NULL,
                 `user_id` INT(11) UNSIGNED NOT NULL,
-                `permanent` TINYINT(1) UNSIGNED NOT NULL
+                `permanent` TINYINT(1) UNSIGNED NOT NULL,
+                INDEX `FK_[prefix]_users_dialog_hidden_[prefix]_users` (`user_id`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_users_dialog_hidden_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_users_dialog_reply` (
@@ -206,40 +220,48 @@ class Config extends \Ilch\Config\Install
                 `c_id_fk` INT(11) NOT NULL,
                 `time` DATETIME NOT NULL,
                 `read` TINYINT(1) DEFAULT 0,
-                PRIMARY KEY (`cr_id`)
+                PRIMARY KEY (`cr_id`) USING BTREE,
+                INDEX `FK_[prefix]_users_dialog_reply_[prefix]_users` (`user_id_fk`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_users_dialog_reply_[prefix]_users` FOREIGN KEY (`user_id_fk`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_users_media` (
                 `id` INT(11) NOT NULL AUTO_INCREMENT,
-                `user_id` INT(11) NOT NULL,
+                `user_id` INT(11) UNSIGNED NOT NULL,
                 `name` VARCHAR(50) NOT NULL DEFAULT 0,
                 `url` VARCHAR(150) NOT NULL DEFAULT 0,
                 `url_thumb` VARCHAR(150) NOT NULL DEFAULT 0,
                 `ending` VARCHAR(5) NOT NULL DEFAULT 0,
                 `datetime` DATETIME NOT NULL,
-                PRIMARY KEY (`id`)
+                PRIMARY KEY (`id`) USING BTREE,
+                INDEX `FK_[prefix]_users_media_[prefix]_users` (`user_id`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_users_media_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_users_gallery_imgs` (
                 `id` INT(11) NOT NULL AUTO_INCREMENT,
-                `user_id` INT(11) NOT NULL,
+                `user_id` INT(11) UNSIGNED NOT NULL,
                 `image_id` VARCHAR(150)NOT NULL,
                 `image_title` VARCHAR(255) NOT NULL DEFAULT \'\',
                 `image_description` VARCHAR(255) NOT NULL DEFAULT \'\',
                 `cat` MEDIUMINT(9) NOT NULL DEFAULT 0,
                 `visits` INT(11) NOT NULL DEFAULT 0,
-                PRIMARY KEY (`id`)
+                PRIMARY KEY (`id`) USING BTREE,
+                INDEX `FK_[prefix]_users_gallery_imgs_[prefix]_users` (`user_id`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_users_gallery_imgs_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_users_gallery_items` (
                 `id` INT(11) NOT NULL AUTO_INCREMENT,
-                `user_id` INT(11) NOT NULL,
+                `user_id` INT(11) UNSIGNED NOT NULL,
                 `sort` INT(11) NOT NULL DEFAULT 0,
                 `parent_id` INT(11) NOT NULL DEFAULT 0,
                 `type` TINYINT(1) NOT NULL,
                 `title` VARCHAR(255) NOT NULL,
                 `description` VARCHAR(255) NOT NULL,
-                PRIMARY KEY (`id`)
+                PRIMARY KEY (`id`) USING BTREE,
+                INDEX `FK_[prefix]_users_gallery_items_[prefix]_users` (`user_id`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_users_gallery_items_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_auth_tokens` (
@@ -247,8 +269,10 @@ class Config extends \Ilch\Config\Install
                 `selector` CHAR(12),
                 `token` CHAR(64),
                 `userid` INT(11) UNSIGNED NOT NULL,
-                `expires` DATETIME,
-                PRIMARY KEY (`id`)
+                `expires` DATETIME NULL DEFAULT NULL,
+                PRIMARY KEY (`id`) USING BTREE,
+                INDEX `FK_[prefix]_auth_tokens_[prefix]_users` (`userid`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_auth_tokens_[prefix]_users` FOREIGN KEY (`userid`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
             CREATE TABLE IF NOT EXISTS `[prefix]_cookie_stolen` (
@@ -714,11 +738,6 @@ class Config extends \Ilch\Config\Install
                 }
 
                 // Delete rows in profile_trans with a field_id for a field that no longer exists.
-                $idsProfileFields = $this->db()->select('id')
-                    ->from('profile_fields')
-                    ->execute()
-                    ->fetchList();
-
                 $idsProfileTrans = $this->db()->select('field_id')
                     ->from('profile_trans')
                     ->execute()
@@ -734,11 +753,181 @@ class Config extends \Ilch\Config\Install
                 // Change column types and add FKCs.
                 $this->db()->queryMulti('ALTER TABLE `[prefix]_profile_content` MODIFY COLUMN `field_id` INT(11) UNSIGNED NOT NULL;
                         ALTER TABLE `[prefix]_profile_content` MODIFY COLUMN `user_id` INT(11) UNSIGNED NOT NULL;
-                        ALTER TABLE `[prefix]_profile_trans` MODIFY COLUMN `field_id` INT(11) UNSIGNED NOT NULL;');
-
-                $this->db()->queryMulti('ALTER TABLE `[prefix]_profile_content` ADD CONSTRAINT `FK_[prefix]_profile_content_[prefix]_profile_fields` FOREIGN KEY (`field_id`) REFERENCES `[prefix]_profile_fields` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
+                        ALTER TABLE `[prefix]_profile_trans` MODIFY COLUMN `field_id` INT(11) UNSIGNED NOT NULL;
+                        ALTER TABLE `[prefix]_profile_content` ADD CONSTRAINT `FK_[prefix]_profile_content_[prefix]_profile_fields` FOREIGN KEY (`field_id`) REFERENCES `[prefix]_profile_fields` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
                         ALTER TABLE `[prefix]_profile_content` ADD CONSTRAINT `FK_[prefix]_profile_content_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
                         ALTER TABLE `[prefix]_profile_trans` ADD CONSTRAINT `FK_[prefix]_profile_trans_[prefix]_profile_fields` FOREIGN KEY (`field_id`) REFERENCES `[prefix]_profile_fields` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
+
+                // Add FKCs for users_groups, users_gallery_imgs, users_gallery_items, users_media, auth_tokens, visits_online, users_friends, users_dialog, users_dialog_reply and users_dialog_hidden.
+                // Delete orphaned rows in users_groups.
+                $idsGroups = $this->db()->select('id')
+                    ->from('groups')
+                    ->execute()
+                    ->fetchList();
+
+                $userIdsUserGroups = $this->db()->select('user_id')
+                    ->from('users_groups')
+                    ->execute()
+                    ->fetchList();
+
+                $groupIdsUserGroups = $this->db()->select('group_id')
+                    ->from('users_groups')
+                    ->execute()
+                    ->fetchList();
+
+                $orphanedRows = array_diff($userIdsUserGroups ?? [], $idsGroups ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('users_groups')
+                        ->where(['user_id' => $orphanedRows])
+                        ->execute();
+                }
+
+                $orphanedRows = array_diff($groupIdsUserGroups ?? [], $idsGroups ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('users_groups')
+                        ->where(['group_id' => $orphanedRows])
+                        ->execute();
+                }
+
+                // Delete orphaned rows in auth_tokens.
+                $userIdsAuthTokens = $this->db()->select('userid')
+                    ->from('auth_tokens')
+                    ->execute()
+                    ->fetchList();
+
+                $orphanedRows = array_diff($userIdsAuthTokens ?? [], $idsUsers ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('auth_tokens')
+                        ->where(['userid' => $orphanedRows])
+                        ->execute();
+                }
+
+                // Delete orphaned rows in user_friends.
+                $userIdsUserFriends = $this->db()->select('user_id')
+                    ->from('user_friends')
+                    ->execute()
+                    ->fetchList();
+
+                $userIdsFriendsUserFriends = $this->db()->select('friend_user_id')
+                    ->from('user_friends')
+                    ->execute()
+                    ->fetchList();
+
+                $orphanedRows = array_diff($userIdsUserFriends ?? [], $userIdsFriendsUserFriends ?? [], $idsUsers ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('user_friends')
+                        ->where(['user_id' => $orphanedRows, 'friend_user_id' => $orphanedRows], 'or')
+                        ->execute();
+                }
+
+                // Delete orphaned rows in users_dialog, users_dialog_reply and users_dialog_hidden.
+                $userOneUsersDialog = $this->db()->select('user_one')
+                    ->from('users_dialog')
+                    ->execute()
+                    ->fetchList();
+
+                $userTwoUsersDialog = $this->db()->select('user_two')
+                    ->from('users_dialog')
+                    ->execute()
+                    ->fetchList();
+
+                $userIdUsersDialogReply = $this->db()->select('user_id_fk')
+                    ->from('users_dialog_reply')
+                    ->execute()
+                    ->fetchList();
+
+                $userIdUsersDialogHidden = $this->db()->select('user_id')
+                    ->from('users_dialog_hidden')
+                    ->execute()
+                    ->fetchList();
+
+                $orphanedRows = array_diff($userOneUsersDialog ?? [], $userTwoUsersDialog ?? [], $idsUsers ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('users_dialog')
+                        ->where(['user_one' => $orphanedRows, 'user_two' => $orphanedRows], 'or')
+                        ->execute();
+                }
+
+                $orphanedRows = array_diff($userIdUsersDialogReply ?? [], $idsUsers ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('users_dialog_reply')
+                        ->where(['user_id_fk' => $orphanedRows])
+                        ->execute();
+                }
+
+                $orphanedRows = array_diff($userIdUsersDialogHidden ?? [], $idsUsers ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('users_dialog_hidden')
+                        ->where(['user_id' => $orphanedRows])
+                        ->execute();
+                }
+
+                // Delete orphaned rows in users_gallery_imgs, users_gallery_items and users_media.
+                $userIdUsersGalleryImgs = $this->db()->select('user_id')
+                    ->from('users_gallery_imgs')
+                    ->execute()
+                    ->fetchList();
+
+                $userIdUsersGalleryItems = $this->db()->select('user_id')
+                    ->from('users_gallery_items')
+                    ->execute()
+                    ->fetchList();
+
+                $userIdUsersMedia = $this->db()->select('user_id')
+                    ->from('users_media')
+                    ->execute()
+                    ->fetchList();
+
+                $orphanedRows = array_diff($userIdUsersGalleryImgs ?? [], $idsUsers ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('users_gallery_imgs')
+                        ->where(['user_id' => $orphanedRows])
+                        ->execute();
+                }
+
+                $orphanedRows = array_diff($userIdUsersGalleryItems ?? [], $idsUsers ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('users_gallery_items')
+                        ->where(['user_id' => $orphanedRows])
+                        ->execute();
+                }
+
+                $orphanedRows = array_diff($userIdUsersMedia ?? [], $idsUsers ?? []);
+                if (count($orphanedRows) > 0) {
+                    $this->db()->delete()->from('users_media')
+                        ->where(['user_id' => $orphanedRows])
+                        ->execute();
+                }
+
+                // Change column types and add FKCs.
+                // user_groups
+                $this->db()->queryMulti('ALTER TABLE `[prefix]_users_groups` MODIFY COLUMN `user_id` INT(11) UNSIGNED NOT NULL;
+                        ALTER TABLE `[prefix]_users_groups` ADD CONSTRAINT `FK_[prefix]_users_groups_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
+                        ALTER TABLE `[prefix]_users_groups` ADD CONSTRAINT `FK_[prefix]_users_groups_[prefix]_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
+
+                // auth_tokens
+                $this->db()->queryMulti('ALTER TABLE `[prefix]_auth_tokens` ADD CONSTRAINT `FK_[prefix]_auth_tokens_[prefix]_users` FOREIGN KEY (`userid`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
+
+                // user_friends
+                $this->db()->queryMulti('ALTER TABLE `[prefix]_user_friends` MODIFY COLUMN `user_id` INT(11) UNSIGNED NOT NULL;
+                        ALTER TABLE `[prefix]_user_friends` MODIFY COLUMN `friend_user_id` INT(11) UNSIGNED NOT NULL;
+                        ALTER TABLE `[prefix]_user_friends` ADD CONSTRAINT `FK_[prefix]_user_friends_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
+                        ALTER TABLE `[prefix]_user_friends` ADD CONSTRAINT `FK_[prefix]_user_friends_[prefix]_users_2` FOREIGN KEY (`friend_user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
+
+                // users_dialog, users_dialog_reply and users_dialog_hidden
+                $this->db()->queryMulti('ALTER TABLE `[prefix]_users_dialog` ADD CONSTRAINT `FK_[prefix]_users_dialog_[prefix]_users` FOREIGN KEY (`user_one`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
+                        ALTER TABLE `[prefix]_users_dialog` ADD CONSTRAINT `FK_[prefix]_users_dialog_[prefix]_users` FOREIGN KEY (`user_two`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
+                        ALTER TABLE `[prefix]_users_dialog_reply` ADD CONSTRAINT `FK_[prefix]_users_dialog_reply_[prefix]_users` FOREIGN KEY (`user_id_fk`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
+                        ALTER TABLE `[prefix]_users_dialog_hidden` ADD CONSTRAINT `FK_[prefix]_users_dialog_hidden_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
+
+                // users_gallery_imgs, users_gallery_items and users_media
+                $this->db()->queryMulti('ALTER TABLE `[prefix]_users_gallery_imgs` MODIFY COLUMN `user_id` INT(11) UNSIGNED NOT NULL;
+                        ALTER TABLE `[prefix]_users_gallery_items` MODIFY COLUMN `user_id` INT(11) UNSIGNED NOT NULL;
+                        ALTER TABLE `[prefix]_users_media` MODIFY COLUMN `user_id` INT(11) UNSIGNED NOT NULL;
+                        ALTER TABLE `[prefix]_users_gallery_imgs` ADD CONSTRAINT `FK_[prefix]_users_gallery_imgs_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
+                        ALTER TABLE `[prefix]_users_gallery_items` ADD CONSTRAINT `FK_[prefix]_users_gallery_items_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;
+                        ALTER TABLE `[prefix]_users_media` ADD CONSTRAINT `FK_[prefix]_users_media_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
+                break;
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';

--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -345,10 +345,6 @@ class Panel extends BaseController
         $userMapper = new UserMapper();
         $authTokenMapper = new AuthTokenMapper();
         $statisticMapper = new StatisticMapper();
-        $profileFieldsContentMapper = new ProfileFieldsContentMapper();
-        $authProviderMapper = new AuthProvider();
-        $friendsMapper = new FriendsMapper();
-        $dialogMapper = new DialogMapper();
 
         $this->getLayout()->getHmenu()
             ->add($this->getTranslator()->trans('menuPanel'), ['controller' => 'panel', 'action' => 'index'])
@@ -376,14 +372,9 @@ class Panel extends BaseController
                     rmdir($path);
                 }
 
-                $profileFieldsContentMapper->deleteProfileFieldContentByUserId($userId);
-                $authProviderMapper->deleteUser($userId);
                 if ($userMapper->delete($userId)) {
-                    $authTokenMapper->deleteAllAuthTokenOfUser($userId);
+                    // AuthTokens, auth providers, profile field content, friends and dialogs connected to the user get deleted due to FKCs.
                     $statisticMapper->deleteUserOnline($userId);
-                    $friendsMapper->deleteFriendsByUserId($userId);
-                    $friendsMapper->deleteFriendByFriendUserId($userId);
-                    $dialogMapper->deleteAllOfUser($userId);
                 }
 
                 if (!empty($_COOKIE['remember'])) {

--- a/application/modules/user/mappers/Group.php
+++ b/application/modules/user/mappers/Group.php
@@ -194,14 +194,7 @@ class Group extends \Ilch\Mapper
             $groupId = $groupId->getId();
         }
 
-        $this->db()->delete('users_groups')
-            ->where(['group_id' => $groupId])
-            ->execute();
-
-        $this->db()->delete('groups_access')
-            ->where(['group_id' => $groupId])
-            ->execute();
-
+        // Rows in users_groups and groups_access get deleted due to FKCs.
         return $this->db()->delete('groups')
             ->where(['id' => $groupId])
             ->execute();

--- a/application/modules/user/mappers/User.php
+++ b/application/modules/user/mappers/User.php
@@ -8,9 +8,6 @@
 namespace Modules\User\Mappers;
 
 use Modules\Statistic\Mappers\Statistic as StatisticMapper;
-use Modules\User\Mappers\AuthToken as AuthTokenMapper;
-use Modules\User\Mappers\Dialog as DialogMapper;
-use Modules\User\Mappers\Friends as FriendsMapper;
 use Modules\User\Models\User as UserModel;
 use Modules\User\Mappers\Group as GroupMapper;
 use Ilch\Date as IlchDate;
@@ -539,10 +536,7 @@ class User extends \Ilch\Mapper
     public function deleteselectsdelete($timetodelete = 5): bool
     {
         $date = new IlchDate();
-        $authTokenMapper = new AuthTokenMapper();
         $statisticMapper = new StatisticMapper();
-        $friendsMapper = new FriendsMapper();
-        $dialogMapper = new DialogMapper();
 
         $date->modify('-' . $timetodelete . ' days');
         $entries = $this->getUserList(['selectsdelete >' => '1000-01-01 00:00:00', 'selectsdelete <=' => $date]);
@@ -552,11 +546,7 @@ class User extends \Ilch\Mapper
                 $dateuser = new IlchDate($user->getSelectsDelete());
                 if ($dateuser->getTimestamp() <= $date->getTimestamp()) {
                     $this->delete($user->getId());
-                    $authTokenMapper->deleteAllAuthTokenOfUser($user->getId());
                     $statisticMapper->deleteUserOnline($user->getId());
-                    $friendsMapper->deleteFriendsByUserId($user->getId());
-                    $friendsMapper->deleteFriendByFriendUserId($user->getId());
-                    $dialogMapper->deleteAllOfUser($user->getId());
                 }
             }
         }
@@ -576,26 +566,7 @@ class User extends \Ilch\Mapper
             $userId = $userId->getId();
         }
 
-        $this->db()->delete('users_groups')
-            ->where(['user_id' => $userId])
-            ->execute();
-
-        $this->db()->delete('profile_content')
-            ->where(['user_id' => $userId])
-            ->execute();
-
-        $this->db()->delete('users_gallery_imgs')
-            ->where(['user_id' => $userId])
-            ->execute();
-
-        $this->db()->delete('users_gallery_items')
-            ->where(['user_id' => $userId])
-            ->execute();
-
-        $this->db()->delete('users_media')
-            ->where(['user_id' => $userId])
-            ->execute();
-
+        // Groups, profile content, user gallery content and media connected to the user gets deleted due to FKCs.
         return $this->db()->delete('users')
             ->where(['id' => $userId])
             ->execute();

--- a/tests/modules/user/_files/mysql_database.yml
+++ b/tests/modules/user/_files/mysql_database.yml
@@ -1,22 +1,3 @@
-auth_tokens:
-  -
-    id: 1
-    selector: "selector"
-    token: "token"
-    userid: 1
-    expires: "2014-01-01 12:12:12"
-  -
-    id: 2
-    selector: "selector2"
-    token: "token"
-    userid: 2
-    expires: "2014-01-01 12:12:12"
-
-cookie_stolen:
-  -
-    id: 1
-    userid: 1
-
 users:
   -
     id: 1
@@ -36,6 +17,37 @@ users:
     date_confirmed: "2014-01-01 12:12:12"
     confirmed: 1
     confirmed_code: "123"
+  -
+    id: 3
+    name: "admin"
+    password: "top"
+    email: "admin@admin.admin"
+    date_created: "2020-02-01 15:00:00"
+  -
+    id: 4
+    name: "user"
+    password: "secret"
+    email: "user@user.user"
+    date_created: "2020-02-01 15:00:00"
+
+auth_tokens:
+  -
+    id: 1
+    selector: "selector"
+    token: "token"
+    userid: 1
+    expires: "2014-01-01 12:12:12"
+  -
+    id: 2
+    selector: "selector2"
+    token: "token"
+    userid: 2
+    expires: "2014-01-01 12:12:12"
+
+cookie_stolen:
+  -
+    id: 1
+    userid: 1
 
 groups:
   -


### PR DESCRIPTION
# Description
- Create updated tables on install, update tables on update and delete orphaned rows.
- Updated unit tests to add users before trying to add auth_tokens to fix failing unit tests.
- Removed code no longer needed after adding FKCs.

## Updated tables
- auth_tokens (userid)
- groups_access (group_id)
- user_friends (user_id, friend_user_id)
- users_auth_providers (user_id)
- users_dialog (user_one, user_two)
- users_dialog_hidden (user_id)
- users_dialog_reply (user_id_fk)
- users_gallery_imgs (user_id)
- users_gallery_items (user_id)
- users_groups (user_id, group_id)
- users_media (user_id)

A FKC for visits_online (user_id) was not possible due to the default value of 0 for guests.

Fixes #1066 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
