### PR TITLE
Menu: Fix selecting of user groups

### DIFF
--- a/application/modules/admin/views/admin/menu/index.php
+++ b/application/modules/admin/views/admin/menu/index.php
@@ -173,27 +173,16 @@ function buildMenu($parentId, $menuData, View $view) {
         });
 
         function setChoices(selectedValues) {
-            let selectElement = $(accessElement);
-
             accessChoices.removeActiveItems();
 
             let values = [];
             if (typeof selectedValues === 'string') {
                 values = selectedValues.split(',').map(value => value.trim());
-
-
             } else if (typeof selectedValues === 'object') {
                 values = selectedValues.map(value => value.trim());
-
-
             }
-            selectElement.val(null).trigger('change');
-            selectElement.val(values).trigger('change');
-            accessChoices.setValue(values);
 
-            values.forEach(value => {
-                accessChoices.setChoiceByValue(value);
-            });
+            accessChoices.setChoiceByValue(values);
         }
 
         setChoices();
@@ -403,7 +392,7 @@ function buildMenu($parentId, $menuData, View $view) {
                 $('.dyn').html('');
             } else if ($(this).val() == '1') {
                 $('.dyn').html('<div class="row mb-3"><label for="href" class="col-xl-4 col-form-label"><?=$this->getTrans('address') ?></label>\n\
-                                <div class="col-xl-8"><input type="text" class="form-control" id="href" value="http://" /></div></div>\n\
+                                <div class="col-xl-8"><input type="text" class="form-control" id="href" value="https://" /></div></div>\n\
                                 <div class="row mb-3"><label for="target" class="col-xl-4 col-form-label"><?=$this->getTrans('target') ?></label>\n\
                                 <div class="col-xl-8"><select class="form-select" id="target"><?php foreach ($targets as $target => $translation) {
                     echo '<option value="' . $target . '">' . $this->getTrans($translation) . '</option>';
@@ -464,9 +453,7 @@ function buildMenu($parentId, $menuData, View $view) {
             $('#boxkey').val($(this).parent().find('.hidden_boxkey').val());
             $('#modulekey').val($(this).parent().find('.hidden_modulekey').val());
             $('#menukey').val($(this).parent().find('.hidden_menukey').val());
-
-            $(accessElement).val($(this).parent().find('.hidden_access').val());
-            setChoices($(accessElement).val());
+            setChoices($(this).parent().find('.hidden_access').val());
         });
     });
 </script>

--- a/application/modules/admin/views/admin/menu/index.php
+++ b/application/modules/admin/views/admin/menu/index.php
@@ -1,4 +1,5 @@
 <?php
+
 use Ilch\View;
 use Modules\Admin\Mappers\Menu as MenuMapper;
 use Modules\Admin\Models\MenuItem;
@@ -16,7 +17,8 @@ $targets = [
     '_top' => 'targetTop',
 ];
 
-function rec(MenuMapper $menuMapper, View $view) {
+function rec(MenuMapper $menuMapper, View $view)
+{
     $items = $menuMapper->getMenuItems($view->get('menu')->getId());
 
     // prepare array with parent-child relations
@@ -33,7 +35,8 @@ function rec(MenuMapper $menuMapper, View $view) {
     buildMenu(0, $menuData, $view);
 }
 
-function buildMenu($parentId, $menuData, View $view) {
+function buildMenu($parentId, $menuData, View $view)
+{
     $class = 'mjs-nestedSortable-branch mjs-nestedSortable-expanded';
 
     if (isset($menuData['parents'][$parentId])) {
@@ -64,6 +67,7 @@ function buildMenu($parentId, $menuData, View $view) {
                     <input type="hidden" class="hidden_siteid" name="items[' . $menuData['items'][$itemId]->getId() . '][siteid]" value="' . $menuData['items'][$itemId]->getSiteId() . '" />
                     <input type="hidden" class="hidden_boxkey" name="items[' . $menuData['items'][$itemId]->getId() . '][boxkey]" value="' . $boxKey . '" />
                     <input type="hidden" class="hidden_modulekey" name="items[' . $menuData['items'][$itemId]->getId() . '][modulekey]" value="' . $menuData['items'][$itemId]->getModuleKey() . '" />
+                    <input type="hidden" class="hidden_menukey" name="items[' . $menuData['items'][$itemId]->getId() . '][menukey]" value="' . $menuData['items'][$itemId]->getParentId() . '" />
                     <input type="hidden" class="hidden_access" name="items[' . $menuData['items'][$itemId]->getId() . '][access]" value="' . $menuData['items'][$itemId]->getAccess() . '" />
                     <span></span>
                 </span>


### PR DESCRIPTION
# Description
- Fix the selection of user groups for the "not visible for" setting of a menu item.

Fixes #1198

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
