### PR TITLE
Create UploadTest and deprecate parts of Upload class.php

### DIFF
--- a/application/libraries/Ilch/Upload.php
+++ b/application/libraries/Ilch/Upload.php
@@ -20,16 +20,19 @@ class Upload extends \Ilch\Controller\Base
 
     /**
      * @var string $ending
+     * @deprecated
      */
     protected $ending;
 
     /**
      * @var string $name
+     * @deprecated
      */
     protected $name;
 
     /**
      * @var string $fileName
+     * @deprecated
      */
     protected $fileName;
 
@@ -45,6 +48,7 @@ class Upload extends \Ilch\Controller\Base
 
     /**
      * @var string $types
+     * @deprecated
      */
     protected $types;
 
@@ -60,16 +64,19 @@ class Upload extends \Ilch\Controller\Base
 
     /**
      * @var string $path
+     * @deprecated
      */
     protected $mediaExtImage;
 
     /**
      * @var string $size
+     * @deprecated
      */
     protected $size;
 
     /**
      * __construct
+     * @deprecated
      */
     public function __construct()
     {
@@ -78,6 +85,7 @@ class Upload extends \Ilch\Controller\Base
 
     /**
      * Resets
+     * @deprecated
      */
     public function reset(): Upload
     {
@@ -117,6 +125,7 @@ class Upload extends \Ilch\Controller\Base
      * @param string $ending
      *
      * @return Upload Ending
+     * @deprecated
      */
     public function setEnding(string $ending): Upload
     {
@@ -127,6 +136,7 @@ class Upload extends \Ilch\Controller\Base
 
     /**
      * @return string
+     * @deprecated Use getExtension instead.
      */
     public function getEnding(): string
     {
@@ -136,9 +146,21 @@ class Upload extends \Ilch\Controller\Base
     }
 
     /**
+     * Get the extension of file. This gets determined from the value of file.
+     *
+     * @return string
+     * @since 2.2.9
+     */
+    public function getExtension(): string
+    {
+        return strtolower(pathinfo($this->file, PATHINFO_EXTENSION));
+    }
+
+    /**
      * @param string $name
      *
      * @return Upload Name
+     * @deprecated
      */
     public function setName(string $name): Upload
     {
@@ -148,6 +170,8 @@ class Upload extends \Ilch\Controller\Base
     }
 
     /**
+     * Get the name of the file. This gets determined from the value of file.
+     *
      * @return string
      */
     public function getName(): string
@@ -161,6 +185,7 @@ class Upload extends \Ilch\Controller\Base
      * @param string $fileName
      *
      * @return Upload fileName
+     * @deprecated
      */
     public function setFileName(string $fileName): Upload
     {
@@ -171,6 +196,7 @@ class Upload extends \Ilch\Controller\Base
 
     /**
      * @return string
+     * @deprecated
      */
     public function getFileName(): string
     {
@@ -201,6 +227,7 @@ class Upload extends \Ilch\Controller\Base
      * @param string $types
      *
      * @return Upload types
+     * @deprecated Use setAllowedExtensions instead.
      */
     public function setTypes(string $types): Upload
     {
@@ -211,6 +238,7 @@ class Upload extends \Ilch\Controller\Base
 
     /**
      * @return string
+     * @deprecated Use getAllowedExtensions instead.
      */
     public function getTypes(): string
     {

--- a/application/libraries/Ilch/Upload.php
+++ b/application/libraries/Ilch/Upload.php
@@ -125,7 +125,7 @@ class Upload extends \Ilch\Controller\Base
      * @param string $ending
      *
      * @return Upload Ending
-     * @deprecated
+     * @deprecated Just use setFile instead.
      */
     public function setEnding(string $ending): Upload
     {
@@ -160,7 +160,7 @@ class Upload extends \Ilch\Controller\Base
      * @param string $name
      *
      * @return Upload Name
-     * @deprecated
+     * @deprecated Just use setFile instead.
      */
     public function setName(string $name): Upload
     {

--- a/tests/libraries/ilch/UploadTest.php
+++ b/tests/libraries/ilch/UploadTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @package ilch_phpunit
+ */
+
+namespace Ilch;
+
+use PHPUnit\Ilch\TestCase;
+
+class UploadTest extends TestCase
+{
+    protected Upload $upload;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->upload = new Upload();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->upload);
+        parent::tearDown();
+    }
+
+    public function testProperties()
+    {
+        $this->upload->setFile('file.png')
+            ->setEnding('png')
+            ->setFileName('file')
+            ->setUrl('https://test/file.png')
+            ->setUrlThumb('https://test/file_thumb.png')
+            ->setTypes('png jpg jpeg')
+            ->setAllowedExtensions('png jpg jpeg')
+            ->setPath('file');
+
+        self::assertSame('file.png', $this->upload->getFile());
+        self::assertSame('png', $this->upload->getEnding());
+        self::assertSame('file', $this->upload->getFileName());
+        self::assertSame('https://test/file.png', $this->upload->getUrl());
+        self::assertSame('https://test/file_thumb.png', $this->upload->getUrlThumb());
+        self::assertSame('png jpg jpeg', $this->upload->getTypes());
+        self::assertSame('png jpg jpeg', $this->upload->getAllowedExtensions());
+        self::assertSame('file', $this->upload->getPath());
+    }
+
+    public function testIsAllowedExtension()
+    {
+        $this->upload->setFile('file.png')
+            ->setAllowedExtensions('png jpg jpeg');
+
+        self::assertTrue($this->upload->isAllowedExtension());
+    }
+
+    public function testIsAllowedExtensionFalse()
+    {
+        $this->upload->setFile('file.php')
+            ->setAllowedExtensions('png jpg jpeg');
+
+        self::assertFalse($this->upload->isAllowedExtension());
+    }
+
+    public function testReturnBytes()
+    {
+        self::assertSame(1048576, $this->upload->returnBytes('1M'));
+        self::assertSame(1024, $this->upload->returnBytes('1K'));
+        self::assertSame(1073741824, $this->upload->returnBytes('1G'));
+        self::assertSame(1048576, $this->upload->returnBytes('1m'));
+        self::assertSame(1024, $this->upload->returnBytes('1k'));
+        self::assertSame(1073741824, $this->upload->returnBytes('1g'));
+
+        self::assertSame(2097152, $this->upload->returnBytes('2M'));
+        self::assertSame(2048, $this->upload->returnBytes('2K'));
+        self::assertSame(2147483648, $this->upload->returnBytes('2G'));
+
+        self::assertSame('1024', $this->upload->returnBytes('1024'));
+    }
+}


### PR DESCRIPTION
# Description
- Add some unit tests for the upload class.
- Update Upload.php to deprecate functions

The upload class will be replaced after some time by #1162

See also:
https://github.com/IlchCMS/Ilch-2.0/pull/1162
Fixes https://github.com/IlchCMS/Ilch-2.0/issues/809