### PR TITLE
Decline empty comment

### DIFF
--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -343,7 +343,7 @@ return [
     'shortcutCustumCSSLineLeft' => 'Verschiebt die markierte Zeile nach links',
     'shortcutCustumCSSLineRight' => 'Verschiebt die markierte Zeile nach rechts',
     'shortcutCustumCSSMultiEdit' => 'Markiert mit der Maus mehrere Zeilen zur gleichzeitigen Bearbeitung',
-    'shortcutCustumCSStoggleComment' => 'Zum auskommentieren von markierten Zeilen oder um die Kommentar wieder zu entfernen',
+    'shortcutCustumCSStoggleComment' => 'Zum Auskommentieren von markierten Zeilen oder um die Kommentar wieder zu entfernen',
 
     'menuLogs' => 'Protokoll',
     'hmenuLogs' => 'Protokoll',

--- a/application/modules/article/controllers/Index.php
+++ b/application/modules/article/controllers/Index.php
@@ -147,6 +147,12 @@ class Index extends \Ilch\Controller\Frontend
 
         if ($this->getUser() && $hasReadAccess && !$article->getCommentsDisabled()) {
             if ($this->getRequest()->getPost('saveComment')) {
+                if (!$this->getRequest()->getPost('comment_text')) {
+                    $this->redirect()
+                        ->withMessage('emptyCommentText', 'danger')
+                        ->to(['action' => 'show', 'id' => $this->getRequest()->getParam('id')]);
+                }
+
                 $comments = new Comments();
                 $key = sprintf(ArticleConfig::COMMENT_KEY_TPL, $this->getRequest()->getParam('id'));
 

--- a/application/modules/article/translations/de.php
+++ b/application/modules/article/translations/de.php
@@ -63,4 +63,5 @@ return [
     'clock' => 'Uhr',
     'rssDesc' => 'Alle Neuigkeiten von %s',
     'articleNotFound' => 'Artikel nicht gefunden.',
+    'emptyCommentText' => 'Sie haben für den Kommentar keinen Text eingegeben.',
 ];

--- a/application/modules/article/translations/en.php
+++ b/application/modules/article/translations/en.php
@@ -63,4 +63,5 @@ return [
     'clock' => 'o\'clock',
     'rssDesc' => 'All articles from %s',
     'articleNotFound' => 'Article not found.',
+    'emptyCommentText' => 'You have not entered any text for the comment.',
 ];

--- a/application/modules/user/controllers/Profil.php
+++ b/application/modules/user/controllers/Profil.php
@@ -42,6 +42,12 @@ class Profil extends \Ilch\Controller\Frontend
 
             if ($this->getUser() && $profil->getOptComments() && $profil->getAdminComments() && $commentsOnProfiles) {
                 if ($this->getRequest()->getPost('saveComment')) {
+                    if (!$this->getRequest()->getPost('comment_text')) {
+                        $this->redirect()
+                            ->withMessage('emptyCommentText', 'danger')
+                            ->to(['action' => 'index', 'user' => $this->getRequest()->getParam('user')]);
+                    }
+
                     $comments = new Comments();
                     $key = sprintf(UserConfig::COMMENT_KEY_TPL, $this->getRequest()->getParam('user'));
 

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -414,4 +414,6 @@ return [
     'grantedPermissionSuccess' => 'Die Erlaubnis Benachrichtigungen anzuzeigen wurde erfolgreich gegeben.',
     'noNotificationPermissions' => 'Keine Einträge vorhanden.',
     'notificationsAllTypes' => 'alle',
+
+    'emptyCommentText' => 'Sie haben für den Kommentar keinen Text eingegeben.',
 ];

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -414,4 +414,6 @@ return [
     'grantedPermissionSuccess' => 'Successfully granted the permission to issue notifications.',
     'noNotificationPermissions' => 'No entries existing.',
     'notificationsAllTypes' => 'all',
+
+    'emptyCommentText' => 'You have not entered any text for the comment.',
 ];


### PR DESCRIPTION
# Description
- Decline empty comment in article and user module.

```
PHP Fatal error:  Uncaught TypeError: Ilch\Comments::saveComment(): Argument #2 ($text) must be of type string, null given, called in application/modules/article/controllers/Index.php on line 157 and defined in application/libraries/Ilch/Comments.php:426
Stack trace:
#0 application/modules/article/controllers/Index.php(157): Ilch\Comments->saveComment()
#1 application/libraries/Ilch/Page.php(243): Modules\Article\Controllers\Index->showAction()
#2 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#3 index.php(68): Ilch\Page->loadPage()
#4 {main}
  thrown in application/libraries/Ilch/Comments.php on line 426, referer: index.php/article/index/show/id/1

PHP Fatal error:  Uncaught TypeError: Ilch\Comments::saveComment(): Argument #2 ($text) must be of type string, null given, called in application/modules/user/controllers/Profil.php on line 52 and defined in application/libraries/Ilch/Comments.php:426
Stack trace:
#0 application/modules/user/controllers/Profil.php(52): Ilch\Comments->saveComment()
#1 application/libraries/Ilch/Page.php(243): Modules\User\Controllers\Profil->indexAction()
#2 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#3 index.php(68): Ilch\Page->loadPage()
#4 {main}
  thrown in application/libraries/Ilch/Comments.php on line 426, referer: index.php/user/profil/index/user/1
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
