### PR TITLE
Admincenter: Fix error when check for module updates failed

### DIFF
--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -261,6 +261,7 @@ return [
     'lastUpdateUnknown' => 'unbekannt',
     'lastUpdateError' => 'Abfrage des Updateservers fehlgeschlagen.',
     'layoutModuleNotInstalled' => 'Das dazugehörige Modul ist nicht installiert.',
+    'checkForModuleUpdatesFailed' => 'Abfrage des Updateservers auf Modul-Updates fehlgeschlagen.',
 
     'menuInfos' => 'Informationen',
     'menuPHPInfo' => 'PHP Info',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -261,6 +261,7 @@ return [
     'lastUpdateUnknown' => 'unknown',
     'lastUpdateError' => 'Querying the updateserver failed.',
     'layoutModuleNotInstalled' => 'The associated module is not installed.',
+    'checkForModuleUpdatesFailed' => 'Querying the updateserver for modules updates failed.',
 
     'menuInfos' => 'Information',
     'menuPHPInfo' => 'PHP Info',


### PR DESCRIPTION
# Description
- Fix error when check for module updates failed

```
Invalid argument supplied for foreach() in application/modules/admin/controllers/admin/Index.php:60
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
