### PR TITLE
Fix various errors

### DIFF
--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -469,10 +469,12 @@ function group(string $file)
  */
 function validateDate(?string $date, string $format = 'Y-m-d H:i:s'): bool
 {
-    if ((0 === substr_compare($date ?? '', "\0", - 1))) {
-        // Return false when $date contains null bytes.
-        // This avoids "createFromFormat(): Argument must not contain any null bytes".
-        return false;
+    foreach (["\0", "%00"] as $nullByte) {
+        if ((0 === substr_compare($date ?? '', $nullByte, - 1))) {
+            // Return false when $date contains null bytes.
+            // This avoids "createFromFormat(): Argument must not contain any null bytes".
+            return false;
+        }
     }
 
     $d = DateTime::createFromFormat($format, $date ?? '');

--- a/application/modules/admin/controllers/admin/Menu.php
+++ b/application/modules/admin/controllers/admin/Menu.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Ilch 2.0
+ * @copyright Ilch 2
  * @package ilch
  */
 
@@ -35,9 +35,7 @@ class Menu extends \Ilch\Controller\Admin
         $pageMapper = new PageMapper();
         $userGroupMapper = new UserGroupMapper();
 
-        /*
-         * Saves the item tree to database.
-         */
+        // Saves the item tree to database.
         if ($this->getRequest()->isPost()) {
             if ($this->getRequest()->getPost('save')) {
                 $sortItems = json_decode($this->getRequest()->getPost('hiddenMenu'));
@@ -58,9 +56,7 @@ class Menu extends \Ilch\Controller\Admin
 
                 $oldItems = $menuMapper->getMenuItems($menuId);
 
-                /*
-                 * Deletes old entries from database.
-                 */
+                // Deletes old entries from database.
                 if (!empty($oldItems)) {
                     foreach ($oldItems as $oldItem) {
                         if (!isset($items[$oldItem->getId()])) {
@@ -170,6 +166,24 @@ class Menu extends \Ilch\Controller\Admin
         $menuItems = $menuMapper->getMenuItemsByParent($menuId, 0);
         $menu = $menuMapper->getMenu($menuId);
         $menus = $menuMapper->getMenus();
+
+        if (!$menus) {
+            // The last remaining menu was deleted. Restore one empty menu.
+            $menuMapper = new MenuMapper();
+
+            $menu = new MenuModel();
+            $menu->setTitle('New');
+            $menuMapper->save($menu);
+
+            $menus = $menuMapper->getMenus();
+            $this->addMessage('lastMenuDeletedRestored');
+        }
+
+        if (!$menu) {
+            $this->addMessage('menuNotFound', 'danger');
+            $this->redirect(['action' => 'index']);
+        }
+
         $userGroupList = $userGroupMapper->getGroupList();
 
         $moduleMapper = new \Modules\Admin\Mappers\Module();

--- a/application/modules/admin/controllers/admin/Settings.php
+++ b/application/modules/admin/controllers/admin/Settings.php
@@ -112,6 +112,7 @@ class Settings extends \Ilch\Controller\Admin
                 'multilingualAcp' => 'required|numeric|integer|min:0|max:1',
                 'domain' => 'domain',
                 'standardMail' => 'required|email',
+                'timezone' => 'required|timezone',
                 'defaultPaginationObjects' => 'numeric|integer|min:1',
                 'hmenuFixed' => 'required|numeric|integer|min:0|max:1',
                 'htmlPurifier' => 'required|numeric|integer|min:0|max:1',

--- a/application/modules/admin/mappers/Menu.php
+++ b/application/modules/admin/mappers/Menu.php
@@ -57,18 +57,21 @@ class Menu extends Mapper
      * Gets the menu for the given id.
      *
      * @param int $menuId
-     * @return MenuModel
+     * @return MenuModel|null
      */
-    public function getMenu(int $menuId): MenuModel
+    public function getMenu(int $menuId): ?MenuModel
     {
-        $menu = new MenuModel();
-
         $menuRow = $this->db()->select(['id','title'])
             ->from('menu')
             ->where(['id' => $menuId])
             ->execute()
             ->fetchAssoc();
 
+        if (empty($menuRow)) {
+            return null;
+        }
+
+        $menu = new MenuModel();
         $menu->setId($menuRow['id']);
         $menu->setTitle($menuRow['title']);
 
@@ -300,6 +303,11 @@ class Menu extends Mapper
         $this->db()->delete('menu')
             ->where(['id' => $id])
             ->execute();
+
+        // Truncate table if this was the last menu. This will also reset AUTO_INCREMENT.
+        if (!$this->getMenus()) {
+            $this->db()->truncate('menu');
+        }
     }
 
     /**

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -146,6 +146,8 @@ return [
     'menu' => 'Menü',
     'deleteMenu' => 'Menü löschen',
     'askIfDeleteMenu' => 'Sind Sie sicher, dass das Menü "%s" entfernt werden soll?',
+    'lastMenuDeletedRestored' => 'Sie haben das einzig verbliebene Menü gelöscht. Es wurde ein leeres Menü wiederhergestellt.',
+    'menuNotFound' => 'Menü nicht gefunden.',
     'multilingualAcp' => 'Mehrsprachige Einstellungen',
     'list' => 'Liste',
     'menuActionNewLayout' => 'Neues Layout hinzufügen',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -146,6 +146,8 @@ return [
     'menu' => 'menu',
     'deleteMenu' => 'Delete menu',
     'askIfDeleteMenu' => 'Are you sure to delete menu "%s"?',
+    'lastMenuDeletedRestored' => 'You have deleted the only remaining menu. An empty menu has been restored.',
+    'menuNotFound' => 'Menu not found.',
     'multilingualAcp' => 'Multilingual Settings',
     'list' => 'List',
     'menuActionNewLayout' => 'Add new layout',

--- a/application/modules/admin/views/admin/settings/index.php
+++ b/application/modules/admin/views/admin/settings/index.php
@@ -109,7 +109,7 @@
             </select>
         </div>
     </div>
-    <div class="row mb-3">
+    <div class="row mb-3<?= $this->validation()->hasError('timezone') ? ' has-error' : '' ?>">
         <label for="timezone" class="col-xl-2 col-form-label">
             <?= $this->getTrans('timezone') ?>:
         </label>

--- a/application/modules/cookieconsent/controllers/admin/Index.php
+++ b/application/modules/cookieconsent/controllers/admin/Index.php
@@ -58,7 +58,7 @@ class Index extends \Ilch\Controller\Admin
                     ->set('cookie_consent_btn_bg_color', $this->getRequest()->getPost('cookieConsentBtnBGColor'))
                     ->set('cookie_consent_btn_text_color', $this->getRequest()->getPost('cookieConsentBtnTextColor'))
                     ->set('cookie_consent_type', $this->getRequest()->getPost('cookieConsentType'))
-                    ->set('cookie_consent_services', implode(',', $this->getRequest()->getPost('cookieConsentServices')) ?? '');
+                    ->set('cookie_consent_services', implode(',', (is_array($this->getRequest()->getPost('cookieConsentServices'))) ? $this->getRequest()->getPost('cookieConsentServices') : []) ?? '');
 
                 $this->redirect()
                     ->withMessage('saveSuccess')


### PR DESCRIPTION
# Description
- Fix "createFromFormat(): Argument must not contain any null bytes"
- CookieConsent module: Fix "must be of type array, string given"
- Validate the selected (or posted) timezone.
- Handle deleting of last menu: A new empty menu will be created. Further the table will get truncated, which resets auto_increment. This should allow to recover from a "broken" menu from inside the admincenter instead of having to fix it manually in the database table.

```
Uncaught ValueError: DateTime::createFromFormat(): Argument #2 ($datetime) must not contain any null bytes in application/libraries/Ilch/Functions.php:478
Stack trace:
#0 application/libraries/Ilch/Functions.php(478): DateTime::createFromFormat()
#1 application/libraries/Ilch/Validation/Validators/Date.php(30): validateDate()
#2 application/libraries/Ilch/Validation.php(284): Ilch\Validation\Validators\Date->run()
#3 application/libraries/Ilch/Validation.php(207): Ilch\Validation->validate()
#4 application/libraries/Ilch/Validation.php(151): Ilch\Validation->validateRules()
#5 application/libraries/Ilch/Validation.php(141): Ilch\Validation->run()
#6 application/libraries/Ilch/Validation.php(309): Ilch\Validation->__construct()
#7 application/modules/away/controllers/Index.php(45): Ilch\Validation::create()
#8 application/libraries/Ilch/Page.php(243): Modules\Away\Controllers\Index->indexAction()
#9 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#10 index.php(68): Ilch\Page->loadPage()\n#11 {main}
  thrown in application/libraries/Ilch/Functions.php on line 478
```

```
Uncaught TypeError: implode(): Argument #1 ($array) must be of type array, string given in application/modules/cookieconsent/controllers/admin/Index.php:61
Stack trace:
#0 application/modules/cookieconsent/controllers/admin/Index.php(61): implode()
#1 application/libraries/Ilch/Page.php(243): Modules\Cookieconsent\Controllers\Admin\Index->indexAction()
#2 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#3 index.php(68): Ilch\Page->loadPage()
#4 {main}
  thrown in application/modules/cookieconsent/controllers/admin/Index.php on line 61
```

```
PHP Warning: Trying to access array offset on null in application/modules/admin/mappers/Menu.php on line 72
PHP Warning: Trying to access array offset on null in application/modules/admin/mappers/Menu.php on line 73
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
