### PR TITLE
User: Add user group required info message

### DIFF
--- a/application/modules/user/controllers/admin/Index.php
+++ b/application/modules/user/controllers/admin/Index.php
@@ -297,6 +297,7 @@ class Index extends \Ilch\Controller\Admin
                 $user = $userMapper->loadFromArray($userData);
 
                 if (empty($userData['groups'])) {
+                    $this->addMessage('userGroupRequired', 'info');
                     $userData['groups'][0] = 2;
                 }
                 foreach ($userData['groups'] as $groupId) {

--- a/application/modules/user/translations/de.php
+++ b/application/modules/user/translations/de.php
@@ -49,6 +49,7 @@ return [
     'delUserMsg' => 'Der Benutzer wurde erfolgreich entfernt.',
     'delLastAdminProhibited' => 'Es ist nicht erlaubt den letzten aktiven Benutzer mit zugewiesener Gruppe "Administrator" zu entfernen.',
     'delOwnUserProhibited' => 'Es ist nicht erlaubt Ihren eigenen Benutzer zu entfernen.',
+    'userGroupRequired' => 'Ein Benutzer muss in mindestens einer Benutzergruppe sein. Es wurde die Benutzergruppe "User" zugewiesen.',
     'userNotFound' => 'Benutzer nicht gefunden.',
     'insufficientRightsToEditUser' => 'Sie haben nicht die nötigen Rechte um diesen Benutzer zu bearbeiten.',
     'menuSettingsGallery' => 'Galerie',

--- a/application/modules/user/translations/en.php
+++ b/application/modules/user/translations/en.php
@@ -49,6 +49,7 @@ return [
     'delUserMsg' => 'User got deleted successfully.',
     'delLastAdminProhibited' => 'It is not allowed to delete the last user with the group "Administrator" assigned.',
     'delOwnUserProhibited' => 'It is not allowed to delete the your own user.',
+    'userGroupRequired' => 'A user must be in at least one user group. User group "User" assigned.',
     'userNotFound' => 'User not found.',
     'insufficientRightsToEditUser' => 'You do not have permission to edit this user.',
     'menuSettingsGallery' => 'Gallery',


### PR DESCRIPTION
# Description
- Add user group required info message

When saving a user without a user group the user group "user" gets assigned by default. Added an info message as this might be unexpected.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
