### PR TITLE
Add comments on profile

### DIFF
--- a/application/modules/user/config/config.php
+++ b/application/modules/user/config/config.php
@@ -14,6 +14,8 @@ use Modules\User\Service\Password as PasswordService;
 
 class Config extends \Ilch\Config\Install
 {
+    const COMMENT_KEY_TPL = 'user/profil/index/user/%d';
+
     public $config = [
         'key' => 'user',
         'icon_small' => 'fa-solid fa-user',
@@ -102,6 +104,7 @@ class Config extends \Ilch\Config\Install
                 `signature` VARCHAR(255) NOT NULL DEFAULT "",
                 `locale` VARCHAR(255) NOT NULL DEFAULT "",
                 `opt_mail` TINYINT(1) DEFAULT 1,
+                `opt_comments` TINYINT(1) DEFAULT 1,
                 `opt_gallery` TINYINT(1) DEFAULT 1,
                 `date_created` DATETIME NOT NULL,
                 `date_confirmed` DATETIME NULL DEFAULT NULL,
@@ -960,6 +963,9 @@ class Config extends \Ilch\Config\Install
                 // users_auth_providers
                 $this->db()->queryMulti('ALTER TABLE `[prefix]_users_auth_providers` MODIFY COLUMN `user_id` INT(11) UNSIGNED NOT NULL;
                         ALTER TABLE `[prefix]_users_auth_providers` ADD CONSTRAINT `FK_[prefix]_users_auth_providers_[prefix]_users` FOREIGN KEY (`user_id`) REFERENCES `[prefix]_users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
+
+                // Add new opt_comments column to users table.
+                $this->db()->query('ALTER TABLE `[prefix]_users` ADD COLUMN `opt_comments` TINYINT(1) DEFAULT 1 AFTER `opt_mail`;');
                 break;
         }
 

--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -315,14 +315,16 @@ class Panel extends BaseController
 
         if ($this->getRequest()->isPost()) {
             $validation = Validation::create($this->getRequest()->getPost(), [
-                'optMail' => 'required|numeric|integer|min:0|max:1'
+                'optMail' => 'required|numeric|integer|min:0|max:1',
+                'optComments' => 'required|numeric|integer|min:0|max:1'
             ]);
 
             if ($validation->isValid()) {
                 $model = new UserModel();
                 $model->setId($this->getUser()->getId())
                     ->setLocale($this->getRequest()->getPost('locale'))
-                    ->setOptMail($this->getRequest()->getPost('optMail'));
+                    ->setOptMail($this->getRequest()->getPost('optMail'))
+                    ->setOptComments($this->getRequest()->getPost('optComments'));
                 $profilMapper->save($model);
 
                 $this->redirect()

--- a/application/modules/user/mappers/User.php
+++ b/application/modules/user/mappers/User.php
@@ -259,6 +259,10 @@ class User extends \Ilch\Mapper
             $user->setOptMail($userRow['opt_mail']);
         }
 
+        if (isset($userRow['opt_comments'])) {
+            $user->setOptComments($userRow['opt_comments']);
+        }
+
         if (isset($userRow['opt_gallery'])) {
             $user->setOptGallery($userRow['opt_gallery']);
         }
@@ -380,6 +384,7 @@ class User extends \Ilch\Mapper
         $fields['signature'] = $user->getSignature();
         $fields['locale'] = $user->getLocale();
         $fields['opt_mail'] = $user->getOptMail();
+        $fields['opt_comments'] = $user->getOptComments();
         $fields['opt_gallery'] = $user->getOptGallery();
 
         $userId = (int)$this->db()->select('id')

--- a/application/modules/user/models/User.php
+++ b/application/modules/user/models/User.php
@@ -104,6 +104,13 @@ class User extends \Ilch\Model
     protected $opt_mail;
 
     /**
+     * The opt_comments of the user.
+     *
+     * @var int
+     */
+    protected $opt_comments;
+
+    /**
      * The opt_gallery of the user.
      *
      * @var int
@@ -314,6 +321,28 @@ class User extends \Ilch\Model
     {
         $this->opt_mail = (string)$opt_mail;
 
+        return $this;
+    }
+
+    /**
+     * Returns the opt_comments of the user.
+     *
+     * @return int
+     */
+    public function getOptComments(): int
+    {
+        return $this->opt_comments;
+    }
+
+    /**
+     * Sets the opt_comments of the user.
+     *
+     * @param int $opt_comments
+     * @return $this
+     */
+    public function setOptComments(int $opt_comments): User
+    {
+        $this->opt_comments = $opt_comments;
         return $this;
     }
 

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -266,6 +266,7 @@ return [
     'emailSuccess' => 'E-Mail wurde erfolgreich versendet',
     'locale' => 'Sprache',
     'optMail' => 'E-Mail von anderen Usern?',
+    'optComments' => 'Kommentare auf Profil?',
     'writes' => 'schreibt',
 
     'cat' => 'Kategorie',

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -266,6 +266,7 @@ return [
     'emailSuccess' => 'E-Mail was successfully send',
     'locale' => 'Locale',
     'optMail' => 'E-Mail from other users?',
+    'optComments' => 'Comments on profile?',
     'writes' => 'writes',
 
     'cat' => 'Categorie',

--- a/application/modules/user/views/panel/setting.php
+++ b/application/modules/user/views/panel/setting.php
@@ -31,17 +31,27 @@
                     </div>
                     <div class="col-xl-4">
                         <div class="flipswitch">
-                            <input type="radio" class="flipswitch-input" id="opt_mail_yes" name="optMail" value="1" <?php if ($this->getUser()->getOptMail() == '1') {
-    echo 'checked="checked"';
-} ?> />
+                            <input type="radio" class="flipswitch-input" id="opt_mail_yes" name="optMail" value="1" <?=($this->getUser()->getOptMail() == '1') ? 'checked="checked"' : '' ?> />
                             <label for="opt_mail_yes" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('yes') ?></label>
-                            <input type="radio" class="flipswitch-input" id="opt_mail_no" name="optMail" value="0" <?php if ($this->getUser()->getOptMail() == '0') {
-    echo 'checked="checked"';
-} ?> />
+                            <input type="radio" class="flipswitch-input" id="opt_mail_no" name="optMail" value="0" <?=($this->getUser()->getOptMail() == '0') ? 'checked="checked"' : '' ?> />
                             <label for="opt_mail_no" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('no') ?></label>
                             <span class="flipswitch-selection"></span>
                         </div>
                      </div>
+                </div>
+                <div class="row mb-3<?=$this->validation()->hasError('optComments') ? ' has-error' : '' ?>">
+                    <div class="col-xl-3 col-form-label">
+                        <?=$this->getTrans('optComments') ?>
+                    </div>
+                    <div class="col-xl-4">
+                        <div class="flipswitch">
+                            <input type="radio" class="flipswitch-input" id="opt_comments_yes" name="optComments" value="1" <?=($this->getUser()->getOptComments() == '1') ? 'checked="checked"' : '' ?> />
+                            <label for="opt_comments_yes" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('yes') ?></label>
+                            <input type="radio" class="flipswitch-input" id="opt_comments_no" name="optComments" value="0" <?=($this->getUser()->getOptComments() == '0') ? 'checked="checked"' : '' ?> />
+                            <label for="opt_comments_no" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('no') ?></label>
+                            <span class="flipswitch-selection"></span>
+                        </div>
+                    </div>
                 </div>
                 <div class="row mb-3">
                     <div class="offset-xl-3 col-xl-12">

--- a/application/modules/user/views/profil/index.php
+++ b/application/modules/user/views/profil/index.php
@@ -217,3 +217,10 @@ foreach ($profil->getGroups() as $group) {
         </div>
     </div>
 </div>
+
+<?php if ($profil->getOptComments() /* comments not disabled by user or globally */): ?>
+    <?php
+    $commentsClass = new Ilch\Comments();
+    echo $commentsClass->getComments(sprintf(Modules\User\Config\Config::COMMENT_KEY_TPL, $profil->getId()), $profil, $this);
+    ?>
+<?php endif; ?>


### PR DESCRIPTION
# Description
- Added comments on profile.
- Added setting to the user panel settings to enable/disable comments on profile.

## ToDo
- User module: Setting in the admincenter to enable/disable comments on profiles globally.
- User module: Setting in the admincenter to enable/disable comments on the profile when creating or editing a user.
- Comment module: Setting to enable/disable the CKEditor for comments.
- Allow moderation of comments on own profile.
- Create issue for better handling and filtering of comments in the comment module.
- ...

Fixes #455

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
