### PR TITLE
Beta 2.2.5

### DIFF
--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -469,15 +469,13 @@ function group(string $file)
  */
 function validateDate(?string $date, string $format = 'Y-m-d H:i:s'): bool
 {
-    foreach (["\0", "%00"] as $nullByte) {
-        if ((0 === substr_compare($date ?? '', $nullByte, - 1))) {
-            // Return false when $date contains null bytes.
-            // This avoids "createFromFormat(): Argument must not contain any null bytes".
-            return false;
-        }
+    if (!$date || (strpos($date, chr(0)) !== false)) {
+        // Return false when $date contains null bytes.
+        // This avoids "createFromFormat(): Argument must not contain any null bytes".
+        return false;
     }
 
-    $d = DateTime::createFromFormat($format, $date ?? '');
+    $d = DateTime::createFromFormat($format, $date);
     return $d && $d->format($format) === $date;
 }
 

--- a/application/modules/shop/views/index/cart.php
+++ b/application/modules/shop/views/index/cart.php
@@ -31,7 +31,7 @@ if (!empty($_SESSION['shopping_cart']) && $this->getRequest()->isSecure()) {
             }
         }
 
-        $_SESSION['shopping_willCollect'] = $_POST['willCollect'];
+        $_SESSION['shopping_willCollect'] = $_POST['willCollect'] ?? null;
     }
 }
 

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@ header('Content-Type: text/html; charset=utf-8');
 $serverTimeZone = @date_default_timezone_get();
 date_default_timezone_set('UTC');
 
-define('VERSION', '2.2.4');
+define('VERSION', '2.2.5');
 define('SERVER_TIMEZONE', $serverTimeZone);
 define('DEFAULT_MODULE', 'page');
 define('DEFAULT_LAYOUT', 'index');

--- a/tests/libraries/ilch/FunctionsTest.php
+++ b/tests/libraries/ilch/FunctionsTest.php
@@ -264,6 +264,7 @@ class FunctionsTest extends TestCase
             'invalid null bytes middle' => ['params' => ['date' => 'test' . chr(0) . 'test', 'format' => 'Y-m-d H:i:s'], false],
             'invalid null bytes end' => ['params' => ['date' => 'test' . chr(0), 'format' => 'Y-m-d H:i:s'], false],
             'invalid zero date' => ['params' => ['date' => '0000-00-00 00:00:00', 'format' => 'Y-m-d H:i:s'], false],
+            'invalid date format' => ['params' => ['date' => '2024-10-27 04:42:04', 'format' => 'Y-m-d H:i'], false],
             'valid date' => ['params' => ['date' => '2024-10-27 04:42:04', 'format' => 'Y-m-d H:i:s'], true],
             'valid date without seconds' => ['params' => ['date' => '2024-10-27 04:42', 'format' => 'Y-m-d H:i'], true],
         ];

--- a/tests/libraries/ilch/FunctionsTest.php
+++ b/tests/libraries/ilch/FunctionsTest.php
@@ -239,4 +239,33 @@ class FunctionsTest extends TestCase
             'yottabytes' => ['params' => ['bytes' => 2417851639229258349412352, 'decimals' => 0], '2 YB'],
         ];
     }
+
+    /**
+     * Tests the validateDate function.
+     *
+     * @dataProvider dpForTestValidateDate
+     * @return void
+     */
+    public function testValidateDate(array $params, $expected)
+    {
+        self::assertSame($expected, validateDate($params['date'], $params['format']));
+    }
+
+    /**
+     * @return array
+     */
+    public function dpForTestValidateDate(): array
+    {
+        return [
+            'invalid empty string' => ['params' => ['date' => '', 'format' => 'Y-m-d H:i:s'], false],
+            'invalid null' => ['params' => ['date' => null, 'format' => 'Y-m-d H:i:s'], false],
+            'invalid null bytes' => ['params' => ['date' => chr(0), 'format' => 'Y-m-d H:i:s'], false],
+            'invalid null bytes beginning' => ['params' => ['date' => chr(0) . 'test', 'format' => 'Y-m-d H:i:s'], false],
+            'invalid null bytes middle' => ['params' => ['date' => 'test' . chr(0) . 'test', 'format' => 'Y-m-d H:i:s'], false],
+            'invalid null bytes end' => ['params' => ['date' => 'test' . chr(0), 'format' => 'Y-m-d H:i:s'], false],
+            'invalid zero date' => ['params' => ['date' => '0000-00-00 00:00:00', 'format' => 'Y-m-d H:i:s'], false],
+            'valid date' => ['params' => ['date' => '2024-10-27 04:42:04', 'format' => 'Y-m-d H:i:s'], true],
+            'valid date without seconds' => ['params' => ['date' => '2024-10-27 04:42', 'format' => 'Y-m-d H:i'], true],
+        ];
+    }
 }

--- a/tests/libraries/ilch/Validation/Validators/DateTest.php
+++ b/tests/libraries/ilch/Validation/Validators/DateTest.php
@@ -92,6 +92,12 @@ class DateTest extends TestCase
                 'expectedErrorKey'        => 'validation.errors.date.mustBeDate',
                 'expectedErrorParameters' => ['Y-m-d']
             ],
+            'empty string' => [
+                'data'                    => $this->createData(""),
+                'expectedIsValid'         => false,
+                'expectedErrorKey'        => 'validation.errors.date.mustBeDate',
+                'expectedErrorParameters' => ['Y-m-d']
+            ],
         ];
     }
 


### PR DESCRIPTION
**Version 2.2.5**  
**Änderungen**  
<u>Ilch:</u>  
- "Angemeldet bleiben?" beim Admin-Login ermöglichen.  
- Cookieconsent entfernt. Nutzen nun in Ilch und im Cookie-Richtlinien-Modul "Tarteaucitron" anstatt "Cookieconsent".  
- Kommentare nutzen nun, wie z.B. das Forum den CKEditor.  
- Die neue Konfigurationsmöglichkeit für die Domain wurde in einigen Fällen nicht angewendet.  
- Zwei Domains für Google Maps zur Liste sicherer Domains hinzugefügt.  
- Es lassen sich nun in den Einstellungen weitere Domains zur Liste sicherer Domains hinzufügen.  
- Zeitzonen (timezone)-Validator hinzugefügt. Unterstützt alle aktuell gültigen Zeitzonen und auf Wunsch für die Abwärtskompatibilität auch inzwischen nicht mehr gültige.  
- Es konnte eine ungültige Zeitzone im Admincenter in den Einstellungen gesetzt werden.  
- Fehler im Admincenter behoben, wenn alle Menüs gelöscht wurden.  
- Fehler im Admincenter bei nicht vorhandenen E-Mail-Vorlagen oder Vorlagen für deinstallierte Module behoben.  
- Mehrere Fehler behoben.  
- PHPMailer auf Version 6.9.2 aktualisiert.  
- CKEditor 5 auf Version 43.3.1 aktualisiert.  
- jQuery UI auf Version 1.14.1 aktualisiert.  
- HTMLPurifier auf Version 4.18.0 aktualisiert.  
**Artikel-Modul:**  
- Fehler bei ungültiger Artikel-ID im Admincenter behoben.  
**Benutzer-Modul:**  
- Vereinfachungen von Code, die durch Nutzung von Fremdschlüsseleinschränkungen ermöglicht wurden.  
- Kommentarfunktion auf der Profilseite von Benutzern eingebunden. Die Funktion kann auf Wunsch durch den Benutzer für seine Profilseite oder einem Administrator global, sowie für einen Benutzer aktiviert/deaktiviert werden. Kommentare können vom Benutzer oder einem Administrator gelöscht werden.  
- Fehler beim Laden von Profilfeldern behoben.  
- Ein eventuell doppelter "Link Zusatz" beim Typ "Icon" in der Ausgabe des Profilfeldes behoben.  
- Einen Fehler behoben, welcher auftrat, wenn versucht wurde einen nicht existierenden Dialog zu öffnen.  
- Fehler behoben, welcher auftrat, wenn versucht wurde einen neuen Dialog mit einem nicht existierenden Benutzer zu öffnen.  
- Fehler beim Versuch einen nicht existierenden Benutzer per E-Mail zu kontaktieren, behoben.  
- Mehrere Fehler behoben.  
- Verbesserungen am Code.  
**Cookie-Richtlinien-Modul:**  
- Nutze Tarteaucitron anstatt Cookieconsent.  
- Es können Dienste (Discord, Facebook, Google, ...) ausgewählt werden, die in den Dialog eingebunden werden sollen.  
**Kommentare-Modul:**  
- Fehler beim Anzeigen von Kommentaren deinstallierter Module behoben.
**Downloads-Modules (1.14.2):**  
- Kommentare beim Deinstallieren löschen.
**Veranstaltungen-Modules (1.23.3):**  
- Für Kommentare wird nun der CKEditor genutzt.
- Kommentarbereich wurde angezeigt, obwohl keine Kommentare vorhanden waren.
**Forum-Modules (1.35.3):**  
- Beiträge können nun deutlich länger sein.
**Galerie-Modules (1.23.3):**  
- Kommentare beim Deinstallieren löschen.
**Links-Modules (1.11.1):**  
- Fehler bei ungültiger Link-ID behoben.
**Newsletter-Modules (1.8.1):**  
- Gäste werden nun auf die Login-Seite weitergeleitet, wenn sie versuchen die Newsletter Einstellungen für Benutzer zu öffnen.  
- Einen Fehler im Zusammenhang mit der "Double-Opt-In"-Funktion behoben.
**Shop-Modules (1.3.3):**  
- Es konnte eine ungültige Währung in den Einstellungen der Standardwerte gesetzt werden.
- Einzelne Übersetzung geändert.
**Training-Modules (1.9.2):**  
- Benutze den Validator für mehr Eingaben.  
- Es wurden alle Eingaben hervorgehoben, anstatt nur die fehlende bzw. ungültige Eingabe.  
- Wenn "Voiceserver" oder "Gameserver" ausgewählt wurde, dann ist nun mindestens die Adresse erforderlich.  
- Weiterleitung bei negativen Ergebnis des Validators korrigiert.
**War-Modules (1.16.3):**  
- Kommentare beim Deinstallieren löschen.  
  
**Wie halte ich Ilch auf den aktuellen Stand?**  
<a href="https://github.com/IlchCMS/Ilch-2.0/wiki/Doku-Benutzer-Ilch-aktuell-halten" target="_blank">Doku Benutzer Ilch aktuell halten</a>