### PR TITLE
Events module: Use CKEditor and alwaysPurify()

### DIFF
--- a/application/modules/events/config/config.php
+++ b/application/modules/events/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'events',
-        'version' => '1.23.2',
+        'version' => '1.23.3',
         'icon_small' => 'fa-solid fa-ticket',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/events/views/show/event.php
+++ b/application/modules/events/views/show/event.php
@@ -242,10 +242,10 @@ if (!empty($event)) {
                         <input type="hidden" name="id" value="<?= $this->escape($event->getId()) ?>">
                         <div style="margin-bottom: 10px; margin-top: 10px;">
                             <div class="col-xl-12">
-                                <textarea class="eventTextarea"
+                                <textarea class="eventTextarea form-control ckeditor"
                                           name="commentEvent"
                                           placeholder="<?=$this->getTrans('writeToEvent') ?>"
-                                          required></textarea>
+                                          toolbar="ilch_html_frontend"></textarea>
                             </div>
                         </div>
                         <div class="col-xl-12 eventSubmit">
@@ -257,7 +257,7 @@ if (!empty($event)) {
                 </div>
             <?php endif; ?>
 
-            <?php if ($this->get('eventComments') != '') : ?>
+            <?php if ($this->get('eventComments')) : ?>
                 <div class="eventBoxHead">
                     <strong><?=$this->getTrans('comments') ?></strong>
                 </div>
@@ -278,7 +278,7 @@ if (!empty($event)) {
                             <a href="<?=$this->getUrl('user/profil/index/user/' . $commentUser->getId()) ?>" target="_blank"><?=$this->escape($commentUser->getName()) ?></a><br />
                             <span class="small"><?=$commentDate->format('Y.m.d H:i', true) ?></span>
                         </div>
-                        <div class="commentEventText"><?=nl2br($this->escape($eventComment->getText())) ?></div>
+                        <div class="commentEventText"><?=nl2br($this->alwaysPurify($eventComment->getText())) ?></div>
                     </div>
                     <br />
                 <?php endforeach; ?>


### PR DESCRIPTION
# Description
- Use CKEditor and alwaysPurify() for comments.
- Fix empty comments box being shown.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
