### PR TITLE
Add timezone validator

### DIFF
--- a/application/libraries/Ilch/Translations/de.php
+++ b/application/libraries/Ilch/Translations/de.php
@@ -32,6 +32,7 @@ return [
     'validation.errors.max.numeric' => '%s darf höchstens %s betragen.',
     'validation.errors.max.string' => '%s darf höchstens %s Zeichen lang sein.',
     'validation.errors.max.array' => '%s darf höchstens %s Einträge haben.',
+    'validation.errors.timezone.notAValidTimezone' => '%s ist keine gültige Zeitzone.',
 
     // general
     'saveSuccess' => 'Erfolgreich gespeichert',

--- a/application/libraries/Ilch/Translations/en.php
+++ b/application/libraries/Ilch/Translations/en.php
@@ -32,6 +32,7 @@ return [
     'validation.errors.max.numeric' => '%s may not be greater than %s.',
     'validation.errors.max.string' => '%s may not be greater than %s characters.',
     'validation.errors.max.array' => '%s may not have more than %s items.',
+    'validation.errors.timezone.notAValidTimezone' => '%s is not a valid timezone.',
 
     // general
     'saveSuccess' => 'Saved successful',

--- a/application/libraries/Ilch/Validation/Validators/Timezone.php
+++ b/application/libraries/Ilch/Validation/Validators/Timezone.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright Ilch 2
+ */
+
+namespace Ilch\Validation\Validators;
+
+/**
+ * Timezone validation class.
+ */
+class Timezone extends Base
+{
+    /**
+     * Default error key for this validator.
+     *
+     * @var string
+     */
+    protected $errorKey = 'validation.errors.timezone.notAValidTimezone';
+
+    /**
+     * Runs the validation.
+     *
+     * @return self
+     */
+    public function run(): self
+    {
+        $includeOutdated = $this->getParameter(1) === 'backwardsCompatible';
+
+        $this->setIsValid($this->getValue() === '' || in_array($this->getValue(), \DateTimeZone::listIdentifiers($includeOutdated ? \DateTimeZone::ALL_WITH_BC : \DateTimeZone::ALL)) !== false);
+
+        return $this;
+    }
+}

--- a/tests/libraries/ilch/Validation/Validators/TimezoneTest.php
+++ b/tests/libraries/ilch/Validation/Validators/TimezoneTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Ilch\Validation\Validators;
+
+use PHPUnit\Ilch\TestCase;
+use stdClass;
+
+/**
+ * Tests for the timezone validator
+ */
+class TimezoneTest extends TestCase
+{
+    /**
+     * @dataProvider dpForTestValidator
+     *
+     * @param stdClass $data
+     * @param bool $expectedIsValid
+     * @param string $expectedErrorKey
+     * @param array $expectedErrorParameters
+     */
+    public function testValidator(stdClass $data, bool $expectedIsValid, string $expectedErrorKey = '', array $expectedErrorParameters = [])
+    {
+        $validator = new Timezone($data);
+        $validator->run();
+        self::assertSame($expectedIsValid, $validator->isValid());
+        if (!empty($expectedErrorKey)) {
+            self::assertSame($expectedErrorKey, $validator->getErrorKey());
+            self::assertSame($expectedErrorParameters, $validator->getErrorParameters());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidator(): array
+    {
+        return [
+            // timezone validations
+            'timezone valid' => [
+                'data'                    => $this->createData('Europe/Kyiv'),
+                'expectedIsValid'         => true
+            ],
+            'timezone valid including outdated' => [
+                'data'                    => $this->createData('America/Shiprock', true),
+                'expectedIsValid'         => true
+            ],
+            'empty timezone valid' => [
+                'data'                    => $this->createData(''),
+                'expectedIsValid'         => true
+            ],
+            'timezone invalid' => [
+                'data'                    => $this->createData('test'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.timezone.notAValidTimezone',
+                'expectedErrorParameters' => []
+            ],
+            'timezone invalid completely removed' => [
+                'data'                    => $this->createData('Canada/East-Saskatchewan'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.timezone.notAValidTimezone',
+                'expectedErrorParameters' => []
+            ],
+            'timezone invalid outdated' => [
+                'data'                    => $this->createData('America/Shiprock'),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.timezone.notAValidTimezone',
+                'expectedErrorParameters' => []
+            ],
+        ];
+    }
+
+    /**
+     * Helper function for creating data object
+     *
+     * @param string $value
+     * @return stdClass
+     */
+    private function createData(string $value, bool $includeOutdated = false): stdClass
+    {
+        $data = new stdClass();
+        $data->field = 'fieldName';
+        $data->parameters = [''];
+        $data->input = ['fieldName' => $value];
+        if ($includeOutdated) {
+            $data->parameters[] = 'backwardsCompatible';
+        }
+        return $data;
+    }
+}


### PR DESCRIPTION
# Description
- Add timezone validator
- Add unit tests for the timezone validator

https://www.php.net/manual/en/datetimezone.listidentifiers.php
https://www.php.net/manual/en/class.datetimezone.php#datetimezone.constants.all-with-bc
https://github.com/IlchCMS/Ilch-2.0/wiki/Doku-Entwickler-Validation

My plan is to use this first here:
https://github.com/IlchCMS/Ilch-2.0/blob/master/application/modules/admin/controllers/admin/Settings.php#L111
https://github.com/IlchCMS/Ilch-2.0/blob/master/application/modules/admin/controllers/admin/Settings.php#L135
https://github.com/IlchCMS/Ilch-2.0/blob/master/application/modules/admin/views/admin/settings/index.php#L117

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update