### PR TITLE
Teams: Fix argument not int in teams view

### DIFF
--- a/application/modules/teams/config/config.php
+++ b/application/modules/teams/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'teams',
-        'version' => '1.24.1',
+        'version' => '1.24.2',
         'icon_small' => 'fa-solid fa-users',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/teams/views/index/index.php
+++ b/application/modules/teams/views/index/index.php
@@ -34,8 +34,8 @@ $teams = $this->get('teams');
                     <div class="col-xl-12">
                         <?php
                         $groupList = $groupMapper->getUsersForGroup($team->getGroupId());
-                        $leaderIds = explode(',', $team->getLeader());
-                        $coLeaderIds = explode(',', $team->getCoLeader());
+                        $leaderIds = $team->getLeader() ? explode(',', $team->getLeader()) : [];
+                        $coLeaderIds = $team->getCoLeader() ? explode(',', $team->getCoLeader()) : [];
                         $groupList = array_unique(array_merge($leaderIds, $coLeaderIds, $groupList));
                         ?>
                         <div class="table-responsive">


### PR DESCRIPTION
# Description
- Fix argument not int in teams view

```
Uncaught TypeError: Modules\User\Mappers\User::getUserById(): Argument #1 ($id) must be of type int, string given, called in application/modules/teams/views/index/index.php on line 50 and defined in application/modules/user/mappers/User.php:24

Stack trace:
#0 application/modules/teams/views/index/index.php(50): Modules\User\Mappers\User->getUserById()
#1 application/libraries/Ilch/View.php(22): include('...')
#2 application/libraries/Ilch/Page.php(161): Ilch\View->loadScript()
#3 index.php(68): Ilch\Page->loadPage()
#4 {main} thrown in application/modules/user/mappers/User.php on line 24
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
