### PR TITLE
Initialize modulesDB and update xdebug.ini

### DIFF
--- a/application/modules/admin/mappers/Module.php
+++ b/application/modules/admin/mappers/Module.php
@@ -48,7 +48,7 @@ class Module extends \Ilch\Mapper
     /**
      * Gets all not installed modules.
      *
-     * @return ModuleModel[]|Array[]
+     * @return ModuleModel[]|[]
      */
     public function getModulesNotInstalled()
     {
@@ -60,6 +60,7 @@ class Module extends \Ilch\Mapper
             }
         }
 
+        $modulesDB = [];
         $removeModule = ['admin', 'install', 'sample', 'error'];
         $modulesDir = array_diff($modulesDir, $removeModule);
 

--- a/development/vagrant/xdebug.ini
+++ b/development/vagrant/xdebug.ini
@@ -1,16 +1,19 @@
 
-; This switch controls whether Xdebug should try to contact a debug client which
-; is listening on the host and port as set with the settings xdebug.remote_host
-; and xdebug.remote_port. If a connection can not be established the script will
-; just continue as if this setting was Off.
-xdebug.remote_enable = On
+; This setting controls which Xdebug features are enabled.
+; debug: Enables Step Debugging. This can be used to step through your code while it is running,
+; and analyse values of variables.
+; xdebug.mode=debug should be used instead of xdebug.remote_enable.
+xdebug.mode = debug
 
-; If enabled, the xdebug.remote_host setting is ignored and Xdebug will try to connect
-; to the client that made the HTTP request. It checks the $_SERVER['REMOTE_ADDR'] variable
-; to find out which IP address to use. Please note that there is no filter available,
-; and anybody who can connect to the webserver will then be able to start a debugging session,
-; even if their address does not match xdebug.remote_host.
-xdebug.remote_connect_back = on
+; If enabled, Xdebug will first try to connect to the client that made the HTTP request. It checks the
+; $_SERVER['HTTP_X_FORWARDED_FOR'] and $_SERVER['REMOTE_ADDR'] variables to find out which hostname or IP address to use.
+; If xdebug.client_discovery_header is configured, then the $_SERVER variable with that configured name will be checked
+; instead of the default variables.
+; If Xdebug can not connect to a debugging client as found in one of the HTTP headers, it will fall back to the hostname
+; or IP address as configured by the xdebug.client_host setting.
+; This setting does not apply for debugging through the CLI, as the $_SERVER header variables are not available there.
+; xdebug.remote_connect_back was replaced by xdebug.discover_client_host.
+xdebug.discover_client_host = true
 
 ; Controls the amount of array children and object's properties are shown when
 ; variables are displayed with either xdebug_var_dump(), xdebug.show_local_vars


### PR DESCRIPTION
# Description
- Initialize modulesDB
- Update xdebug.ini

https://xdebug.org/docs/upgrade_guide

```
PHP Warning:  Undefined variable $modulesDB in application/modules/admin/mappers/Module.php on line 73

PHP Fatal error:  Uncaught TypeError: array_diff(): Argument #2 must be of type array, null given in application/modules/admin/mappers/Module.php:73
Stack trace:
#0 application/modules/admin/mappers/Module.php(73): array_diff()
#1 application/modules/admin/mappers/Module.php(196): Modules\Admin\Mappers\Module->getModulesNotInstalled()
#2 application/modules/admin/controllers/admin/Index.php(59): Modules\Admin\Mappers\Module->getVersionsOfModules()
#3 application/libraries/Ilch/Page.php(243): Modules\Admin\Controllers\Admin\Index->indexAction()
#4 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#5 index.php(68): Ilch\Page->loadPage()
#6 {main}
  thrown in application/modules/admin/mappers/Module.php on line 73
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
