### PR TITLE
Awards: Add user notification

### DIFF
--- a/application/modules/awards/config/config.php
+++ b/application/modules/awards/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'awards',
-        'version' => '1.11.1',
+        'version' => '1.12.0',
         'icon_small' => 'fa-solid fa-trophy',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -32,12 +32,18 @@ class Config extends \Ilch\Config\Install
     public function install()
     {
         $this->db()->queryMulti($this->getInstallSql());
+
+        $databaseConfig = new \Ilch\Config\Database($this->db());
+        $databaseConfig->set('awards_userNotification', 1);
     }
 
     public function uninstall()
     {
         $this->db()->queryMulti('DROP TABLE `[prefix]_awards_recipients` IF EXISTS;
             DROP TABLE `[prefix]_awards` IF EXISTS;');
+
+        $databaseConfig = new \Ilch\Config\Database($this->db());
+        $databaseConfig->delete('awards_userNotification');
     }
 
     public function getInstallSql()
@@ -110,6 +116,10 @@ class Config extends \Ilch\Config\Install
                 $this->db()->query('ALTER TABLE `[prefix]_awards` DROP COLUMN `ut_id`, DROP COLUMN `typ`');
             case '1.10.0':
             case '1.10.1':
+            case '1.11.0':
+                // Enable notification of users if they receive an award by default.
+                $databaseConfig = new \Ilch\Config\Database($this->db());
+                $databaseConfig->set('awards_userNotification', 1);
         }
     }
 }

--- a/application/modules/awards/controllers/admin/Settings.php
+++ b/application/modules/awards/controllers/admin/Settings.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Awards\Controllers\Admin;
+
+use Ilch\Validation;
+
+class Settings extends \Ilch\Controller\Admin
+{
+    public function init()
+    {
+        $items = [
+            [
+                'name' => 'manage',
+                'active' => false,
+                'icon' => 'fa-solid fa-table-list',
+                'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
+            ],
+            [
+                'name' => 'settings',
+                'active' => true,
+                'icon' => 'fa-solid fa-gears',
+                'url' => $this->getLayout()->getUrl(['controller' => 'settings', 'action' => 'index'])
+            ]
+        ];
+
+        $this->getLayout()->addMenu(
+            'menuAwards',
+            $items
+        );
+    }
+
+    public function indexAction()
+    {
+        $this->getLayout()->getAdminHmenu()
+                ->add($this->getTranslator()->trans('menuAwards'), ['action' => 'index'])
+                ->add($this->getTranslator()->trans('manage'), ['action' => 'index']);
+
+        if ($this->getRequest()->isPost()) {
+            $rules = [
+                'userNotification' => 'required|numeric|integer|min:0|max:1',
+            ];
+
+            $validation = Validation::create($this->getRequest()->getPost(), $rules);
+
+            if ($validation->isValid()) {
+                $this->getConfig()->set('awards_userNotification', $this->getRequest()->getPost('userNotification'));
+
+                $this->redirect()
+                    ->withMessage('saveSuccess')
+                    ->to(['action' => 'index']);
+            }
+
+            $this->addMessage($validation->getErrorBag()->getErrorMessages(), 'danger', true);
+            $this->redirect()
+                ->withInput()
+                ->withErrors($validation->getErrorBag())
+                ->to(['action' => 'index']);
+        }
+
+        $this->getView()->set('userNotification', $this->getConfig()->get('awards_userNotification'));
+    }
+}

--- a/application/modules/awards/translations/de.php
+++ b/application/modules/awards/translations/de.php
@@ -26,4 +26,7 @@ return [
     'formerUsersOrTeams' => 'Ehemalige Benutzer oder Teams',
     'awardNotFound' => 'Auszeichnung nicht gefunden',
     'recipientsOfAward' => 'Auszeichnung haben erhalten',
+    'userNotification' => 'Benutzer über Auszeichnung benachrichtigen',
+    'awardReceived' => 'Sie haben eine Auszeichnung erhalten.',
+    'awardReceivedAsTeam' => 'Sie haben als Mitglied eines Teams eine Auszeichnung erhalten.',
 ];

--- a/application/modules/awards/translations/en.php
+++ b/application/modules/awards/translations/en.php
@@ -26,4 +26,7 @@ return [
     'formerUsersOrTeams' => 'Former users or teams',
     'awardNotFound' => 'Award not found',
     'recipientsOfAward' => 'Recipients of this award',
+    'userNotification' => 'Notify user of received award',
+    'awardReceived' => 'You have received an award.',
+    'awardReceivedAsTeam' => 'You have received an award as a member of a team.',
 ];

--- a/application/modules/awards/views/admin/settings/index.php
+++ b/application/modules/awards/views/admin/settings/index.php
@@ -1,0 +1,23 @@
+<?php
+
+/** @var \Ilch\View $this */
+?>
+<h1><?=$this->getTrans('settings') ?></h1>
+<form method="POST">
+    <?=$this->getTokenField() ?>
+    <div class="row mb-3<?=$this->validation()->hasError('userNotification') ? ' has-error' : '' ?>">
+        <div class="col-xl-2 col-form-label">
+            <?=$this->getTrans('userNotification') ?>
+        </div>
+        <div class="col-xl-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="userNotification-on" name="userNotification" value="1" <?=($this->get('userNotification') === '1') ? 'checked="checked"' : '' ?> />
+                <label for="userNotification-on" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('on') ?></label>
+                <input type="radio" class="flipswitch-input" id="userNotification-off" name="userNotification" value="0" <?=($this->get('userNotification') !== '1') ? 'checked="checked"' : '' ?> />
+                <label for="userNotification-off" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('off') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+        </div>
+    </div>
+    <?=$this->getSaveBar() ?>
+</form>


### PR DESCRIPTION
# Description
- Add user notification for receiving an award (either as user or team).
- Add option to disable the user notification. By default it is enabled.

#438 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
