### PR TITLE
CI workflow: Add MariaDB latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,17 +67,17 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.4']
-        mariadb-versions: ['10.5']
+        mariadb-versions: ['10.5', 'latest']
 
     services:
       mariadb:
         image: mariadb:${{ matrix.mariadb-versions }}
         env:
-          MYSQL_RANDOM_ROOT_PASSWORD: yes
-          MYSQL_DATABASE: ilch2_test
-          MYSQL_USER: ilch2_test_user
-          MYSQL_PASSWORD: ilch2_test_password
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
+          MARIADB_RANDOM_ROOT_PASSWORD: yes
+          MARIADB_DATABASE: ilch2_test
+          MARIADB_USER: ilch2_test_user
+          MARIADB_PASSWORD: ilch2_test_password
+        options: --health-cmd="mariadb-admin ping" --health-interval=10s --health-timeout=10s --health-retries=10
         ports:
           - 3306:3306
 


### PR DESCRIPTION
# Description
- Add the latest version of MariaDB to the CI workflow.
- Use mariadb-admin instead of mysqladmin where required.

mysqladmin is no longer known in the official docker image of MariaDB 11 and newer.

> 11.0, unlike previous version, no longer includes mysql named compatible executable symlinks inside the container. 

https://mariadb.com/kb/en/mariadb-11-0-1-release-notes/#docker-official-images
https://jira.mariadb.org/browse/MDEV-29582

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
