### PR TITLE
Fix "Passing null to parameter of type string is deprecated"

### DIFF
--- a/application/modules/events/config/config.php
+++ b/application/modules/events/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'events',
-        'version' => '1.23.3',
+        'version' => '1.23.4',
         'icon_small' => 'fa-solid fa-ticket',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/events/mappers/Events.php
+++ b/application/modules/events/mappers/Events.php
@@ -382,7 +382,7 @@ class Events extends \Ilch\Mapper
             ->execute()
             ->fetchAssoc();
 
-        if (file_exists($imageRow['image'])) {
+        if (isset($imageRow['image']) && file_exists($imageRow['image'])) {
             unlink($imageRow['image']);
         }
 


### PR DESCRIPTION
# Description
- Fix "file_exists(): Passing null to parameter of type string is deprecated"

https://www.ilch.de/forum-showposts-58779.html

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
