### PR TITLE
Update CI workflow to test with MySQL and MariaDB

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,19 +15,12 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        mysql-versions: ['5.7']
-
-    services:
-      mysql:
-        image: mysql:${{ matrix.mysql-versions }}
-        env:
-          MYSQL_RANDOM_ROOT_PASSWORD: yes
-          MYSQL_DATABASE: ilch2_test
-          MYSQL_USER: ilch2_test_user
-          MYSQL_PASSWORD: ilch2_test_password
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
-        ports:
-          - 3306:3306
+        db:
+          - name: 'MySQL'
+            version: '5.7'
+        include:
+            - {php-versions: '8.4', db: {name: 'MariaDB', version: '10.5'}}
+            - {php-versions: '8.4', db: {name: 'MariaDB', version: 'latest'}}
 
     steps:
       - name: Checkout code
@@ -38,6 +31,22 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           coverage: xdebug
           tools: composer
+      - name: Setup MariaDB
+        if: ${{ matrix.db.name == 'MariaDB' }}
+        uses: getong/mariadb-action@v1.11
+        with:
+          mariadb version: ${{ matrix.db.version }}
+          mysql database: ilch2_test
+          mysql user: ilch2_test_user
+          mysql password: ilch2_test_password
+      - name: Setup MySQL
+        if: ${{ matrix.db.name == 'MySQL' }}
+        uses: mirromutth/mysql-action@v1.1
+        with:
+          mysql version: ${{ matrix.db.version }}
+          mysql database: ilch2_test
+          mysql user: ilch2_test_user
+          mysql password: ilch2_test_password
       - name: Get composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -49,10 +58,10 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-php${{ matrix.php-versions }}
       - name: Install dependencies
         run: composer install --prefer-dist
-      - name: Verify MySQL connection
+      - name: Verify ${{ matrix.db.name }} connection
         env:
           HOST: 127.0.0.1
-          PORT: ${{ job.services.mysql.ports[3306] }}
+          PORT: 3306
         run: |
           while ! mysqladmin ping -h"$HOST" -P"$PORT" --silent; do
             sleep 1


### PR DESCRIPTION
# Description
- Update CI workflow to test with MySQL and MariaDB.

The tests with **MariaDB** currently only **run with PHP 8.4** to keep the number of variants that need to run lower. Otherwise the number of variants would be 18 instead of 8.
All tests run as previously with **MySQL 5.7** and **all supported PHP versions**.
Currently we don't run tests with **MySQL greater than 5.7** as they **would fail**.

#1180 

