### PR TITLE
Teams: Add user notification for users added to a team.

### DIFF
--- a/application/modules/teams/config/config.php
+++ b/application/modules/teams/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'teams',
-        'version' => '1.24.4',
+        'version' => '1.25.0',
         'icon_small' => 'fa-solid fa-users',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -243,10 +243,16 @@ class Config extends \Ilch\Config\Install
                 $this->db()->query("UPDATE `[prefix]_modules` SET `icon_small` = 'fa-solid fa-users' WHERE `key` = 'teams';");
                 // no break
             case "1.22.0":
-                // no break
             case "1.23.0":
-                // no break
             case "1.23.1":
+            case "1.24.0":
+            case "1.24.1":
+            case "1.24.2":
+            case "1.24.3":
+            case "1.24.4":
+                // Enable notification of users if they are added to a team by default.
+                $databaseConfig = new \Ilch\Config\Database($this->db());
+                $databaseConfig->set('teams_userNotification', 1);
                 // no break
         }
         return 'Update function executed.';

--- a/application/modules/teams/config/config.php
+++ b/application/modules/teams/config/config.php
@@ -43,7 +43,8 @@ class Config extends \Ilch\Config\Install
         $databaseConfig->set('teams_uploadpath', 'application/modules/teams/static/upload/')
             ->set('teams_height', '80')
             ->set('teams_width', '530')
-            ->set('teams_filetypes', 'jpg jpeg png');
+            ->set('teams_filetypes', 'jpg jpeg png')
+            ->set('teams_userNotification', '1');
     }
 
     public function uninstall()
@@ -55,7 +56,8 @@ class Config extends \Ilch\Config\Install
         $databaseConfig->delete('teams_uploadpath')
             ->delete('teams_height')
             ->delete('teams_width')
-            ->delete('teams_filetypes');
+            ->delete('teams_filetypes')
+            ->delete('teams_userNotification');
 
         $this->db()->query("DELETE FROM `[prefix]_emails` WHERE `moduleKey` = 'teams'");
     }

--- a/application/modules/teams/controllers/admin/Index.php
+++ b/application/modules/teams/controllers/admin/Index.php
@@ -226,7 +226,7 @@ class Index extends \Ilch\Controller\Admin
                         $notificationModel->setUserId($user->getId())
                             ->setModule('teams')
                             ->setMessage($this->getTranslator()->trans('teamsAddedToTeam', $model->getName()))
-                            ->setURL($this->getLayout()->getUrl(['module' => 'teams', 'controller' => 'index', 'action' => 'show', 'id' => $model->getId()], ''))
+                            ->setURL($this->getLayout()->getUrl(['module' => 'teams', 'controller' => 'index', 'action' => 'team', 'id' => $model->getId()], ''))
                             ->setType('teamsAddedToTeam');
                         $notificationModels[] = $notificationModel;
                     }

--- a/application/modules/teams/controllers/admin/Settings.php
+++ b/application/modules/teams/controllers/admin/Settings.php
@@ -54,7 +54,8 @@ class Settings extends \Ilch\Controller\Admin
 
             $validation = Validation::create($this->getRequest()->getPost(), [
                 'image_height' => 'required|numeric|integer|min:1',
-                'image_width' => 'required|numeric|integer|min:1'
+                'image_width' => 'required|numeric|integer|min:1',
+                'userNotification' => 'required|numeric|integer|min:0|max:1',
             ]);
 
             if ($validation->isValid()) {
@@ -65,6 +66,7 @@ class Settings extends \Ilch\Controller\Admin
                     $this->getConfig()->set('teams_height', $this->getRequest()->getPost('image_height'));
                     $this->getConfig()->set('teams_width', $this->getRequest()->getPost('image_width'));
                     $this->getConfig()->set('teams_filetypes', strtolower($this->getRequest()->getPost('image_filetypes')));
+                    $this->getConfig()->set('teams_userNotification', $this->getRequest()->getPost('userNotification'));
 
                     $this->redirect()
                         ->withMessage('saveSuccess')
@@ -82,6 +84,7 @@ class Settings extends \Ilch\Controller\Admin
 
         $this->getView()->set('teams_height', $this->getConfig()->get('teams_height'))
             ->set('teams_width', $this->getConfig()->get('teams_width'))
-            ->set('teams_filetypes', $this->getConfig()->get('teams_filetypes'));
+            ->set('teams_filetypes', $this->getConfig()->get('teams_filetypes'))
+            ->set('userNotification', $this->getConfig()->get('teams_userNotification'));
     }
 }

--- a/application/modules/teams/translations/de.php
+++ b/application/modules/teams/translations/de.php
@@ -28,6 +28,8 @@ return [
     'imageHeight' => 'Max. Bild Höhe',
     'imageWidth' => 'Max. Bild Breite',
     'allowedFileExtensions' => 'Erlaubte Dateiendungen',
+    'userNotification' => 'Benutzer über Aufnahme zum Team benachrichtigen.',
+    'teamsAddedToTeam' => 'Sie wurden dem Team "%s" hinzugefügt.',
     'forbiddenExtension' => 'Sie haben versucht eine unerlaubte Dateiendung einzutragen.',
     'failedFiletypes' => 'Bild enthält kein erlaubtes Dateiformat.',
     'failedFilesize' => 'Bild hat unerlaubte Breite, Höhe oder ist zu groß.',

--- a/application/modules/teams/translations/de.php
+++ b/application/modules/teams/translations/de.php
@@ -28,7 +28,7 @@ return [
     'imageHeight' => 'Max. Bild Höhe',
     'imageWidth' => 'Max. Bild Breite',
     'allowedFileExtensions' => 'Erlaubte Dateiendungen',
-    'userNotification' => 'Benutzer über Aufnahme zum Team benachrichtigen.',
+    'userNotification' => 'Benutzer bei Aufnahme ins Team benachrichtigen.',
     'teamsAddedToTeam' => 'Sie wurden dem Team "%s" hinzugefügt.',
     'forbiddenExtension' => 'Sie haben versucht eine unerlaubte Dateiendung einzutragen.',
     'failedFiletypes' => 'Bild enthält kein erlaubtes Dateiformat.',

--- a/application/modules/teams/translations/en.php
+++ b/application/modules/teams/translations/en.php
@@ -28,7 +28,7 @@ return [
     'imageHeight' => 'Maximum image height',
     'imageWidth' => 'Maximum image width',
     'allowedFileExtensions' => 'Allowed file extensions',
-    'userNotification' => 'Notify user of enrollment in the team.',
+    'userNotification' => 'Notify users of enrollment in the team.',
     'teamsAddedToTeam' => 'You have been added to the "%s" team.',
     'forbiddenExtension' => 'You tried to add an forbidden file extension.',
     'failedFiletypes' => 'Image does not contain allowed file format.',

--- a/application/modules/teams/translations/en.php
+++ b/application/modules/teams/translations/en.php
@@ -28,6 +28,8 @@ return [
     'imageHeight' => 'Maximum image height',
     'imageWidth' => 'Maximum image width',
     'allowedFileExtensions' => 'Allowed file extensions',
+    'userNotification' => 'Notify user of enrollment in the team.',
+    'teamsAddedToTeam' => 'You have been added to the "%s" team.',
     'forbiddenExtension' => 'You tried to add an forbidden file extension.',
     'failedFiletypes' => 'Image does not contain allowed file format.',
     'failedFilesize' => 'Image has unauthorized width, height or is too big.',

--- a/application/modules/teams/views/admin/settings/index.php
+++ b/application/modules/teams/views/admin/settings/index.php
@@ -45,5 +45,19 @@
                    value="<?=$this->get('teams_filetypes') ?>" />
         </div>
     </div>
+    <div class="row mb-3<?=$this->validation()->hasError('userNotification') ? ' has-error' : '' ?>">
+        <div class="col-xl-2 col-form-label">
+            <?=$this->getTrans('userNotification') ?>
+        </div>
+        <div class="col-xl-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="userNotification-on" name="userNotification" value="1" <?=($this->get('userNotification') === '1') ? 'checked="checked"' : '' ?> />
+                <label for="userNotification-on" class="flipswitch-label flipswitch-label-on"><?=$this->getTrans('on') ?></label>
+                <input type="radio" class="flipswitch-input" id="userNotification-off" name="userNotification" value="0" <?=($this->get('userNotification') !== '1') ? 'checked="checked"' : '' ?> />
+                <label for="userNotification-off" class="flipswitch-label flipswitch-label-off"><?=$this->getTrans('off') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+        </div>
+    </div>
     <?=$this->getSaveBar() ?>
 </form>


### PR DESCRIPTION
# Description
- Added a notification for users added to a team. By default enabled.
- Added an option to disable this feature.

Fixes #438

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
