### PR TITLE
Article module: Fix "Call to a member function getReadAccess() on null"

### DIFF
--- a/application/modules/article/controllers/admin/Index.php
+++ b/application/modules/article/controllers/admin/Index.php
@@ -187,8 +187,9 @@ class Index extends \Ilch\Controller\Admin
                 ->to($redirect);
         }
 
-        if ($this->getRequest()->getParam('id')) {
-            $groups = explode(',', $articleMapper->getArticleByIdLocale($this->getRequest()->getParam('id'))->getReadAccess());
+        if ($this->getRequest()->getParam('id') && is_numeric($this->getRequest()->getParam('id'))) {
+            $article = $articleMapper->getArticleByIdLocale($this->getRequest()->getParam('id'));
+            $groups = explode(',', $article ? $article->getReadAccess() : [1,2,3]);
         } else {
             $groups = [1,2,3];
         }


### PR DESCRIPTION
# Description
- Fix "Call to a member function getReadAccess() on null"

```
PHP Fatal error:  Uncaught Error: Call to a member function getReadAccess() on null in application/modules/article/controllers/admin/Index.php:191
Stack trace:
#0 application/libraries/Ilch/Page.php(243): Modules\Article\Controllers\Admin\Index->treatAction()
#1 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#2 index.php(68): Ilch\Page->loadPage()
#3 {main}
  thrown in application/modules/article/controllers/admin/Index.php on line 191
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
