### PR TITLE
Forum: Remove bootstrap tokenfield and update CSS

### DIFF
--- a/application/modules/forum/static/css/forum-items.css
+++ b/application/modules/forum/static/css/forum-items.css
@@ -1,0 +1,59 @@
+.item_delete {
+    float: right;
+    cursor: pointer;
+}
+
+.item_edit {
+    margin-right: 6px;
+    float: right;
+    cursor: pointer;
+}
+
+ol.sortable, ol.sortable ol {
+    margin: 0 0 0 25px;
+    padding: 0;
+    list-style-type: none;
+}
+
+ol.sortable {
+    margin: 0;
+}
+
+.sortable li {
+    margin: 5px 0 0 0;
+    padding: 0;
+}
+
+.sortable li div {
+    border: 1px solid;
+    border-radius: 3px;
+    border-color: #D4D4D4 #D4D4D4 #BCBCBC;
+    padding: 6px;
+    margin: 0;
+    cursor: move;
+    background: #f6f6f6;
+    background: linear-gradient(to bottom, #ffffff 0%, #f6f6f6 47%, #ededed 100%);
+}
+
+li.mjs-nestedSortable-collapsed.mjs-nestedSortable-hovering div {
+    border-color: #999;
+    background: #fafafa;
+}
+
+.disclose {
+    cursor: pointer;
+    width: 18px;
+    display: none;
+}
+
+.sortable li.mjs-nestedSortable-collapsed > ol {
+    display: none;
+}
+
+.sortable li.mjs-nestedSortable-branch > div > .disclose {
+    display: inline-block;
+}
+
+.placeholder {
+    outline: 1px dashed #4183C4;
+}


### PR DESCRIPTION
# Description
- Use choices instead of bootstrap tokenfield.
- Update CSS and move it to a file.
- Some other smaller changes.

Fixes #1157

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
