### PR TITLE
CookieConsent: Add tarteaucitron services

### DIFF
--- a/application/libraries/Ilch/Layout/Frontend.php
+++ b/application/libraries/Ilch/Layout/Frontend.php
@@ -625,9 +625,18 @@ class Frontend extends Base
                         iconPosition: "' . $this->escape($this->getConfigKey('cookie_icon_pos')) . '",
                         ' . ($this->getConfigKey('cookieConsentType') == 'opt-in' ? 'highPrivacy: true,' : ($this->getConfigKey('cookieConsentType') == 'opt-out' ? 'highPrivacy: false,' : '')) . '
                         ' . ($this->getConfigKey('cookieConsentType') == 'opt-in' ? 'AcceptAllCta: true,' : ($this->getConfigKey('cookieConsentType') == 'opt-out' ? 'AcceptAllCta: false,' : '')) . '
-                    });
+                    })
                 </script>
                 ';
+
+            if ($this->getConfigKey('cookie_consent_services')) {
+                $services = explode(',', $this->getConfigKey('cookie_consent_services'));
+                $html .= '<script>';
+                foreach ($services as $service) {
+                    $html .= '(tarteaucitron.job = tarteaucitron.job || []).push("' . $this->escape($service) . '");';
+                }
+                $html .= '</script>';
+            }
         }
 
         return $html;

--- a/application/modules/cookieconsent/controllers/admin/Index.php
+++ b/application/modules/cookieconsent/controllers/admin/Index.php
@@ -57,7 +57,8 @@ class Index extends \Ilch\Controller\Admin
                     ->set('cookie_consent_popup_text_color', $this->getRequest()->getPost('cookieConsentPopUpTextColor'))
                     ->set('cookie_consent_btn_bg_color', $this->getRequest()->getPost('cookieConsentBtnBGColor'))
                     ->set('cookie_consent_btn_text_color', $this->getRequest()->getPost('cookieConsentBtnTextColor'))
-                    ->set('cookie_consent_type', $this->getRequest()->getPost('cookieConsentType'));
+                    ->set('cookie_consent_type', $this->getRequest()->getPost('cookieConsentType'))
+                    ->set('cookie_consent_services', implode(',', $this->getRequest()->getPost('cookieConsentServices')) ?? '');
 
                 $this->redirect()
                     ->withMessage('saveSuccess')
@@ -78,6 +79,7 @@ class Index extends \Ilch\Controller\Admin
             ->set('cookieConsentPopUpTextColor', $this->getConfig()->get('cookie_consent_popup_text_color'))
             ->set('cookieConsentBtnBGColor', $this->getConfig()->get('cookie_consent_btn_bg_color'))
             ->set('cookieConsentBtnTextColor', $this->getConfig()->get('cookie_consent_btn_text_color'))
-            ->set('cookieConsentType', $this->getConfig()->get('cookie_consent_type'));
+            ->set('cookieConsentType', $this->getConfig()->get('cookie_consent_type'))
+            ->set('cookieConsentServices', $this->getConfig()->get('cookie_consent_services') ? explode(',', $this->getConfig()->get('cookie_consent_services')) : []);
     }
 }

--- a/application/modules/cookieconsent/translations/de.php
+++ b/application/modules/cookieconsent/translations/de.php
@@ -37,5 +37,5 @@ return [
     'addServices' => 'Dienste hinzufügen',
     'removeServices' => 'Dienste entfernen',
     'removeAllServices' => 'Alle Dienste entfernen',
-    'servicesNeededModificationsDesc' => 'Wenn Sie einen oder mehrere Dienste ausgewählt haben, müssen Sie noch die Einbindung der Dienste anpassen. Lesen Sie hierzu mehr auf folgender Seite: <a href="https://tarteaucitron.io/en/install/">tarteaucitron.io/en/install/</a>',
+    'servicesNeededModificationsDesc' => 'Wenn Sie einen oder mehrere Dienste ausgewählt haben, müssen Sie noch die Einbindung der Dienste anpassen. Lesen Sie hierzu mehr auf folgender Seite: <a href="https://tarteaucitron.io/en/install/" target="_blank" rel="noopener">tarteaucitron.io/en/install/</a>',
 ];

--- a/application/modules/cookieconsent/translations/de.php
+++ b/application/modules/cookieconsent/translations/de.php
@@ -31,4 +31,11 @@ return [
     'cookieConsentLocale' => 'Sprache',
     'cookieConsentDesc' => 'Beschreibung',
     'cookieConsentText' => 'Richtlinien',
+    'cookieConsentServices' => 'Auswahl der Dienste',
+    'cookieConsentAvailableServices' => 'Verfügbare Dienste',
+    'cookieConsentSelectedServices' => 'Ausgewählte Dienste',
+    'addServices' => 'Dienste hinzufügen',
+    'removeServices' => 'Dienste entfernen',
+    'removeAllServices' => 'Alle Dienste entfernen',
+    'servicesNeededModificationsDesc' => 'Wenn Sie einen oder mehrere Dienste ausgewählt haben, müssen Sie noch die Einbindung der Dienste anpassen. Lesen Sie hierzu mehr auf folgender Seite: <a href="https://tarteaucitron.io/en/install/">tarteaucitron.io/en/install/</a>',
 ];

--- a/application/modules/cookieconsent/translations/en.php
+++ b/application/modules/cookieconsent/translations/en.php
@@ -37,5 +37,5 @@ return [
     'addServices' => 'Add services',
     'removeServices' => 'Remove services',
     'removeAllServices' => 'Remove all services',
-    'servicesNeededModificationsDesc' => 'If you have selected one or more services, you still need to adjust the integration of the services. Read more about this on the following page: <a href="https://tarteaucitron.io/en/install/">tarteaucitron.io/en/install/</a>',
+    'servicesNeededModificationsDesc' => 'If you have selected one or more services, you still need to adjust the integration of the services. Read more about this on the following page: <a href="https://tarteaucitron.io/en/install/" target="_blank" rel="noopener">tarteaucitron.io/en/install/</a>',
 ];

--- a/application/modules/cookieconsent/translations/en.php
+++ b/application/modules/cookieconsent/translations/en.php
@@ -31,4 +31,11 @@ return [
     'cookieConsentLocale' => 'Locale',
     'cookieConsentDesc' => 'Description',
     'cookieConsentText' => 'Consent',
+    'cookieConsentServices' => 'Selection of services',
+    'cookieConsentAvailableServices' => 'Available services',
+    'cookieConsentSelectedServices' => 'Selected services',
+    'addServices' => 'Add services',
+    'removeServices' => 'Remove services',
+    'removeAllServices' => 'Remove all services',
+    'servicesNeededModificationsDesc' => 'If you have selected one or more services, you still need to adjust the integration of the services. Read more about this on the following page: <a href="https://tarteaucitron.io/en/install/">tarteaucitron.io/en/install/</a>',
 ];

--- a/application/modules/cookieconsent/views/admin/index/index.php
+++ b/application/modules/cookieconsent/views/admin/index/index.php
@@ -187,23 +187,12 @@
         }
     });
 
-    function removeSelectedServices()
-    {
+    document.getElementById("removeButton").addEventListener("click", () => {
         for (let i = selectSelectedServices.selectedOptions.length - 1; i >= 0; i--) {
             selectSelectedServices.selectedOptions[i].remove();
         }
         for (let option of selectSelectedServices.options) {
             option.selected = true;
-        }
-    }
-
-    document.getElementById("removeButton").addEventListener("click", () => {
-        removeSelectedServices();
-    });
-
-    selectSelectedServices.addEventListener("keyup", (e) => {
-        if (e.keyCode === 46) {
-            removeSelectedServices();
         }
     });
 

--- a/application/modules/cookieconsent/views/admin/index/index.php
+++ b/application/modules/cookieconsent/views/admin/index/index.php
@@ -58,6 +58,29 @@
             </select>
         </div>
     </div>
+    <div class="row mb-3 col-xl-5">
+        <label for="serviceSelection" class="col-xl-2 col-form-label">
+            <?=$this->getTrans('cookieConsentServices') ?>:
+        </label>
+        <div id="serviceSelection" class="row mb-3">
+            <div class="col-xl-5">
+                <select id="selectAvailableServices" class="form-select" size="10" multiple aria-label="<?=$this->getTrans('cookieConsentAvailableServices') ?>"></select>
+            </div>
+            <div class="col-auto">
+                <p><button type="button" class="btn btn-secondary" id="addButton" title="<?=$this->getTrans('addServices') ?>"><i class="fa-solid fa-arrow-right"></i></button></p>
+                <p><button type="button" class="btn btn-secondary" id="removeButton" title="<?=$this->getTrans('removeServices') ?>"><i class="fa-solid fa-arrow-left"></i></button></p>
+                <p><button type="button" class="btn btn-secondary" id="removeAllButton" title="<?=$this->getTrans('removeAllServices') ?>"><i class="fa-solid fa-backward-fast"></i></button></p>
+            </div>
+            <div class="col-xl-5">
+                <select id="selectSelectedServices" name="cookieConsentServices[]" class="form-select" size="10" multiple aria-label="<?=$this->getTrans('cookieConsentSelectedServices') ?>">
+                    <?php foreach ($this->get('cookieConsentServices') as $service): ?>
+                        <option value="<?=$service ?>" selected></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+        </div>
+    </div>
+    <p><?=$this->getTrans('servicesNeededModificationsDesc') ?></p>
 
     <h1><?=$this->getTrans('cookieConsentPopUp') ?></h1>
     <div class="row mb-3<?=$this->validation()->hasError('cookieConsentPopUpBGColor') ? ' has-error' : '' ?>">
@@ -125,4 +148,66 @@
     <?=$this->getSaveBar() ?>
 </form>
 
+<script src="<?=$this->getStaticUrl('js/tarteaucitron/build/tarteaucitron.min.js') ?>"></script>
+<script src="<?=$this->getStaticUrl('js/tarteaucitron/build/tarteaucitron.services.min.js') ?>"></script>
 <script src="<?=$this->getStaticUrl('js/jscolor/jscolor.min.js') ?>"></script>
+
+<script>
+    let services = Object.entries(tarteaucitron.services).sort();
+    let selectAvailableServices = document.getElementById("selectAvailableServices");
+    let selectSelectedServices = document.getElementById("selectSelectedServices");
+
+    services.forEach(item => {
+        let option = document.createElement("option");
+        option.value = item[1].key;
+        option.text = item[1].name;
+        selectAvailableServices.appendChild(option);
+
+        for (let selectedItem of selectSelectedServices.selectedOptions) {
+            if (item[1].key === selectedItem.value) {
+                selectedItem.text = item[1].name;
+                return;
+            }
+        }
+    });
+
+    document.getElementById("addButton").addEventListener("click", () => {
+        availableServices: for (let item of selectAvailableServices.selectedOptions) {
+            for (let selectedItem of selectSelectedServices.selectedOptions) {
+                if (item.value === selectedItem.value) {
+                    continue availableServices;
+                }
+            }
+
+            let option = document.createElement("option");
+            option.value = item.value;
+            option.text = item.text;
+            option.setAttribute('selected', '');
+            selectSelectedServices.appendChild(option);
+        }
+    });
+
+    function removeSelectedServices()
+    {
+        for (let i = selectSelectedServices.selectedOptions.length - 1; i >= 0; i--) {
+            selectSelectedServices.selectedOptions[i].remove();
+        }
+        for (let option of selectSelectedServices.options) {
+            option.selected = true;
+        }
+    }
+
+    document.getElementById("removeButton").addEventListener("click", () => {
+        removeSelectedServices();
+    });
+
+    selectSelectedServices.addEventListener("keyup", (e) => {
+        if (e.keyCode === 46) {
+            removeSelectedServices();
+        }
+    });
+
+    document.getElementById("removeAllButton").addEventListener("click", () => {
+        selectSelectedServices.length = 0;
+    });
+</script>


### PR DESCRIPTION
# Description
- Add tarteaucitron services to the dialog when they are selected in the admincenter. This doesn't automatically adjust how the services are integrated into the website for it to take effect.

> If you have selected one or more services, you still need to adjust the integration of the services. Read more about this on the following page: [tarteaucitron.io/en/install/](https://tarteaucitron.io/en/install/)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [x] Edge
