### PR TITLE
Admin: Use arrows for the order of module data

### DIFF
--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -135,6 +135,8 @@ return [
     'pageTitleOrderInfo' => '%%moduledata%% -> Moduldaten<br>%%title%% -> Titel',
     'moduledata' => 'Moduldaten',
     'pageTitleModuledataOrder' => 'Moduldaten Reihenfolge',
+    'pageTitleModuledataOrderLeftToRight' => 'Von links nach rechts',
+    'pageTitleModuledataOrderRightToLeft' => 'Von rechts nach links',
     'pageTitleModuledataSeparator' => 'Moduldaten Trenner',
     'pageContent' => 'Inhalt',
     'startPage' => 'Startseite',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -135,6 +135,8 @@ return [
     'pageTitleOrderInfo' => '%%moduledata%% -> Module data<br>%%title%% -> Title',
     'moduledata' => 'Module data',
     'pageTitleModuledataOrder' => 'Module data order',
+    'pageTitleModuledataOrderLeftToRight' => 'From left to right',
+    'pageTitleModuledataOrderRightToLeft' => 'From right to left',
     'pageTitleModuledataSeparator' => 'Module data separator',
     'pageContent' => 'Content',
     'startPage' => 'Startpage',

--- a/application/modules/admin/views/admin/layouts/settings.php
+++ b/application/modules/admin/views/admin/layouts/settings.php
@@ -101,9 +101,9 @@
         <div class="col-xl-4">
             <div class="flipswitch">
                 <input type="radio" class="flipswitch-input" id="pageTitleModuledataOrder-yes" name="pageTitleModuledataOrder" value="1" <?=($this->originalInput('pageTitleModuledataOrder', $this->get('pageTitleModuledataOrder'))) ? 'checked="checked"' : '' ?> />
-                <label for="pageTitleModuledataOrder-yes" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('DESC') ?></label>
+                <label for="pageTitleModuledataOrder-yes" class="flipswitch-label flipswitch-label-on"><i class="fa-solid fa-arrow-left-long" title="<?=$this->getTrans('pageTitleModuledataOrderRightToLeft') ?>"></i></label>
                 <input type="radio" class="flipswitch-input" id="pageTitleModuledataOrder-no" name="pageTitleModuledataOrder" value="0"  <?=(!$this->originalInput('pageTitleModuledataOrder', $this->get('pageTitleModuledataOrder'))) ? 'checked="checked"' : '' ?> />
-                <label for="pageTitleModuledataOrder-no" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('ASC') ?></label>
+                <label for="pageTitleModuledataOrder-no" class="flipswitch-label flipswitch-label-off"><i class="fa-solid fa-arrow-right-long" title="<?=$this->getTrans('pageTitleModuledataOrderLeftToRight') ?>"></i></label>
                 <span class="flipswitch-selection"></span>
             </div>
         </div>


### PR DESCRIPTION
# Description
- Use arrows for the order of the module data.

Previously "ASC" and "DESC" was displayed, which is not intuitive for a user. From left to right or from right to left is better in this case.

![grafik](https://github.com/user-attachments/assets/5572e90b-24eb-46cd-af36-967b50aafcf0)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
