### PR TITLE
Training: Add getNextTrainings and fix usage of pagination class

### DIFF
--- a/application/modules/training/boxes/Nexttraining.php
+++ b/application/modules/training/boxes/Nexttraining.php
@@ -32,7 +32,7 @@ class Nexttraining extends \Ilch\Box
         }
 
         // Get trainings, calculate next date if it's a recurrent event and sort them by date.
-        $trainings = $trainingMapper->getTrainingsListWithLimt($config->get('training_boxNexttrainingLimit') ?: 5, $groupIds);
+        $trainings = $trainingMapper->getNextTrainings($config->get('training_boxNexttrainingLimit') ?? 5, $groupIds);
         foreach ($trainings as $training) {
             $trainingMapper->calculateNextTrainingDate($training);
         }


### PR DESCRIPTION
# Description
- Add getNextTrainings and fix usage of pagination class.

The limit for the number of entries in the box wasn't correctly applied. Further the limit could easily be reached without showing any entries, because they are in the past.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [x] Firefox
- [ ] Opera
- [ ] Edge
