### PR TITLE
Newsletter: Redirect guest to login page

### DIFF
--- a/application/modules/newsletter/config/config.php
+++ b/application/modules/newsletter/config/config.php
@@ -13,7 +13,7 @@ class Config extends Install
 {
     public $config = [
         'key' => 'newsletter',
-        'version' => '1.8.0',
+        'version' => '1.8.1',
         'icon_small' => 'fa-regular fa-newspaper',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/newsletter/controllers/Index.php
+++ b/application/modules/newsletter/controllers/Index.php
@@ -34,12 +34,15 @@ class Index extends Frontend
             ]);
 
             if ($validation->isValid()) {
+                $date = new Date();
                 $countEmails = $subscriberMapper->countEmails($this->getRequest()->getPost('email'));
                 if ($countEmails == 0) {
                     $subscriberModel = new SubscriberModel();
                     $subscriberModel->setSelector(bin2hex(random_bytes(9)));
                     $subscriberModel->setConfirmCode(bin2hex(random_bytes(32)));
                     $subscriberModel->setEmail($this->getRequest()->getPost('email'));
+                    $subscriberModel->setDoubleOptInDate($date);
+                    $subscriberModel->setDoubleOptInConfirmed(!$this->getConfig()->get('newsletter_doubleOptIn'));
                     $subscriberMapper->saveSubscriber($subscriberModel);
                 }
 
@@ -131,6 +134,10 @@ class Index extends Frontend
 
     public function settingsAction()
     {
+        if (!$this->getUser()) {
+            $this->redirect(['module' => 'user', 'controller' => 'login', 'action' => 'index']);
+        }
+
         $subscriberMapper = new SubscriberMapper();
         $userMapper = new UserMapper();
         $UserMenuMapper = new UserMenuMapper();


### PR DESCRIPTION
# Description
- Redirect guests to login page when they try to view the newsletter settings.
- Set needed values for the Double-Opt-In feature.

```
PHP Fatal error:  Uncaught Error: Call to a member function getEmail() on null in application/modules/newsletter/controllers/Index.php:165
Stack trace:
#0 application/libraries/Ilch/Page.php(243): Modules\Newsletter\Controllers\Index->settingsAction()
#1 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#2 index.php(68): Ilch\Page->loadPage()
#3 {main}
  thrown in application/modules/newsletter/controllers/Index.php on line 165
```

```
PHP Fatal error:  Uncaught TypeError: Modules\Newsletter\Models\Subscriber::getDoubleOptInDate(): Return value must be of type string, null returned in application/modules/newsletter/models/Subscriber.php:159
Stack trace:
#0 application/modules/newsletter/mappers/Subscriber.php(174): Modules\Newsletter\Models\Subscriber->getDoubleOptInDate()
#1 application/modules/newsletter/controllers/Index.php(43): Modules\Newsletter\Mappers\Subscriber->saveSubscriber()
#2 application/libraries/Ilch/Page.php(243): Modules\Newsletter\Controllers\Index->indexAction()
#3 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#4 index.php(68): Ilch\Page->loadPage()
#5 {main}
  thrown in application/modules/newsletter/models/Subscriber.php on line 159, referer: index.php/newsletter
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
