### PR TITLE
Training v1.10.1

### DIFF
--- a/application/modules/training/config/config.php
+++ b/application/modules/training/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public array $config = [
         'key' => 'training',
-        'version' => '1.10.0',
+        'version' => '1.10.1',
         'icon_small' => 'fa-solid fa-graduation-cap',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/training/controllers/Index.php
+++ b/application/modules/training/controllers/Index.php
@@ -35,10 +35,12 @@ class Index extends \Ilch\Controller\Frontend
 
         // Get trainings, calculate next date if it's a recurrent event and sort them by date.
         $trainings = $trainingMapper->getTraining([], $groupIds);
-        foreach ($trainings as $training) {
-            $trainingMapper->calculateNextTrainingDate($training);
+        if ($trainings) {
+            foreach ($trainings as $training) {
+                $trainingMapper->calculateNextTrainingDate($training);
+            }
+            usort($trainings, fn (TrainingModel $a, TrainingModel $b) => strcmp($a->getDate(), $b->getDate()));
         }
-        usort($trainings, fn(TrainingModel $a, TrainingModel $b) => strcmp($a->getDate(), $b->getDate()));
 
         $this->getView()->set('entrantsMapper', $entrantsMapper)
             ->set('trainings', $trainings);


### PR DESCRIPTION
# Description
Behenbt den Fehler : "foreach() argument must be of type array|object, null given in"

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [x] Firefox
- [ ] Opera
- [ ] Edge
