### PR TITLE
Birthday: Fix date format for the date validator

### DIFF
--- a/application/modules/birthday/config/config.php
+++ b/application/modules/birthday/config/config.php
@@ -10,7 +10,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'birthday',
-        'version' => '1.7.0',
+        'version' => '1.7.1',
         'icon_small' => 'fa-solid fa-cake-candles',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/birthday/controllers/Birthdays.php
+++ b/application/modules/birthday/controllers/Birthdays.php
@@ -23,8 +23,8 @@ class Birthdays extends \Ilch\Controller\Frontend
             $input = $this->getRequest()->getQuery();
             $validation = Validation::create(
                 $input, [
-                    'start' => 'required|date',
-                    'end'   => 'required|date',
+                    'start' => 'required|date:Y-m-d\TH\\:i\\:sP',
+                    'end'   => 'required|date:Y-m-d\TH\\:i\\:sP',
                 ]
             );
 


### PR DESCRIPTION
# Description
- Fix date format for the date validator

The date from fullcalendar is like this:
2025-04-28T00:00:00+02:00

Cherry picked from this branch:
https://github.com/IlchCMS/Ilch-2.0/compare/birthday-fixes-issue1213?expand=1

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
