### PR TITLE
Training: Improve getNextTrainings and fix deleting trainings

### DIFF
--- a/application/modules/training/boxes/Nexttraining.php
+++ b/application/modules/training/boxes/Nexttraining.php
@@ -9,7 +9,6 @@ namespace Modules\Training\Boxes;
 
 use Modules\Training\Mappers\Training as TrainingMapper;
 use Modules\Training\Mappers\Entrants as EntrantsMapper;
-use Modules\Training\Models\Training as TrainingModel;
 use Modules\User\Mappers\User as UserMapper;
 
 class Nexttraining extends \Ilch\Box
@@ -31,15 +30,8 @@ class Nexttraining extends \Ilch\Box
             }
         }
 
-        // Get trainings, calculate next date if it's a recurrent event and sort them by date.
-        $trainings = $trainingMapper->getNextTrainings($config->get('training_boxNexttrainingLimit') ?? 5, $groupIds);
-        foreach ($trainings as $training) {
-            $trainingMapper->calculateNextTrainingDate($training);
-        }
-        usort($trainings, fn(TrainingModel $a, TrainingModel $b) => strcmp($a->getDate(), $b->getDate()));
-
         $this->getView()->set('trainingMapper', $trainingMapper)
             ->set('entrantsMapper', $entrantsMapper)
-            ->set('trainings', $trainings);
+            ->set('trainings', $trainingMapper->getNextTrainings($config->get('training_boxNexttrainingLimit') ?? 5, $groupIds));
     }
 }

--- a/application/modules/training/controllers/admin/Index.php
+++ b/application/modules/training/controllers/admin/Index.php
@@ -52,8 +52,8 @@ class Index extends \Ilch\Controller\Admin
         $trainingMapper = new TrainingMapper();
         $this->getLayout()->getAdminHmenu()
             ->add($this->getTranslator()->trans('menuTraining'), ['action' => 'index']);
-        if ($this->getRequest()->getPost('check_training') && $this->getRequest()->getPost('action') === 'delete') {
-            foreach ($this->getRequest()->getPost('check_training') as $trainingId) {
+        if ($this->getRequest()->getPost('check_trainings') && $this->getRequest()->getPost('action') === 'delete') {
+            foreach ($this->getRequest()->getPost('check_trainings') as $trainingId) {
                 $trainingMapper->delete($trainingId);
             }
             $this->redirect()
@@ -61,7 +61,7 @@ class Index extends \Ilch\Controller\Admin
                 ->to(['action' => 'index']);
         }
 
-        $this->getView()->set('training', $trainingMapper->getEntriesBy());
+        $this->getView()->set('trainings', $trainingMapper->getEntriesBy());
     }
 
     public function treatAction()

--- a/application/modules/training/models/Training.php
+++ b/application/modules/training/models/Training.php
@@ -45,7 +45,7 @@ class Training extends \Ilch\Model
     protected int $periodDay = 0;
 
     /**
-     * period day of the training.
+     * period type of the training.
      *
      * @var string
      */

--- a/application/modules/training/views/admin/index/index.php
+++ b/application/modules/training/views/admin/index/index.php
@@ -2,8 +2,8 @@
 
 /** @var \Ilch\View $this */
 
-/** @var \Modules\Training\Models\Training[]|null $training */
-$training = $this->get('training');
+/** @var \Modules\Training\Models\Training[]|null $trainings */
+$trainings = $this->get('trainings');
 
 $periodDays = [
     '1' => $this->getTranslator()->trans('Monday'),
@@ -24,7 +24,7 @@ $periodTypes = [
 ];
 ?>
 <h1><?=$this->getTrans('manage') ?></h1>
-<?php if ($training) : ?>
+<?php if ($trainings) : ?>
     <form method="POST" action="">
         <?=$this->getTokenField() ?>
         <div class="table-responsive">
@@ -41,7 +41,7 @@ $periodTypes = [
                 </colgroup>
                 <thead>
                     <tr>
-                        <th><?=$this->getCheckAllCheckbox('check_training') ?></th>
+                        <th><?=$this->getCheckAllCheckbox('check_trainings') ?></th>
                         <th></th>
                         <th></th>
                         <th><?=$this->getTrans('start') ?></th>
@@ -52,7 +52,7 @@ $periodTypes = [
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($training as $model) :
+                    <?php foreach ($trainings as $model) :
                         $datecreate = '';
                         if ($model->getDate()) {
                             $date = new \Ilch\Date($model->getDate());


### PR DESCRIPTION
# Description
- Improve getNextTrainings.
- Fix deleting of multiple trainings.

Previously a bunch of recurrent trainings could hide single trainings as their "real" date wasn't known until after fetching them from the database. Now the function gets all recurrent events in addition to the other trainings and return the requested count of trainings sorted by date.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
