### PR TITLE
Do not try to uninstall a system module and check module and layout key

### DIFF
--- a/application/modules/admin/controllers/admin/Layouts.php
+++ b/application/modules/admin/controllers/admin/Layouts.php
@@ -321,6 +321,7 @@ class Layouts extends \Ilch\Controller\Admin
 
         if (!$layoutKey || !file_exists(APPLICATION_PATH . '/layouts/' . $layoutKey . '/config/config.php')) {
             $this->redirect()
+                ->withMessage('layoutNotFoundOrInvalid', 'danger')
                 ->to(['action' => 'advSettings']);
         }
 

--- a/application/modules/admin/controllers/admin/Layouts.php
+++ b/application/modules/admin/controllers/admin/Layouts.php
@@ -318,11 +318,18 @@ class Layouts extends \Ilch\Controller\Admin
     public function advSettingsShowAction()
     {
         $layoutKey = $this->getRequest()->getParam('layoutKey');
+
+        if (!$layoutKey || !file_exists(APPLICATION_PATH . '/layouts/' . $layoutKey . '/config/config.php')) {
+            $this->redirect()
+                ->to(['action' => 'advSettings']);
+        }
+
         $this->getLayout()->getAdminHmenu()
             ->add($this->getTranslator()->trans('menuLayouts'), ['action' => 'index'])
             ->add($this->getTranslator()->trans('menuSettings'), ['action' => 'settings'])
             ->add($this->getTranslator()->trans('menuAdvSettings'), ['action' => 'advSettings'])
             ->add($this->getTranslator()->trans('menuAdvSettingsShow'), ['action' => 'advSettings', 'layoutKey' => $layoutKey]);
+
         $settings = [];
         $layoutPath = APPLICATION_PATH . '/layouts/' . $layoutKey;
         if (is_dir($layoutPath)) {

--- a/application/modules/admin/controllers/admin/Modules.php
+++ b/application/modules/admin/controllers/admin/Modules.php
@@ -421,7 +421,7 @@ class Modules extends \Ilch\Controller\Admin
         $key = $this->getRequest()->getParam('key');
 
         if ($this->getRequest()->isSecure()) {
-            if (file_exists(APPLICATION_PATH . '/modules/' . $key . '/config/config.php')) {
+            if ($key && file_exists(APPLICATION_PATH . '/modules/' . $key . '/config/config.php')) {
                 $configClass = '\\Modules\\' . ucfirst($key) . '\\Config\\Config';
                 $config = new $configClass($this->getTranslator());
 
@@ -429,8 +429,12 @@ class Modules extends \Ilch\Controller\Admin
                     $config->uninstall();
                     $moduleMapper->delete($key);
 
-                    $this->addMessage('deleteSuccess');
+                    $this->addMessage('uninstallSuccess');
+                } else {
+                    $this->addMessage('uninstallDeniedSystemModule', 'danger');
                 }
+            } else {
+                $this->addMessage('moduleNotFoundOrInvalid', 'danger');
             }
         }
 

--- a/application/modules/admin/controllers/admin/Modules.php
+++ b/application/modules/admin/controllers/admin/Modules.php
@@ -234,7 +234,6 @@ class Modules extends \Ilch\Controller\Admin
 
         foreach (glob(ROOT_PATH . '/application/modules/*') as $modulesPath) {
             $key = basename($modulesPath);
-            $modulesDir[] = $key;
 
             $configClass = '\\Modules\\' . ucfirst($key) . '\\Config\\Config';
             if (class_exists($configClass)) {
@@ -424,10 +423,13 @@ class Modules extends \Ilch\Controller\Admin
         if ($this->getRequest()->isSecure()) {
             $configClass = '\\Modules\\' . ucfirst($key) . '\\Config\\Config';
             $config = new $configClass($this->getTranslator());
-            $config->uninstall();
-            $moduleMapper->delete($key);
 
-            $this->addMessage('deleteSuccess');
+            if (!isset($config->config['system_module'])) {
+                $config->uninstall();
+                $moduleMapper->delete($key);
+
+                $this->addMessage('deleteSuccess');
+            }
         }
 
         $this->redirect(['action' => 'index']);

--- a/application/modules/admin/controllers/admin/Modules.php
+++ b/application/modules/admin/controllers/admin/Modules.php
@@ -421,14 +421,16 @@ class Modules extends \Ilch\Controller\Admin
         $key = $this->getRequest()->getParam('key');
 
         if ($this->getRequest()->isSecure()) {
-            $configClass = '\\Modules\\' . ucfirst($key) . '\\Config\\Config';
-            $config = new $configClass($this->getTranslator());
+            if (file_exists(APPLICATION_PATH . '/modules/' . $key . '/config/config.php')) {
+                $configClass = '\\Modules\\' . ucfirst($key) . '\\Config\\Config';
+                $config = new $configClass($this->getTranslator());
 
-            if (!isset($config->config['system_module'])) {
-                $config->uninstall();
-                $moduleMapper->delete($key);
+                if (!isset($config->config['system_module'])) {
+                    $config->uninstall();
+                    $moduleMapper->delete($key);
 
-                $this->addMessage('deleteSuccess');
+                    $this->addMessage('deleteSuccess');
+                }
             }
         }
 

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -385,6 +385,8 @@ return [
     'moduleUpdateFailed' => 'Modul konnte nicht aktualisiert werden.',
     'downloadOrInstallDenied' => 'Aufgrund einer ungültigen Internetadresse wurde das Herunterladen oder Installieren des Updates nicht durchgeführt.',
     'processingPleaseWait' => 'Verarbeite. Bitte warten.',
+    'uninstallDeniedSystemModule' => 'Ein Systemmodul kann nicht deinstalliert werden.',
+    'moduleNotFoundOrInvalid' => 'Modul nicht gefunden oder ungültig.',
 
     'enableSelectedEntries' => 'Sollen die markierten Einträge wirklich freigeschaltet werden?',
     'deleteSelectedEntries' => 'Sollen die markierten Einträge wirklich gelöscht werden?',
@@ -434,6 +436,7 @@ return [
     'menuAdvSettings' => 'Erweiterte Einstellungen',
     'menuAdvSettingsShow' => 'Anzeige',
     'noLayouts' => 'Keine Layouts mit erweiterten Einstellungen gefunden.',
+    'layoutNotFoundOrInvalid' => 'Layout nicht gefunden oder ungültig.',
     'orphanedSettings' => 'Es wurden Einstellungen für nicht vorhandene Layouts gefunden. Diese können unten gelöscht werden.',
     'deleteOrphanedSettings' => 'Lösche verwaiste Einstellungen',
 ];

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -385,6 +385,8 @@ return [
     'moduleUpdateFailed' => 'The update of the module failed.',
     'downloadOrInstallDenied' => 'Due to an invalid web address the update was not downloaded or installed.',
     'processingPleaseWait' => 'Processing. Please wait.',
+    'uninstallDeniedSystemModule' => 'An system module cannot be uninstalled.',
+    'moduleNotFoundOrInvalid' => 'Module not found or invalid.',
 
     'enableSelectedEntries' => 'Enable the selected entries?',
     'deleteSelectedEntries' => 'Delete the selected entries?',
@@ -434,6 +436,7 @@ return [
     'menuAdvSettings' => 'Advanced Settings',
     'menuAdvSettingsShow' => 'Show',
     'noLayouts' => 'No layouts with advanced settings found.',
+    'layoutNotFoundOrInvalid' => 'Layout not found or invalid.',
     'orphanedSettings' => 'Settings have been found for not existing layouts. These can be deleted below.',
     'deleteOrphanedSettings' => 'Delete orphaned settings',
 ];


### PR DESCRIPTION
# Description
- Do not try to uninstall a system module.
- Fix error on uninstall action with invalid module key.
- Check if layoutKey could be valid.
- Add error messages and use correct message for uninstall.
- Remove dead variable.

```
Fatal error: Uncaught Error: Class '\Modules\Aaaa\Config\Config' not found in application/modules/admin/controllers/admin/Modules.php:425

Stack trace:
#0 application/libraries/Ilch/Page.php(243): Modules\Admin\Controllers\Admin\Modules->uninstallAction()
#1 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#2 index.php(68): Ilch\Page->loadPage()
#3 {main}
    thrown in application/modules/admin/controllers/admin/Modules.php on line 425
```

```
PHP Fatal error:  Uncaught Error: Class "\Layouts\Layouts\Config\Config" not found in application/modules/admin/controllers/admin/Layouts.php:330
Stack trace:
#0 application/libraries/Ilch/Page.php(243): Modules\Admin\Controllers\Admin\Layouts->advSettingsShowAction()
#1 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#2 index.php(68): Ilch\Page->loadPage()
#3 {main}
  thrown in application/modules/admin/controllers/admin/Layouts.php on line 330
```

ToDo:
- ...


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
