### PR TITLE
Fix errors trying to show comments of deleted modules

### DIFF
--- a/application/modules/admin/mappers/Module.php
+++ b/application/modules/admin/mappers/Module.php
@@ -118,9 +118,9 @@ class Module extends \Ilch\Mapper
      *
      * @param string $key
      * @param string $locale
-     * @return ModuleModel|void
+     * @return ModuleModel|null
      */
-    public function getModulesByKey($key, $locale)
+    public function getModulesByKey(string $key, string $locale): ?ModuleModel
     {
         $modulesRows = $this->db()->select('*')
             ->from('modules_content')
@@ -129,7 +129,7 @@ class Module extends \Ilch\Mapper
             ->fetchAssoc();
 
         if (empty($modulesRows)) {
-            return;
+            return null;
         }
 
         $modulesModel = new ModuleModel();

--- a/application/modules/comment/controllers/admin/Index.php
+++ b/application/modules/comment/controllers/admin/Index.php
@@ -71,7 +71,7 @@ class Index extends \Ilch\Controller\Admin
         $this->getLayout()->getAdminHmenu()
             ->add($this->getTranslator()->trans('menuComments'), ['action' => 'index'])
             ->add($this->getTranslator()->trans('manage'), ['action' => 'index'])
-            ->add($modules->getName(), ['action' => 'show', 'module' => $module]);
+            ->add($modules ? $modules->getName() : $this->getLayout()->escape($this->getRequest()->getParam('key')), ['action' => 'show', 'module' => $module]);
 
         if ($this->getRequest()->getPost('action') === 'delete' && $this->getRequest()->getPost('check_comments')) {
             foreach ($this->getRequest()->getPost('check_comments') as $commentId) {
@@ -83,10 +83,9 @@ class Index extends \Ilch\Controller\Admin
                 ->to(['action' => 'show', 'key' => $this->getRequest()->getParam('key')]);
         }
 
-        $this->getView()->set('modulesMapper', $modulesMapper);
         $this->getView()->set('userMapper', $userMapper);
+        $this->getView()->set('modules', $modules);
         $this->getView()->set('comments', $commentMapper->getCommentsLikeKey($module));
-        $this->getView()->set('locale', $this->getConfig()->get('locale'));
     }
 
     public function deleteAction()

--- a/application/modules/comment/views/admin/index/show.php
+++ b/application/modules/comment/views/admin/index/show.php
@@ -1,11 +1,10 @@
 <?php
 $userMapper = $this->get('userMapper');
-$modulesMapper = $this->get('modulesMapper');
-$locale = $this->get('locale');
-$modules = $modulesMapper->getModulesByKey($this->getRequest()->getParam('key'), $locale);
+$modules = $this->get('modules');
+$moduleName = $modules ? $modules->getName() : $this->escape($this->getRequest()->getParam('key'));
 ?>
 
-<h1><?=$modules->getName() ?></h1>
+<h1><?=$moduleName ?></h1>
 <form method="POST">
     <?=$this->getTokenField() ?>
     <div class="table-responsive">
@@ -44,7 +43,7 @@ $modules = $modulesMapper->getModulesByKey($this->getRequest()->getParam('key'),
                             <td><?=$this->getDeleteIcon(['action' => 'delete', 'key' => $commentKey, 'id' => $comment->getId()]) ?></td>
                             <td><?=$date->format("d.m.Y H:i", true) ?></td>
                             <td><a href="<?=$this->getUrl('user/profil/index/user/'.$user->getId()) ?>" target="_blank"><?=$this->escape($user->getName()) ?></a></td>
-                            <td><a href="<?=$this->getUrl($comment->getKey()) ?>#comment_<?=$comment->getId() ?>" target="_blank"><?=$modules->getName() ?></a></td>
+                            <td><a href="<?=$this->getUrl($comment->getKey()) ?>#comment_<?=$comment->getId() ?>" target="_blank"><?=$moduleName ?></a></td>
                             <td><?=nl2br($this->escape($comment->getText())) ?></td>
                         </tr>
                     <?php endforeach; ?>

--- a/application/modules/downloads/config/config.php
+++ b/application/modules/downloads/config/config.php
@@ -7,11 +7,13 @@
 
 namespace Modules\Downloads\Config;
 
+use Modules\Comment\Mappers\Comment as CommentMapper;
+
 class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'downloads',
-        'version' => '1.14.1',
+        'version' => '1.14.2',
         'icon_small' => 'fa-regular fa-circle-down',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -38,6 +40,9 @@ class Config extends \Ilch\Config\Install
     {
         $this->db()->drop('downloads_files', true);
         $this->db()->drop('downloads_items', true);
+
+        $commentMapper = new CommentMapper();
+        $commentMapper->deleteByKey('downloads/index/showfile/id/');
     }
 
     public function getInstallSql(): string

--- a/application/modules/gallery/config/config.php
+++ b/application/modules/gallery/config/config.php
@@ -9,12 +9,13 @@ namespace Modules\Gallery\Config;
 
 use Ilch\Config\Install;
 use Modules\Admin\Models\Box;
+use Modules\Comment\Mappers\Comment as CommentMapper;
 
 class Config extends Install
 {
     public $config = [
         'key' => 'gallery',
-        'version' => '1.23.2',
+        'version' => '1.23.3',
         'icon_small' => 'fa-regular fa-image',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -76,6 +77,9 @@ class Config extends Install
 
         $this->db()->drop('gallery_imgs', true);
         $this->db()->drop('gallery_items', true);
+
+        $commentMapper = new CommentMapper();
+        $commentMapper->deleteByKey('gallery/index/showimage/id/');
     }
 
     public function getInstallSql(): string

--- a/application/modules/shop/translations/de.php
+++ b/application/modules/shop/translations/de.php
@@ -145,7 +145,7 @@ return [
     'menuSettings' => 'Einstellungen',
     'menuSettingShop' => 'Shop Daten',
     'menuSettingBank' => 'Bankverbindung',
-    'menuSettingDefault' => 'Standard Werte',
+    'menuSettingDefault' => 'Standardwerte',
     'menuSettingAGB' => 'Allgemeine Geschäftsbedingungen',
     'menuShopOverview' => 'Shop Übersicht',
     'menuShops' => 'Shop',

--- a/application/modules/shop/translations/en.php
+++ b/application/modules/shop/translations/en.php
@@ -145,7 +145,7 @@ return [
     'menuSettings' => 'Settings',
     'menuSettingShop' => 'Shop data',
     'menuSettingBank' => 'Bank details',
-    'menuSettingDefault' => 'Standard values',
+    'menuSettingDefault' => 'Default values',
     'menuSettingAGB' => 'Terms of Service',
     'menuShopOverview' => 'Shop overview',
     'menuShops' => 'Shop',

--- a/application/modules/war/config/config.php
+++ b/application/modules/war/config/config.php
@@ -9,12 +9,13 @@ namespace Modules\War\Config;
 
 use Ilch\Config\Database;
 use Ilch\Config\Install;
+use Modules\Comment\Mappers\Comment as CommentMapper;
 
 class Config extends Install
 {
     public $config = [
         'key' => 'war',
-        'version' => '1.16.2',
+        'version' => '1.16.3',
         'icon_small' => 'fa-solid fa-shield',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -83,6 +84,9 @@ class Config extends Install
         if ($this->db()->ifTableExists('[prefix]_calendar_events')) {
             $this->db()->delete('calendar_events')->where(['url' => 'war/wars/index/'])->execute();
         }
+
+        $commentMapper = new CommentMapper();
+        $commentMapper->deleteByKey('war/index/show/id/');
     }
 
     public function getInstallSql(): string


### PR DESCRIPTION
# Description
- Fix errors trying to show comments of deleted modules.
- Delete comments on uninstall of module (downloads, gallery, war).
- Fix translations of shop module.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
