### PR TITLE
Media module: Abort upload action if filename is missing

### DIFF
--- a/application/modules/media/controllers/admin/Index.php
+++ b/application/modules/media/controllers/admin/Index.php
@@ -156,6 +156,11 @@ class Index extends \Ilch\Controller\Admin
         $mediaMapper = new MediaMapper();
 
         if ($this->getRequest()->isPost()) {
+            // Early return if name is empty. Nothing to do here.
+            if (empty($_FILES['upl']['name'])) {
+                return;
+            }
+
             $upload = new \Ilch\Upload();
             $upload->setFile($_FILES['upl']['name']);
             $upload->setTypes($this->getConfig()->get('media_ext_img'));


### PR DESCRIPTION
# Description
Abort upload action if filename is missing

```
PHP Fatal error:  Uncaught TypeError: Ilch\Upload::setFile(): Argument #1 ($file) must be of type string, null given, called in application/modules/media/controllers/admin/Index.php on line 160 and defined in application/libraries/Ilch/Upload.php:101
Stack trace:
#0 application/modules/media/controllers/admin/Index.php(160): Ilch\Upload->setFile()
#1 application/libraries/Ilch/Page.php(243): Modules\Media\Controllers\Admin\Index->uploadAction()
#2 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#3 index.php(68): Ilch\Page->loadPage()
#4 {main}
  thrown in application/libraries/Ilch/Upload.php on line 101
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
