### PR TITLE
User: locked not required when creating user

### DIFF
--- a/application/modules/user/controllers/admin/Index.php
+++ b/application/modules/user/controllers/admin/Index.php
@@ -248,7 +248,7 @@ class Index extends \Ilch\Controller\Admin
                 'email' => 'required|email|unique:users,email',
                 'opt_gallery' => 'required|integer|min:0|max:1',
                 'admin_comments' => 'required|integer|min:0|max:1',
-                'locked' => 'required|integer|min:0|max:1',
+                'locked' => 'integer|min:0|max:1',
             ];
 
             if ($userData['id']) {


### PR DESCRIPTION
# Description
- locked should not be required when creating a new user. This caused not being able to create a new user.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
