### PR TITLE
User: Fix error when handling profile link addition

### DIFF
--- a/application/modules/user/views/index/index.php
+++ b/application/modules/user/views/index/index.php
@@ -106,11 +106,11 @@ $userAvatarList_allowed = $this->get('userAvatarList_allowed');
                                                 $pos = strpos($profileFieldContent->getValue(), $profileIconField->getAddition());
 
                                                 if ($pos !== false) {
-                                                    $profileFieldContentValue = substr_replace($profileFieldContent->getValue(), '', $pos, $profileIconField->getAddition());
+                                                    $profileFieldContentValue = substr_replace($profileFieldContent->getValue(), '', $pos, strlen($profileIconField->getAddition()));
                                                 }
                                             }
 
-                                            echo '<a href="' . $profileFieldContentValue . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
+                                            echo '<a href="' . $profileIconField->getAddition() . $profileFieldContentValue . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
                                             break;
                                         }
                                     }

--- a/application/modules/user/views/profil/index.php
+++ b/application/modules/user/views/profil/index.php
@@ -98,11 +98,11 @@ foreach ($profil->getGroups() as $group) {
                     $pos = strpos($profileFieldContent->getValue(), $profileIconField->getAddition());
 
                     if ($pos !== false) {
-                        $profileFieldContentValue = substr_replace($profileFieldContent->getValue(), '', $pos, $profileIconField->getAddition());
+                        $profileFieldContentValue = substr_replace($profileFieldContent->getValue(), '', $pos, strlen($profileIconField->getAddition()));
                     }
                 }
 
-                echo '<a href="' . $profileFieldContentValue . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
+                echo '<a href="' . $profileIconField->getAddition() . $profileFieldContentValue . '" target="_blank" rel="noopener" class="' . $profileIconField->getIcon() . ' fa-lg user-link" title="' . $profileFieldName . '"></a>';
                 break;
             }
         }


### PR DESCRIPTION
# Description
- User: Fix error when handling profile link addition

```
Fatal error: Uncaught TypeError: substr_replace(): Argument #4 ($length) must be of type array|int|null, string given in application/modules/user/views/index/index.php:109

Stack trace:
#0 application/modules/user/views/index/index.php(109): substr_replace()
#1 application/libraries/Ilch/View.php(22): include('/homepages/18/d...')
#2 application/libraries/Ilch/Page.php(161): Ilch\View->loadScript()
#3 index.php(68): Ilch\Page->loadPage()
#4 {main} thrown in application/modules/user/views/index/index.php on line 109
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
