### PR TITLE
User module: Fix two errors due to invalid arguments

### DIFF
--- a/application/modules/user/controllers/admin/Index.php
+++ b/application/modules/user/controllers/admin/Index.php
@@ -248,9 +248,9 @@ class Index extends \Ilch\Controller\Admin
                 ];
 
             if ($userData['id']) {
-                $userbyid = $userMapper->getUserById($userData['id']);
+                $userbyid = (is_numeric($userData['id'])) ? $userMapper->getUserById($userData['id']) : null;
 
-                if ($userbyid->isAdmin() && !$this->getUser()->isAdmin()) {
+                if (!$userbyid || ($userbyid->isAdmin() && !$this->getUser()->isAdmin())) {
                     $this->redirect(['action' => 'index']);
                 }
 
@@ -398,7 +398,7 @@ class Index extends \Ilch\Controller\Admin
         $profileFieldsContentMapper = new ProfileFieldsContentMapper();
         $profileFieldsTranslationMapper = new ProfileFieldsTranslationMapper();
 
-        $user = $userMapper->getUserById($this->getRequest()->getParam('user'));
+        $user = ($this->getRequest()->getParam('user') && is_numeric($this->getRequest()->getParam('user'))) ? $userMapper->getUserById($this->getRequest()->getParam('user')) : null;
 
         if ($user) {
             $this->getLayout()->getAdminHmenu()


### PR DESCRIPTION
# Description
- Fix two errors due to invalid arguments

```
Uncaught TypeError: Modules\User\Mappers\User::getUserById(): Argument #1 ($id) must be of type int, string given, called in application/modules/user/controllers/admin/Index.php on line 251 and defined in application/modules/user/mappers/User.php:24
Stack trace:
#0 application/modules/user/controllers/admin/Index.php(251): Modules\User\Mappers\User->getUserById()
#1 application/libraries/Ilch/Page.php(243): Modules\User\Controllers\Admin\Index->treatAction()
#2 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#3 index.php(68): Ilch\Page->loadPage()
#4 {main}
  thrown in application/modules/user/mappers/User.php on line 24
```

```
Uncaught TypeError: Modules\User\Mappers\User::getUserById(): Argument #1 ($id) must be of type int, null given, called in application/modules/user/controllers/admin/Index.php on line 401 and defined in application/modules/user/mappers/User.php:24
Stack trace:
#0 application/modules/user/controllers/admin/Index.php(401): Modules\User\Mappers\User->getUserById()
#1 application/libraries/Ilch/Page.php(243): Modules\User\Controllers\Admin\Index->treatProfileAction()
#2 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#3 index.php(68): Ilch\Page->loadPage()
#4 {main}
  thrown in application/modules/user/mappers/User.php on line 24
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
