### PR TITLE
Thumbnail: Fix wrong if condition

### DIFF
--- a/application/libraries/Thumb/Thumbnail.php
+++ b/application/libraries/Thumb/Thumbnail.php
@@ -1292,7 +1292,7 @@ class Thumbnail
             $random3 = 1;
             $random4 = 1;
         }
-        if (version_compare(PHP_VERSION, '8.1.0', '>=') === -1) {
+        if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
             if ($this->Clipcorner[3] && $random1) {
                 imagefilledpolygon($this->im, $points_tl, $bgcolor);
             }


### PR DESCRIPTION
# Description
- Fix wrong if condition

> By default, version_compare() returns -1 if the first version is lower than the second, 0 if they are equal, and 1 if the second is lower.
> 
> When using the optional operator argument, the function will return [true](https://www.php.net/manual/en/reserved.constants.php#constant.true) if the relationship is the one specified by the operator, [false](https://www.php.net/manual/en/reserved.constants.php#constant.false) otherwise.

https://www.php.net/manual/en/function.version-compare.php

> 8.1.0: Der Parameter num_points ist veraltet und sollte  nicht mehr verwendet werden.

https://www.php.net/manual/de/function.imagefilledpolygon.php

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
