### PR TITLE
Downloads: Various improvements

### DIFF
--- a/application/modules/downloads/config/config.php
+++ b/application/modules/downloads/config/config.php
@@ -27,8 +27,8 @@ class Config extends \Ilch\Config\Install
                 'description' => 'You can create downloads and add information to them. Further you can add them to categories.',
             ],
         ],
-        'ilchCore' => '2.2.0',
-        'phpVersion' => '7.3'
+        'ilchCore' => '2.2.7',
+        'phpVersion' => '7.4'
     ];
 
     public function install()

--- a/application/modules/downloads/controllers/Index.php
+++ b/application/modules/downloads/controllers/Index.php
@@ -21,7 +21,7 @@ class Index extends Frontend
         $downloadsMapper = new DownloadsMapper();
         $fileMapper = new FileMapper();
 
-        $downloadsItems = $downloadsMapper->getDownloadsItemsByParent(1, 0);
+        $downloadsItems = $downloadsMapper->getDownloadsItemsByParent(0);
 
         $this->getLayout()->getTitle()
                 ->add($this->getTranslator()->trans('downloads'));
@@ -60,7 +60,7 @@ class Index extends Frontend
         $pagination->setRowsPerPage(!$this->getConfig()->get('downloads_downloadsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
-        $this->getView()->set('files', $fileMapper->getFileByDownloadsId($id, $pagination));
+        $this->getView()->set('files', $fileMapper->getFilesByItemId($id, $pagination));
         $this->getView()->set('pagination', $pagination);
     }
 
@@ -79,7 +79,7 @@ class Index extends Frontend
                 ->add($this->getTranslator()->trans('menuDownloadsOverview'), ['action' => 'index']);
 
         if ($file !== null) {
-            $download = $downloadsMapper->getDownloadsById($file->getCat());
+            $download = $downloadsMapper->getDownloadsById($file->getItemId());
 
             $this->getLayout()->getTitle()
                     ->add($download->getTitle())

--- a/application/modules/downloads/controllers/admin/Downloads.php
+++ b/application/modules/downloads/controllers/admin/Downloads.php
@@ -76,7 +76,7 @@ class Downloads extends Admin
                 $catId = $this->getRequest()->getParam('id');
                 $model = new FileModel();
                 $model->setFileId($fileId);
-                $model->setCat($catId);
+                $model->setItemId($catId);
                 $model->setFileTitle($file->getName());
                 $fileMapper->save($model);
             }
@@ -84,7 +84,7 @@ class Downloads extends Admin
 
         $pagination->setRowsPerPage(!$this->getConfig()->get('downloads_downloadsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
-        $this->getView()->set('files', $fileMapper->getFileByDownloadsId($id, $pagination));
+        $this->getView()->set('files', $fileMapper->getFilesByItemId($id, $pagination));
         $this->getView()->set('pagination', $pagination);
         $this->getView()->set('downloadsTitle', $downloadsTitle->getTitle());
     }

--- a/application/modules/downloads/controllers/admin/Index.php
+++ b/application/modules/downloads/controllers/admin/Index.php
@@ -45,18 +45,14 @@ class Index extends Admin
         $downloadsMapper = new DownloadsMapper();
         $fileMapper = new FileMapper();
 
-        /*
-         * Saves the item tree to database.
-         */
+        // Saves the item tree to database.
         if ($this->getRequest()->isPost()) {
             if ($this->getRequest()->getPost('save')) {
                 $sortItems = json_decode($this->getRequest()->getPost('hiddenMenu'));
                 $items = $this->getRequest()->getPost('items');
                 $oldItems = $downloadsMapper->getDownloadsItems();
 
-                /*
-                 * Deletes old entries from database.
-                 */
+                // Deletes old entries from database.
                 if (!empty($oldItems)) {
                     foreach ($oldItems as $oldItem) {
                         if (!isset($items[$oldItem->getId()])) {

--- a/application/modules/downloads/controllers/admin/Index.php
+++ b/application/modules/downloads/controllers/admin/Index.php
@@ -52,7 +52,7 @@ class Index extends Admin
             if ($this->getRequest()->getPost('save')) {
                 $sortItems = json_decode($this->getRequest()->getPost('hiddenMenu'));
                 $items = $this->getRequest()->getPost('items');
-                $oldItems = $downloadsMapper->getDownloadsItems(1);
+                $oldItems = $downloadsMapper->getDownloadsItems();
 
                 /*
                  * Deletes old entries from database.
@@ -83,7 +83,6 @@ class Index extends Admin
                             $downloadsItem->setId($item['id']);
                         }
 
-                        $downloadsItem->setDownloadsId(1);
                         $downloadsItem->setType($item['type']);
                         $downloadsItem->setTitle($item['title']);
                         $downloadsItem->setDesc($item['desc']);
@@ -120,7 +119,7 @@ class Index extends Admin
             $this->redirect(['action' => 'index']);
         }
 
-        $downloadsItems = $downloadsMapper->getDownloadsItemsByParent(1, 0);
+        $downloadsItems = $downloadsMapper->getDownloadsItemsByParent(0);
         $this->getView()->set('downloadsItems', $downloadsItems);
         $this->getView()->set('downloadsMapper', $downloadsMapper);
         $this->getView()->set('fileMapper', $fileMapper);

--- a/application/modules/downloads/mappers/Downloads.php
+++ b/application/modules/downloads/mappers/Downloads.php
@@ -13,18 +13,48 @@ use Modules\Downloads\Models\DownloadsItem;
 class Downloads extends Mapper
 {
     /**
+     * Gets all Downloads items by Downloads id.
+     *
+     * @return array|null
+     */
+    public function getDownloadsItems(): ?array
+    {
+        $items = [];
+        $itemRows = $this->db()->select('*')
+            ->from('downloads_items')
+            ->order(['sort' => 'ASC'])
+            ->execute()
+            ->fetchRows();
+
+        if (empty($itemRows)) {
+            return null;
+        }
+
+        foreach ($itemRows as $itemRow) {
+            $itemModel = new DownloadsItem();
+            $itemModel->setId($itemRow['id']);
+            $itemModel->setType($itemRow['type']);
+            $itemModel->setTitle($itemRow['title']);
+            $itemModel->setDesc($itemRow['description']);
+            $itemModel->setParentId($itemRow['parent_id']);
+            $items[] = $itemModel;
+        }
+
+        return $items;
+    }
+
+    /**
      * Gets all Downloads items by parent item id.
      *
-     * @param int $downloadsId
      * @param int $itemId
      * @return array|null
      */
-    public function getDownloadsItemsByParent(int $downloadsId, int $itemId): ?array
+    public function getDownloadsItemsByParent(int $itemId): ?array
     {
         $items = [];
         $itemRows = $this->db()->select('*')
                 ->from('downloads_items')
-                ->where(['downloads_id' => $downloadsId, 'parent_id' => $itemId])
+                ->where(['parent_id' => $itemId])
                 ->order(['sort' => 'ASC'])
                 ->execute()
                 ->fetchRows();
@@ -40,41 +70,6 @@ class Downloads extends Mapper
             $itemModel->setTitle($itemRow['title']);
             $itemModel->setDesc($itemRow['description']);
             $itemModel->setParentId($itemId);
-            $itemModel->setDownloadsId($downloadsId);
-            $items[] = $itemModel;
-        }
-
-        return $items;
-    }
-
-    /**
-     * Gets all Downloads items by type.
-     *
-     * @param int $type
-     * @return array|null
-     */
-    public function getDownloadsCatItem(int $type): ?array
-    {
-        $items = [];
-        $itemRows = $this->db()->select('*')
-                ->from('downloads_items')
-                ->where(['type' => $type])
-                ->order(['sort' => 'ASC'])
-                ->execute()
-                ->fetchRows();
-
-        if (empty($itemRows)) {
-            return null;
-        }
-
-        foreach ($itemRows as $itemRow) {
-            $itemModel = new DownloadsItem();
-            $itemModel->setId($itemRow['id']);
-            $itemModel->setType($itemRow['type']);
-            $itemModel->setTitle($itemRow['title']);
-            $itemModel->setDesc($itemRow['description']);
-            $itemModel->setParentId($itemRow['parent_id']);
-            $itemModel->setDownloadsId($itemRow['downloads_id']);
             $items[] = $itemModel;
         }
 
@@ -106,7 +101,6 @@ class Downloads extends Mapper
         $itemModel->setTitle($itemRows['title']);
         $itemModel->setDesc($itemRows['description']);
         $itemModel->setParentId($itemRows['parent_id']);
-        $itemModel->setDownloadsId($itemRows['downloads_id']);
 
         return $itemModel;
     }
@@ -121,7 +115,6 @@ class Downloads extends Mapper
     {
         $fields = [
             'title' => $downloadsItem->getTitle(),
-            'downloads_id' => $downloadsItem->getDownloadsId(),
             'sort' => $downloadsItem->getSort(),
             'parent_id' => $downloadsItem->getParentId(),
             'type' => $downloadsItem->getType(),
@@ -164,39 +157,5 @@ class Downloads extends Mapper
         $this->db()->delete('downloads_items')
             ->where(['id' => $downloadsItem->getId()])
             ->execute();
-    }
-
-    /**
-     * Gets all Downloads items by Downloads id.
-     *
-     * @param int $downloadsId
-     * @return array|null
-     */
-    public function getDownloadsItems(int $downloadsId): ?array
-    {
-        $items = [];
-        $itemRows = $this->db()->select('*')
-                ->from('downloads_items')
-                ->where(['downloads_id' => $downloadsId])
-                ->order(['sort' => 'ASC'])
-                ->execute()
-                ->fetchRows();
-
-        if (empty($itemRows)) {
-            return null;
-        }
-
-        foreach ($itemRows as $itemRow) {
-            $itemModel = new DownloadsItem();
-            $itemModel->setId($itemRow['id']);
-            $itemModel->setType($itemRow['type']);
-            $itemModel->setTitle($itemRow['title']);
-            $itemModel->setDesc($itemRow['description']);
-            $itemModel->setParentId($itemRow['parent_id']);
-            $itemModel->setDownloadsId($downloadsId);
-            $items[] = $itemModel;
-        }
-
-        return $items;
     }
 }

--- a/application/modules/downloads/mappers/File.php
+++ b/application/modules/downloads/mappers/File.php
@@ -137,7 +137,7 @@ class File extends Mapper
     }
 
     /**
-     * Inserts or updates File entry.
+     * Inserts or updates file entry.
      *
      * @param FileModel $model
      */

--- a/application/modules/downloads/mappers/File.php
+++ b/application/modules/downloads/mappers/File.php
@@ -22,7 +22,7 @@ class File extends Mapper
      */
     public function getFileById(int $id): ?FileModel
     {
-        $fileRow = $this->db()->select(['g.file_id', 'g.cat', 'fileid' => 'g.id', 'g.visits', 'g.file_title', 'g.file_description', 'g.file_image', 'm.url', 'm.id', 'm.url_thumb'])
+        $fileRow = $this->db()->select(['g.file_id', 'g.item_id', 'fileid' => 'g.id', 'g.visits', 'g.file_title', 'g.file_description', 'g.file_image', 'm.url', 'm.id', 'm.url_thumb'])
             ->from(['g' => 'downloads_files'])
             ->join(['m' => 'media'], 'g.file_id = m.id', 'LEFT')
             ->where(['g.id' => $id])
@@ -40,24 +40,24 @@ class File extends Mapper
         $entryModel->setFileImage($fileRow['file_image']);
         $entryModel->setFileTitle($fileRow['file_title']);
         $entryModel->setFileDesc($fileRow['file_description']);
-        $entryModel->setCat($fileRow['cat']);
+        $entryModel->setItemId($fileRow['item_id']);
         $entryModel->setVisits($fileRow['visits']);
 
         return $entryModel;
     }
 
     /**
-     * Get the last file by it's id.
+     * Get the last file by the item id.
      *
-     * @param int $id
+     * @param int $itemId
      * @return FileModel|null
      */
-    public function getLastFileByDownloadsId(int $id): ?FileModel
+    public function getLastFileByItemId(int $itemId): ?FileModel
     {
-        $fileRow = $this->db()->select(['g.file_id', 'g.cat', 'fileid' => 'g.id', 'g.visits', 'g.file_title', 'g.file_description', 'g.file_image', 'm.url', 'm.id', 'm.url_thumb'])
+        $fileRow = $this->db()->select(['g.file_id', 'g.item_id', 'fileid' => 'g.id', 'g.visits', 'g.file_title', 'g.file_description', 'g.file_image', 'm.url', 'm.id', 'm.url_thumb'])
             ->from(['g' => 'downloads_files'])
             ->join(['m' => 'media'], 'g.file_id = m.id', 'LEFT')
-            ->where(['g.cat' => $id])
+            ->where(['g.item_id' => $itemId])
             ->order(['g.id' => 'DESC'])
             ->limit(1)
             ->execute()
@@ -79,52 +79,33 @@ class File extends Mapper
     }
 
     /**
-     * Get the count of files by category.
+     * Get the count of files by the item id.
      *
-     * @param int $catId id of the category
+     * @param int $itemId id of the item
      * @return int count of files
      */
-    public function getCountOfFilesByCategory(int $catId): int
+    public function getCountOfFilesByItemId(int $itemId): int
     {
         return (int)$this->db()->select('Count(*)')
             ->from(['downloads_files'])
-            ->where(['cat' => $catId])
+            ->where(['item_id' => $itemId])
             ->execute()
             ->fetchCell();
     }
 
     /**
-     * Inserts or updates File entry.
+     * Get the files by the item id.
      *
-     * @param FileModel $model
-     */
-    public function save(FileModel $model)
-    {
-        if ($model->getId()) {
-            $this->db()->update('downloads_files')
-                ->values(['file_id' => $model->getFileId(), 'cat' => $model->getCat(), 'file_title' => $model->getFileTitle()])
-                ->where(['id' => $model->getId()])
-                ->execute();
-        } else {
-            $this->db()->insert('downloads_files')
-                ->values(['file_id' => $model->getFileId(), 'cat' => $model->getCat(), 'file_title' => $model->getFileTitle()])
-                ->execute();
-        }
-    }
-
-    /**
-     * Get files by category id.
-     *
-     * @param int $id category id
+     * @param int $itemId id of the item
      * @param Pagination|null $pagination
      * @return array
      */
-    public function getFileByDownloadsId(int $id, ?Pagination $pagination = null): array
+    public function getFilesByItemId(int $itemId, ?Pagination $pagination = null): array
     {
-        $sql = $this->db()->select(['g.cat', 'fileid' => 'g.id', 'g.file_title', 'g.file_image', 'g.file_description', 'g.visits', 'm.url', 'm.url_thumb'])
+        $sql = $this->db()->select(['g.item_id', 'fileid' => 'g.id', 'g.file_title', 'g.file_image', 'g.file_description', 'g.visits', 'm.url', 'm.url_thumb'])
             ->from(['g' => 'downloads_files'])
             ->join(['m' => 'media'], 'g.file_image = m.url', 'LEFT')
-            ->where(['g.cat' => $id])
+            ->where(['g.item_id' => $itemId])
             ->order(['g.id' => 'DESC']);
 
         if ($pagination !== null) {
@@ -148,11 +129,30 @@ class File extends Mapper
             $fileModel->setFileImage($entry['url_thumb'] ?? '');
             $fileModel->setFileDesc($entry['file_description']);
             $fileModel->setVisits($entry['visits']);
-            $fileModel->setCat($entry['cat']);
+            $fileModel->setItemId($entry['item_id']);
             $entries[] = $fileModel;
         }
 
         return $entries;
+    }
+
+    /**
+     * Inserts or updates File entry.
+     *
+     * @param FileModel $model
+     */
+    public function save(FileModel $model)
+    {
+        if ($model->getId()) {
+            $this->db()->update('downloads_files')
+                ->values(['file_id' => $model->getFileId(), 'item_id' => $model->getItemId(), 'file_title' => $model->getFileTitle()])
+                ->where(['id' => $model->getId()])
+                ->execute();
+        } else {
+            $this->db()->insert('downloads_files')
+                ->values(['file_id' => $model->getFileId(), 'item_id' => $model->getItemId(), 'file_title' => $model->getFileTitle()])
+                ->execute();
+        }
     }
 
     /**

--- a/application/modules/downloads/models/DownloadsItem.php
+++ b/application/modules/downloads/models/DownloadsItem.php
@@ -19,44 +19,44 @@ class DownloadsItem extends Model
     /**
      * Id of the item.
      *
-     * @var int
+     * @var int|null
      */
-    protected $id;
+    protected ?int $id = null;
 
     /**
      * Sort of the item.
      *
      * @var int
      */
-    protected $sort;
+    protected int $sort = 0;
 
     /**
      * Type of the item.
      *
-     * @var int
+     * @var int|null
      */
-    protected $type;
+    protected ?int $type = null;
 
     /**
      * ParentId of the item.
      *
      * @var int
      */
-    protected $parentId;
+    protected int $parentId = 0;
 
     /**
      * Title of the item.
      *
-     * @var string
+     * @var string|null
      */
-    protected $title;
+    protected ?string $title = null;
 
     /**
      * Description of the item.
      *
-     * @var string
+     * @var string|null
      */
-    protected $desc;
+    protected ?string $desc = null;
 
     /**
      * Gets the id.

--- a/application/modules/downloads/models/DownloadsItem.php
+++ b/application/modules/downloads/models/DownloadsItem.php
@@ -38,13 +38,6 @@ class DownloadsItem extends Model
     protected $type;
 
     /**
-     * DownloadsId of the item.
-     *
-     * @var int
-     */
-    protected $downloadsId;
-
-    /**
      * ParentId of the item.
      *
      * @var int
@@ -123,26 +116,6 @@ class DownloadsItem extends Model
     public function setType(int $type)
     {
         $this->type = $type;
-    }
-
-    /**
-     * Gets the Downloads id.
-     *
-     * @return int|null
-     */
-    public function getDownloadsId(): ?int
-    {
-        return $this->downloadsId;
-    }
-
-    /**
-     * Sets the Downloads id.
-     *
-     * @param int $id
-     */
-    public function setDownloadsId(int $id)
-    {
-        $this->downloadsId = $id;
     }
 
     /**

--- a/application/modules/downloads/models/File.php
+++ b/application/modules/downloads/models/File.php
@@ -47,11 +47,11 @@ class File extends Model
     protected $file_image;
 
     /**
-     * The cat of the file.
+     * The item id of the file.
      *
      * @var string
      */
-    protected $cat;
+    protected $item_id;
 
     /**
      * The visits of the file.
@@ -133,13 +133,13 @@ class File extends Model
     }
 
     /**
-     * Gets the cat of the file.
+     * Gets the item id of the file.
      *
      * @return string
      */
-    public function getCat(): string
+    public function getItemId(): string
     {
-        return $this->cat;
+        return $this->item_id;
     }
 
     /**
@@ -223,13 +223,13 @@ class File extends Model
     }
 
     /**
-     * Sets the cat of the file.
+     * Sets the item id of the file.
      *
-     * @param string $cat
+     * @param int $itemId
      */
-    public function setCat(string $cat)
+    public function setItemId(int $itemId)
     {
-        $this->cat = $cat;
+        $this->item_id = $itemId;
     }
 
     /**

--- a/application/modules/downloads/models/File.php
+++ b/application/modules/downloads/models/File.php
@@ -14,63 +14,63 @@ class File extends Model
     /**
      * The id of the image.
      *
-     * @var int
+     * @var int|null
      */
-    protected $id;
+    protected ?int $id = null;
 
     /**
      * The fileId of the file.
      *
-     * @var string
+     * @var int
      */
-    protected $file_id;
+    protected int $file_id;
 
     /**
      * Title of the file.
      *
      * @var string
      */
-    protected $file_title;
+    protected string $file_title;
 
     /**
      * Description of the file.
      *
      * @var string
      */
-    protected $file_desc;
+    protected string $file_desc;
 
     /**
      * Image of the file.
      *
      * @var string
      */
-    protected $file_image;
+    protected string $file_image;
 
     /**
      * The item id of the file.
      *
-     * @var string
+     * @var int
      */
-    protected $item_id;
+    protected int $item_id;
 
     /**
      * The visits of the file.
      *
-     * @var string
+     * @var int
      */
-    protected $visits;
+    protected int $visits;
 
     /**
      * The imageUrl of the file.
      *
      * @var string
      */
-    protected $file_url;
+    protected string $file_url;
 
     /**
      * @var string
      */
-    private $filethumb;
+    private string $filethumb;
 
     /**
      * Gets the id of the file.

--- a/application/modules/downloads/views/admin/downloads/treatdownloads.php
+++ b/application/modules/downloads/views/admin/downloads/treatdownloads.php
@@ -53,7 +53,7 @@ tbody tr td {
                         <?php endif; ?>
                         <tr>
                             <td><?=$this->getDeleteCheckbox('check_downloads', $file->getId()) ?></td>
-                            <td><?=$this->getEditIcon(['controller' => 'file', 'action' => 'treatfile', 'downloads' => $file->getCat(), 'id' => $file->getId()]) ?></td>
+                            <td><?=$this->getEditIcon(['controller' => 'file', 'action' => 'treatfile', 'downloads' => $file->getItemId(), 'id' => $file->getId()]) ?></td>
                             <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $file->getId(), 'downloads' => $this->getRequest()->getParam('id')]) ?></td>
                             <td><img class="file img-thumbnail img-fluid" src="<?=$image ?>" alt="<?=$this->escape($file->getFileTitle()) ?>" />
                             </td>

--- a/application/modules/downloads/views/admin/index/index.php
+++ b/application/modules/downloads/views/admin/index/index.php
@@ -16,8 +16,8 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
     /** @var \Modules\Downloads\Mappers\File $fileMapper */
     $fileMapper = $obj->get('fileMapper');
 
-    $subItems = $downloadsMapper->getDownloadsItemsByParent('1', $item->getId());
-    $fileCount = $fileMapper->getCountOfFilesByCategory($item->getId());
+    $subItems = $downloadsMapper->getDownloadsItemsByParent($item->getId());
+    $fileCount = $fileMapper->getCountOfFilesByItemId($item->getId());
     $class = 'mjs-nestedSortable-branch mjs-nestedSortable-expanded';
 
     if (empty($subItems)) {
@@ -122,7 +122,7 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
             </div>
         </div>
         <input type="hidden" id="hiddenMenu" name="hiddenMenu" value="" />
-        <?=$this->getSaveBar('saveButton') ?>
+        <?=$this->getSaveBar() ?>
     </div>
 </form>
 

--- a/application/modules/downloads/views/index/index.php
+++ b/application/modules/downloads/views/index/index.php
@@ -71,8 +71,8 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
     /** @var \Modules\Downloads\Mappers\File $fileMapper */
     $fileMapper = $obj->get('fileMapper');
 
-    $subItems = $downloadsMapper->getDownloadsItemsByParent('1', $item->getId());
-    $fileCount = $fileMapper->getCountOfFilesByCategory($item->getId());
+    $subItems = $downloadsMapper->getDownloadsItemsByParent($item->getId());
+    $fileCount = $fileMapper->getCountOfFilesByItemId($item->getId());
 
     if ($item->getType() === 0) {
         echo '<div class="page-header">
@@ -80,7 +80,7 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
               </h4><hr>';
     }
     if ($item->getType() != 0) {
-        $lastFile = $fileMapper->getLastFileByDownloadsId($item->getId()) ;
+        $lastFile = $fileMapper->getLastFileByItemId($item->getId()) ;
         $image = $obj->getBaseUrl('application/modules/media/static/img/nomedia.png');
         if ($lastFile && $lastFile->getFileImage() != '') {
             $image = $obj->getBaseUrl($lastFile->getFileImage()) ;

--- a/application/modules/downloads/views/index/show.php
+++ b/application/modules/downloads/views/index/show.php
@@ -30,11 +30,6 @@ $pagination = $this->get('pagination');
 
     .card-footer {
         padding: 5px !important;
-        color: #BBB;
-    }
-
-    .card-footer:hover {
-        color: #000;
     }
 
     .thumbnail {

--- a/application/modules/downloads/views/index/show.php
+++ b/application/modules/downloads/views/index/show.php
@@ -8,68 +8,75 @@ $pagination = $this->get('pagination');
 ?>
 
 <style>
-@media (max-width: 990px) {
-    #gallery > [class*="col-"] {
-        padding: 0 !important;
+    @media (max-width: 990px) {
+        #gallery > [class*="col-"] {
+            padding: 0 !important;
+        }
     }
-}
 
-.panel-heading ~ .panel-image img.panel-image-preview {
-    border-radius: 0;
-}
-.panel-body {
-    overflow: hidden;
-}
-.panel-image ~ .panel-footer a {
-    padding: 0 10px;
-    font-size: 1.3em;
-    color: rgb(100, 100, 100);
-}
-.panel-footer{
-    padding: 5px !important;
-    color: #BBB;
-}
-.panel-footer:hover{
-    color: #000;
-}
+    .panel-heading ~ .card-image img {
+        border-radius: 0;
+    }
 
-.thumbnail {
-    position:relative;
-    overflow:hidden;
-    margin-bottom: 0 !important;
-}
-#gallery img{
-    min-height: 20px;
-}
+    .card-body {
+        overflow: hidden;
+    }
+
+    .card-image ~ .card-footer a {
+        padding: 0 10px;
+        font-size: 1.3em;
+        color: rgb(100, 100, 100);
+    }
+
+    .card-footer {
+        padding: 5px !important;
+        color: #BBB;
+    }
+
+    .card-footer:hover {
+        color: #000;
+    }
+
+    .thumbnail {
+        position: relative;
+        overflow: hidden;
+        margin-bottom: 0 !important;
+    }
+
+    #gallery img {
+        min-height: 20px;
+    }
 </style>
 
 <div id="gallery">
-    <?php
-    /** @var \Modules\Downloads\Models\File $file */
-    foreach ($this->get('files') as $file) :
-        $commentsCount = $commentMapper->getCountComments('downloads/index/showfile/id/' . $file->getId());
-        $image = '';
-        if ($file->getFileImage() != '') {
-            $image = $this->getBaseUrl($file->getFileImage());
-        } else {
-            $image = $this->getBaseUrl('application/modules/media/static/img/nomedia.png');
-        }
-        ?>
-        <div class="col-6 col-lg-4 col-xl-3 col-md-4">
-            <div class="card card-default">
-                <div class="card-image me-auto ms-auto thumbnail">
-                    <a href="<?=$this->getUrl(['action' => 'showfile', 'id' => $file->getId()]) ?>">
-                        <img src="<?=$image ?>" class="panel-image-preview" alt="<?=$this->escape($file->getFileTitle()) ?>" />
-                    </a>
-                </div>
-                <div class="card-footer text-center">
-                    <i class="fa-solid fa-pencil"></i> <?=$this->escape($file->getFileTitle()) ?><br>
-                    <i class="fa-regular fa-comment"></i> <?=$commentsCount ?>
-                    <i class="fa-solid fa-eye"></i> <?=$file->getVisits() ?>
+    <div class="row">
+        <?php
+        /** @var \Modules\Downloads\Models\File $file */
+        foreach ($this->get('files') as $file) :
+            $commentsCount = $commentMapper->getCountComments('downloads/index/showfile/id/' . $file->getId());
+            $image = '';
+            if ($file->getFileImage() != '') {
+                $image = $this->getBaseUrl($file->getFileImage());
+            } else {
+                $image = $this->getBaseUrl('application/modules/media/static/img/nomedia.png');
+            }
+            ?>
+            <div class="col-6 col-lg-4 col-xl-3 col-md-4">
+                <div class="card card-default">
+                    <div class="card-body card-image me-auto ms-auto thumbnail">
+                        <a href="<?=$this->getUrl(['action' => 'showfile', 'id' => $file->getId()]) ?>">
+                            <img src="<?=$image ?>" class="card-image-preview" alt="<?=$this->escape($file->getFileTitle()) ?>" />
+                        </a>
+                    </div>
+                    <div class="card-footer text-center">
+                        <i class="fa-solid fa-pencil"></i> <?=$this->escape($file->getFileTitle()) ?><br>
+                        <i class="fa-regular fa-comment"></i> <?=$commentsCount ?>
+                        <i class="fa-solid fa-eye"></i> <?=$file->getVisits() ?>
+                    </div>
                 </div>
             </div>
-        </div>
-    <?php endforeach; ?>
+        <?php endforeach; ?>
+    </div>
     <?php if (empty($this->get('files'))) : ?>
         <?=$this->getTrans('downloadNotFound') ?>
     <?php endif; ?>


### PR DESCRIPTION
# Description
- Removed the unused column "downloads_id" of the "downloads_items" table. This one always had the value 1.
- Changed the data type of the "type" column in the "downloads_items" table from "INT(11)" to "TINYINT(1)".
- Changed the data type of the "cat" column in the "downloads_files" table from "MEDIUMINT(9)" to "INT(11)". Relation with id column of the downloads_items table.
- Renamed the column "cat" to "item_id".
- Changed the data type of the "file_id" column in the "downloads_files" table from "VARCHAR(150)" to "INT(11)". Relation with id column of the media table. See also: https://github.com/IlchCMS/Ilch-2.0/issues/879
- Delete (orphaned) rows with an "item_id" that does not exist in the "downloads_items" table.
- Added a FKC to the "downloads_files" table.
- Renamed several functions of the files mapper.
- Removed the getter and setter for "downloads_id".
- Renamed getter and setter for item_id (previously "cat").
- Fixed cards/files being shown below each other instead of next to each other according to the available space. See forum topic: https://www.ilch.de/forum-showposts-58820.html
- Code style fixes mostly in the models.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
