### PR TITLE
Away: Fix broken user group notification feature

### DIFF
--- a/application/modules/away/config/config.php
+++ b/application/modules/away/config/config.php
@@ -26,8 +26,8 @@ class Config extends \Ilch\Config\Install
                 'description' => 'User can enter when they are away (e.g. on holidays). There is an overview of this and the entries can be mananged in the admincenter.',
             ],
         ],
-        'ilchCore' => '2.2.0',
-        'phpVersion' => '7.3'
+        'ilchCore' => '2.2.7',
+        'phpVersion' => '7.4'
     ];
 
     public function install()

--- a/application/modules/away/controllers/Index.php
+++ b/application/modules/away/controllers/Index.php
@@ -154,7 +154,6 @@ class Index extends \Ilch\Controller\Frontend
                 $notifications = [];
                 $userGroups = $awayGroupMapper->getGroups();
                 $users = $userMapper->getUserListByGroupIds($userGroups, 1);
-                // Users might be in several groups. Remove duplicates so each user only gets one notification.
                 $currentUserId = $this->getUser()->getId();
 
                 foreach ($users as $user) {

--- a/application/modules/away/controllers/Index.php
+++ b/application/modules/away/controllers/Index.php
@@ -93,7 +93,6 @@ class Index extends \Ilch\Controller\Frontend
                     $userGroups = $awayGroupMapper->getGroups();
                     $users = $userMapper->getUserListByGroupIds($userGroups, 1);
                     // Users might be in several groups. Remove duplicates so each user only gets one notification.
-                    $users = array_unique($users, SORT_REGULAR);
                     $currentUserId = $this->getUser()->getId();
 
                     foreach ($users as $user) {
@@ -157,7 +156,6 @@ class Index extends \Ilch\Controller\Frontend
                 $userGroups = $awayGroupMapper->getGroups();
                 $users = $userMapper->getUserListByGroupIds($userGroups, 1);
                 // Users might be in several groups. Remove duplicates so each user only gets one notification.
-                $users = array_unique($users, SORT_REGULAR);
                 $currentUserId = $this->getUser()->getId();
 
                 foreach ($users as $user) {

--- a/application/modules/away/controllers/Index.php
+++ b/application/modules/away/controllers/Index.php
@@ -91,7 +91,7 @@ class Index extends \Ilch\Controller\Frontend
 
                     $notifications = [];
                     $userGroups = $awayGroupMapper->getGroups();
-                    $users = $userMapper->getUserListByGroupId($userGroups, 1);
+                    $users = $userMapper->getUserListByGroupIds($userGroups, 1);
                     // Users might be in several groups. Remove duplicates so each user only gets one notification.
                     $users = array_unique($users, SORT_REGULAR);
                     $currentUserId = $this->getUser()->getId();
@@ -155,7 +155,7 @@ class Index extends \Ilch\Controller\Frontend
 
                 $notifications = [];
                 $userGroups = $awayGroupMapper->getGroups();
-                $users = $userMapper->getUserListByGroupId($userGroups, 1);
+                $users = $userMapper->getUserListByGroupIds($userGroups, 1);
                 // Users might be in several groups. Remove duplicates so each user only gets one notification.
                 $users = array_unique($users, SORT_REGULAR);
                 $currentUserId = $this->getUser()->getId();

--- a/application/modules/away/controllers/Index.php
+++ b/application/modules/away/controllers/Index.php
@@ -92,7 +92,6 @@ class Index extends \Ilch\Controller\Frontend
                     $notifications = [];
                     $userGroups = $awayGroupMapper->getGroups();
                     $users = $userMapper->getUserListByGroupIds($userGroups, 1);
-                    // Users might be in several groups. Remove duplicates so each user only gets one notification.
                     $currentUserId = $this->getUser()->getId();
 
                     foreach ($users as $user) {

--- a/application/modules/away/controllers/admin/Index.php
+++ b/application/modules/away/controllers/admin/Index.php
@@ -79,7 +79,7 @@ class Index extends \Ilch\Controller\Admin
 
                 $notifications = [];
                 $userGroups = $awayGroupMapper->getGroups();
-                $users = $userMapper->getUserListByGroupId($userGroups, 1);
+                $users = $userMapper->getUserListByGroupIds($userGroups, 1);
                 // Users might be in several groups. Remove duplicates so each user only gets one notification.
                 $users = array_unique($users, SORT_REGULAR);
                 $currentUserId = $this->getUser()->getId();

--- a/application/modules/away/controllers/admin/Index.php
+++ b/application/modules/away/controllers/admin/Index.php
@@ -80,7 +80,6 @@ class Index extends \Ilch\Controller\Admin
                 $notifications = [];
                 $userGroups = $awayGroupMapper->getGroups();
                 $users = $userMapper->getUserListByGroupIds($userGroups, 1);
-                // Users might be in several groups. Remove duplicates so each user only gets one notification.
                 $currentUserId = $this->getUser()->getId();
 
                 foreach ($users as $user) {

--- a/application/modules/away/controllers/admin/Index.php
+++ b/application/modules/away/controllers/admin/Index.php
@@ -81,7 +81,6 @@ class Index extends \Ilch\Controller\Admin
                 $userGroups = $awayGroupMapper->getGroups();
                 $users = $userMapper->getUserListByGroupIds($userGroups, 1);
                 // Users might be in several groups. Remove duplicates so each user only gets one notification.
-                $users = array_unique($users, SORT_REGULAR);
                 $currentUserId = $this->getUser()->getId();
 
                 foreach ($users as $user) {

--- a/application/modules/user/mappers/User.php
+++ b/application/modules/user/mappers/User.php
@@ -118,7 +118,6 @@ class User extends \Ilch\Mapper
 
     /**
      * Get users (not all fields) by group ids. The users have to be in at least one of the groups.
-     * This will return duplicated users if a user is in multiple of the groups.
      *
      * @param int[] $groupIds array of group ids.
      * @param int $confirmed
@@ -133,7 +132,8 @@ class User extends \Ilch\Mapper
             ->from(['u' => 'users'])
             ->join(['g' => 'users_groups'], 'u.id = g.user_id', 'LEFT', ['group_id' => 'g.group_id'])
             ->where(['group_id' => $groupIds], 'or')
-            ->andWhere(['confirmed' => $confirmed]);
+            ->andWhere(['confirmed' => $confirmed])
+            ->group(['u.id']);
         if ($pagination !== null) {
             $select->limit($pagination->getLimit())
                 ->useFoundRows();

--- a/application/modules/user/mappers/User.php
+++ b/application/modules/user/mappers/User.php
@@ -113,11 +113,27 @@ class User extends \Ilch\Mapper
      */
     public function getUserListByGroupId(int $groupId, int $confirmed = 0, $pagination = null): array
     {
+        return $this->getUserListByGroupIds([$groupId], $confirmed, $pagination);
+    }
+
+    /**
+     * Get users (not all fields) by group ids. The users have to be in at least one of the groups.
+     * This will return duplicated users if a user is in multiple of the groups.
+     *
+     * @param int[] $groupIds array of group ids.
+     * @param int $confirmed
+     * @param $pagination
+     * @return array
+     * @since 2.2.7
+     */
+    public function getUserListByGroupIds(array $groupIds, int $confirmed = 0, $pagination = null): array
+    {
         $select = $this->db()->select()
             ->fields(['u.id', 'u.name', 'u.opt_mail', 'u.date_created', 'u.date_last_activity', 'u.confirmed'])
             ->from(['u' => 'users'])
             ->join(['g' => 'users_groups'], 'u.id = g.user_id', 'LEFT', ['group_id' => 'g.group_id'])
-            ->where(['group_id' => $groupId, 'confirmed' => $confirmed]);
+            ->where(['group_id' => $groupIds], 'or')
+            ->andWhere(['confirmed' => $confirmed]);
         if ($pagination !== null) {
             $select->limit($pagination->getLimit())
                 ->useFoundRows();

--- a/tests/modules/user/mappers/UserTest.php
+++ b/tests/modules/user/mappers/UserTest.php
@@ -71,17 +71,15 @@ class UserTest extends DatabaseTestCase
         /** @var \Modules\User\Models\User[] $users */
         $users = $userMapper->getUserListByGroupIds([1, 3], 1);
         self::assertNotEmpty($users);
+        self::assertCount(2, $users);
+
         self::assertEquals(1, $users[0]->getId());
         self::assertEquals('Testuser1', $users[0]->getName());
         self::assertEquals(1, $users[0]->getConfirmed());
 
-        self::assertEquals(1, $users[1]->getId());
-        self::assertEquals('Testuser1', $users[1]->getName());
+        self::assertEquals(2, $users[1]->getId());
+        self::assertEquals('Testuser2', $users[1]->getName());
         self::assertEquals(1, $users[1]->getConfirmed());
-
-        self::assertEquals(2, $users[2]->getId());
-        self::assertEquals('Testuser2', $users[2]->getName());
-        self::assertEquals(1, $users[2]->getConfirmed());
     }
 
     /**

--- a/tests/modules/user/mappers/UserTest.php
+++ b/tests/modules/user/mappers/UserTest.php
@@ -43,6 +43,48 @@ class UserTest extends DatabaseTestCase
     }
 
     /**
+     * Test getUserListByGroupId to see if the correct user will be returned.
+     *
+     * @return void
+     */
+    public function testGetUserListByGroupId()
+    {
+        $userMapper = new UserMapper();
+
+        /** @var \Modules\User\Models\User[] $users */
+        $users = $userMapper->getUserListByGroupId(1, 1);
+        self::assertNotEmpty($users);
+        self::assertEquals(1, $users[0]->getId());
+        self::assertEquals('Testuser1', $users[0]->getName());
+        self::assertEquals(1, $users[0]->getConfirmed());
+    }
+
+    /**
+     * Test getUserListByGroupIds to see if the correct users will be returned.
+     *
+     * @return void
+     */
+    public function testGetUserListByGroupIds()
+    {
+        $userMapper = new UserMapper();
+
+        /** @var \Modules\User\Models\User[] $users */
+        $users = $userMapper->getUserListByGroupIds([1, 3], 1);
+        self::assertNotEmpty($users);
+        self::assertEquals(1, $users[0]->getId());
+        self::assertEquals('Testuser1', $users[0]->getName());
+        self::assertEquals(1, $users[0]->getConfirmed());
+
+        self::assertEquals(1, $users[1]->getId());
+        self::assertEquals('Testuser1', $users[1]->getName());
+        self::assertEquals(1, $users[1]->getConfirmed());
+
+        self::assertEquals(2, $users[2]->getId());
+        self::assertEquals('Testuser2', $users[2]->getName());
+        self::assertEquals(1, $users[2]->getConfirmed());
+    }
+
+    /**
      * Returns database schema sql statements to initialize database
      *
      * @return string


### PR DESCRIPTION
# Description
- Add getUserListByGroupIds() to user mapper and use that function in the away module.
- Require ilchCore 2.2.7 for the away module.
- Add unit tests for getUserListByGroupIds() and getUserListByGroupId().

Mit dem jetzt angegebenen Datentyp "int" für groupId tritt folgender Fehler auf:
```
Uncaught TypeError: Argument 1 passed to Modules\User\Mappers\User::getUserListByGroupId() must be of the type int, array given, called in application/modules/away/controllers/Index.php on line 93 and defined in application/modules/user/mappers/User.php:114
Stack trace:
#0 application/modules/away/controllers/Index.php(93): Modules\User\Mappers\User->getUserListByGroupId()
#1 application/libraries/Ilch/Page.php(243): Modules\Away\Controllers\Index->indexAction()
#2 application/libraries/Ilch/Page.php(137): Ilch\Page->loadController()
#3 index.php(68): Ilch\Page->loadPage()
#4 {main}
  thrown in application/modules/user/mappers/User.php on line 114
```

Vorher trat kein Fehler auf, aber es hat nicht wie gewünscht funktioniert. Die Benutzergruppen wurden "und"-Verknüpft. Der Benutzer hat die Benachrichtigung nur bekommen, wenn er in allen Benutzergruppen war.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
