### PR TITLE
Update User.php

### DIFF
--- a/application/modules/user/mappers/User.php
+++ b/application/modules/user/mappers/User.php
@@ -203,7 +203,7 @@ class User extends \Ilch\Mapper
     {
         $user = new UserModel();
 
-        if (isset($userRow['id'])) {
+        if (!empty($userRow['id'])) {
             $user->setId($userRow['id']);
         }
 


### PR DESCRIPTION
# Description
Fatal error: Uncaught TypeError: Argument 1 passed to Modules\User\Models\User::setId() must be of the type int or null, string given, called in /vagrant/application/modules/user/mappers/User.php on line 207 and defined in /vagrant/application/modules/user/models/User.php on line 215

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [x] Firefox
- [ ] Opera
- [ ] Edge
