### PR TITLE
Add FKCs to the modules tables

### DIFF
--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -77,7 +77,7 @@ class Config extends \Ilch\Config\Install
                 `autoload` TINYINT(1) NOT NULL,
                 UNIQUE KEY `key` (`key`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_emails` (
                 `moduleKey` VARCHAR(255) NOT NULL,
                 `type` VARCHAR(255) NOT NULL,
@@ -85,7 +85,7 @@ class Config extends \Ilch\Config\Install
                 `text` TEXT NOT NULL,
                 `locale` VARCHAR(255) NOT NULL
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_modules` (
                 `key` VARCHAR(191) NOT NULL,
                 `system` TINYINT(1) NOT NULL DEFAULT 0,
@@ -97,37 +97,43 @@ class Config extends \Ilch\Config\Install
                 `icon_small` VARCHAR(255) NOT NULL,
                 UNIQUE KEY `key` (`key`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_modules_content` (
                 `key` VARCHAR(191) NOT NULL,
                 `locale` VARCHAR(255) NOT NULL,
                 `description` VARCHAR(255) NOT NULL,
-                `name` VARCHAR(255) NOT NULL
+                `name` VARCHAR(255) NOT NULL,
+                INDEX `FK_[prefix]_modules_content_[prefix]_modules` (`key`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_modules_content_[prefix]_modules` FOREIGN KEY (`key`) REFERENCES `[prefix]_modules` (`key`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_modules_php_extensions` (
                 `key` VARCHAR(191) NOT NULL,
-                `extension` VARCHAR(255) NOT NULL
+                `extension` VARCHAR(255) NOT NULL,
+                INDEX `FK_[prefix]_modules_php_extensions_[prefix]_modules` (`key`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_modules_php_extensions_[prefix]_modules` FOREIGN KEY (`key`) REFERENCES `[prefix]_modules` (`key`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_modules_folderrights` (
                 `key` VARCHAR(191) NOT NULL,
-                `folder` VARCHAR(255) NOT NULL
+                `folder` VARCHAR(255) NOT NULL,
+                INDEX `FK_[prefix]_modules_folderrights_[prefix]_modules` (`key`) USING BTREE,
+                CONSTRAINT `FK_[prefix]_modules_folderrights_[prefix]_modules` FOREIGN KEY (`key`) REFERENCES `[prefix]_modules` (`key`) ON UPDATE NO ACTION ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_modules_boxes_content` (
                 `key` VARCHAR(255) NOT NULL,
                 `module` VARCHAR(255) NOT NULL,
                 `locale` VARCHAR(255) NOT NULL,
                 `name` VARCHAR(255) NOT NULL
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_menu` (
                 `id` INT(11) NOT NULL AUTO_INCREMENT,
                 `title` VARCHAR(255) NOT NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_menu_items` (
                 `id` INT(11) NOT NULL AUTO_INCREMENT,
                 `menu_id` INT(11) NOT NULL,
@@ -144,26 +150,26 @@ class Config extends \Ilch\Config\Install
                 `access` VARCHAR(255) NOT NULL DEFAULT "",
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_boxes` (
                 `id` INT(11) NOT NULL AUTO_INCREMENT,
                 `date_created` DATETIME NOT NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_boxes_content` (
                 `box_id` INT(11) NOT NULL,
                 `content` MEDIUMTEXT NOT NULL,
                 `locale` VARCHAR(255) NOT NULL,
                 `title` VARCHAR(255) NOT NULL
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_pages` (
                 `id` INT(11) NOT NULL AUTO_INCREMENT,
                 `date_created` DATETIME NOT NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_pages_content` (
                 `page_id` INT(11) NOT NULL,
                 `content` MEDIUMTEXT NOT NULL,
@@ -173,20 +179,20 @@ class Config extends \Ilch\Config\Install
                 `title` VARCHAR(255) NOT NULL,
                 `perma` VARCHAR(255) NOT NULL
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_backup` (
                 `id` INT(11) NOT NULL AUTO_INCREMENT,
                 `name` VARCHAR(255) NOT NULL,
                 `date` DATETIME NOT NULL,
             PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_logs` (
                 `user_id` VARCHAR(255) NOT NULL,
                 `date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 `info` VARCHAR(255) NOT NULL
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_admin_layoutadvsettings` (
                 `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
                 `layoutKey` VARCHAR(255) NOT NULL,
@@ -194,7 +200,7 @@ class Config extends \Ilch\Config\Install
                 `value` TEXT NOT NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_admin_notifications` (
                 `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
                 `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -204,13 +210,13 @@ class Config extends \Ilch\Config\Install
                 `type` VARCHAR(255) NOT NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_admin_notifications_permission` (
                 `module` VARCHAR(255) NOT NULL,
                 `granted` TINYINT(1) NOT NULL,
                 `limit` TINYINT(1) UNSIGNED NOT NULL
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-            
+
             CREATE TABLE IF NOT EXISTS `[prefix]_admin_updateservers` (
                 `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
                 `url` VARCHAR(255) NOT NULL,
@@ -218,7 +224,7 @@ class Config extends \Ilch\Config\Install
                 `country` VARCHAR(255) NOT NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-            
+
             INSERT INTO `[prefix]_admin_updateservers` (`id`, `url`, `operator`, `country`) VALUES (1, "https://www.ilch.de/ilch2_updates/stable/", "ilch", "Germany");
             INSERT INTO `[prefix]_admin_updateservers` (`id`, `url`, `operator`, `country`) VALUES (2, "https://ilch.blackcoder.de/stable/", "ilch", "Germany");';
     }

--- a/application/modules/admin/mappers/Module.php
+++ b/application/modules/admin/mappers/Module.php
@@ -280,10 +280,6 @@ class Module extends \Ilch\Mapper
             ->where(['key' => $key])
             ->execute();
 
-        $this->db()->delete('modules_content')
-            ->where(['key' => $key])
-            ->execute();
-
         $this->db()->delete('modules_boxes_content')
             ->where(['module' => $key])
             ->execute();

--- a/application/modules/admin/mappers/Module.php
+++ b/application/modules/admin/mappers/Module.php
@@ -279,5 +279,6 @@ class Module extends \Ilch\Mapper
         $this->db()->delete('modules')
             ->where(['key' => $key])
             ->execute();
+        // Rows in modules_boxes_content, modules_content, modules_folderrights and modules_php_extensions are being deleted due to FKCs.
     }
 }

--- a/application/modules/admin/mappers/Module.php
+++ b/application/modules/admin/mappers/Module.php
@@ -279,9 +279,5 @@ class Module extends \Ilch\Mapper
         $this->db()->delete('modules')
             ->where(['key' => $key])
             ->execute();
-
-        $this->db()->delete('modules_boxes_content')
-            ->where(['module' => $key])
-            ->execute();
     }
 }

--- a/application/modules/install/config/config.php
+++ b/application/modules/install/config/config.php
@@ -5,24 +5,22 @@
  * @package ilch
  */
 
-namespace Modules\Error\Config;
+namespace Modules\Install\Config;
 
 class Config extends \Ilch\Config\Install
 {
     public $config = [
-        'key' => 'error',
+        'key' => 'install',
         'system_module' => true
     ];
 
     public function install()
     {
+
     }
 
-    public function getInstallSql()
+    public function getUpdate($installedVersion)
     {
-    }
 
-    public function getUpdate(string $installedVersion)
-    {
     }
 }

--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -386,7 +386,7 @@ class Index extends \Ilch\Controller\Frontend
     public function configurationAction()
     {
         $fields = ['usage' => '', 'domain' => '', 'adminName' => '', 'adminPassword' => '', 'adminPassword2' => '', 'adminEmail' => ''];
-        $systemModules = ['admin', 'article', 'user', 'media', 'comment', 'imprint', 'contact', 'privacy', 'statistic', 'cookieconsent'];
+        $systemModules = ['admin', 'article', 'comment', 'contact', 'cookieconsent', 'error', 'imprint', 'install', 'media', 'privacy', 'statistic', 'user'];
 
         if ($this->getRequest()->isPost()) {
             $validation = Validation::create($this->getRequest()->getPost(), [
@@ -441,32 +441,32 @@ class Index extends \Ilch\Controller\Frontend
                     $config->install();
 
                     if (!empty($config->config)) {
-                        if ($config->config['key'] !== 'admin') {
-                            $moduleModel = new \Modules\Admin\Models\Module();
-                            $moduleModel->setKey($config->config['key']);
-                            if (isset($config->config['author'])) {
-                                $moduleModel->setAuthor($config->config['author']);
-                            }
-                            if (isset($config->config['link'])) {
-                                $moduleModel->setLink($config->config['link']);
-                            }
-                            if (isset($config->config['languages'])) {
-                                foreach ($config->config['languages'] as $key => $value) {
-                                    $moduleModel->addContent($key, $value);
-                                }
-                            }
-                            if (isset($config->config['system_module'])) {
-                                $moduleModel->setSystemModule(true);
-                            }
-                            if (isset($config->config['hide_menu'])) {
-                                $moduleModel->setHideMenu(true);
-                            }
-                            if (isset($config->config['version'])) {
-                                $moduleModel->setVersion($config->config['version']);
-                            }
-                            $moduleModel->setIconSmall($config->config['icon_small']);
-                            $moduleMapper->save($moduleModel);
+                        $moduleModel = new \Modules\Admin\Models\Module();
+                        $moduleModel->setKey($config->config['key']);
+                        if (isset($config->config['author'])) {
+                            $moduleModel->setAuthor($config->config['author']);
                         }
+                        if (isset($config->config['link'])) {
+                            $moduleModel->setLink($config->config['link']);
+                        }
+                        if (isset($config->config['languages'])) {
+                            foreach ($config->config['languages'] as $key => $value) {
+                                $moduleModel->addContent($key, $value);
+                            }
+                        }
+                        if (isset($config->config['system_module'])) {
+                            $moduleModel->setSystemModule(true);
+                        }
+                        if (isset($config->config['hide_menu'])) {
+                            $moduleModel->setHideMenu(true);
+                        }
+                        if (isset($config->config['version'])) {
+                            $moduleModel->setVersion($config->config['version']);
+                        }
+                        if (isset($config->config['icon_small'])) {
+                            $moduleModel->setIconSmall($config->config['icon_small']);
+                        }
+                        $moduleMapper->save($moduleModel);
 
                         if (isset($config->config['boxes'])) {
                             $boxModel = new \Modules\Admin\Models\Box();
@@ -500,7 +500,7 @@ class Index extends \Ilch\Controller\Frontend
 
                 foreach ($modulesToInstall as $module) {
                     // Will not be linked in the menu
-                    if (in_array($module, ['comment', 'shoutbox', 'admin', 'media', 'newsletter', 'statistic', 'cookieconsent', 'error', 'contact', 'imprint', 'privacy'])) {
+                    if (in_array($module, ['admin', 'comment', 'contact', 'cookieconsent', 'error', 'imprint', 'install', 'media', 'newsletter', 'privacy', 'shoutbox', 'statistic'])) {
                         continue;
                     }
 


### PR DESCRIPTION
# Description
- Add FKCs to the modules tables (modules_boxes_content, modules_content, modules_folderrights, modules_php_extensions).
- Add all modules to modules table (this was required for the FKC for modules_boxes_content and is done in the install module).
- Add config.php for install module.
- Remove some info from config.php of error module as it would otherwise be added to the module menu.

**table:** modules_boxes_content, **column:** modules
**table:** modules_content, **column:** key
**table:** modules_folderrights, **column:** key
**table:** modules_php_extensions, **column:** key

> The column key of modules_boxes_content is not a module key (examples: lastwar, nexttraining, ...).
> ~~The column module of modules_boxes_content previously could contain module keys that where not in the modules table (example: admin).~~
> The column module_key of menu_items contains values that are not module_keys (example: "", undefined).

## ToDo:
- ~~The column module of modules_boxes_content can contain module keys that are not in the modules table. Add all modules to the modules table?~~
- ~~deleteItemsByModuleKey: Second parameter parentId?~~ (left as is)
https://github.com/IlchCMS/Ilch-2.0/blob/master/application/modules/admin/mappers/Menu.php#L272

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
