### PR TITLE
User module: Fix possible duplicate (issue 509)

### DIFF
--- a/application/modules/user/views/index/index.php
+++ b/application/modules/user/views/index/index.php
@@ -99,7 +99,16 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                                                 }
                                             }
 
-                                            echo '<a href="' . $profileIconField->getAddition() . $profileFieldContent->getValue() . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
+                                            // Using this code instead of for example str_replace to only replace the addition once.
+                                            // Example: addition = "https://discord.gg/", value = "https://discord.gg/username". The user entered the complete URL instead of just the username.
+                                            $profileFieldContentValue = $profileFieldContent->getValue();
+                                            $pos = strpos($profileFieldContent->getValue(), $profileIconField->getAddition());
+
+                                            if ($pos !== false) {
+                                                $profileFieldContentValue = substr_replace($profileFieldContent->getValue(), '', $pos, $profileIconField->getAddition());
+                                            }
+
+                                            echo '<a href="' . $profileFieldContentValue . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
                                             break;
                                         }
                                     }

--- a/application/modules/user/views/profil/index.php
+++ b/application/modules/user/views/profil/index.php
@@ -91,7 +91,16 @@ foreach ($profil->getGroups() as $group) {
                     }
                 }
 
-                echo '<a href="'.$profileIconField->getAddition().$profileFieldContent->getValue().'" target="_blank" rel="noopener" class="fa '.$profileIconField->getIcon().'" title="'.$profileFieldName.'"></a>';
+                // Using this code instead of for example str_replace to only replace the addition once.
+                // Example: addition = "https://discord.gg/", value = "https://discord.gg/username". The user entered the complete URL instead of just the username.
+                $profileFieldContentValue = $profileFieldContent->getValue();
+                $pos = strpos($profileFieldContent->getValue(), $profileIconField->getAddition());
+
+                if ($pos !== false) {
+                    $profileFieldContentValue = substr_replace($profileFieldContent->getValue(), '', $pos, $profileIconField->getAddition());
+                }
+
+                echo '<a href="' . $profileFieldContentValue . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
                 break;
             }
         }


### PR DESCRIPTION
# Description
- Fix possible duplicate in output

Example: 
```
addition = "https://discord.gg/"
value = "https://discord.gg/username"

The user entered the complete URL instead of just the username. The output was "https://discord.gg/https://discord.gg/username"
```

Fixes #509

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
