### PR TITLE
Remove failed module install leftovers

### DIFF
--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -1207,6 +1207,19 @@ class Config extends \Ilch\Config\Install
                         )
                         ->execute();
                 }
+
+                // There was a bug, which caused installs of modules with folderrights to fail. Therefore there might be leftovers in the database.
+                $moduleMapper = new \Modules\Admin\Mappers\Module();
+                $modulesNotInstalled = $moduleMapper->getModulesNotInstalled();
+
+                foreach ($modulesNotInstalled as $module) {
+                    if ($module->getKey() === 'events' || $module->getKey() === 'teams') {
+                        // Found one of the known affected modules. Call it's uninstall function to remove possible leftovers.
+                        $configClass = '\\Modules\\' . ucfirst($module->getKey()) . '\\Config\\Config';
+                        $config = new $configClass();
+                        $config->uninstall();
+                    }
+                }
                 break;
         }
 


### PR DESCRIPTION
# Description
- Remove failed module install leftovers

There was a bug, which caused installs of modules with folderrights to fail. Therefore there might be leftovers in the database.
Call the uninstall function for known affected modules to remove possible leftovers if needed. This might be the case if the module is present as not installed.

- [X] events
- [X] teams

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
