### PR TITLE
Remove dead code from buildMenu function

### DIFF
--- a/application/libraries/Ilch/Layout/Helper/GetMenu.php
+++ b/application/libraries/Ilch/Layout/Helper/GetMenu.php
@@ -31,7 +31,7 @@ class GetMenu
     ];
 
     /** @var Layout */
-    private $layout;
+    private Layout $layout;
 
     /**
      * Injects the layout.
@@ -55,9 +55,7 @@ class GetMenu
     {
         $helperMapper = new MapperHelper($this->layout);
         $menuMapper = new MenuMapper();
-        $menu = $helperMapper->getMenu($menuMapper->getMenuIdForPosition($menuId) ?? 0);
-
-        //TODO: optimize loading of menus (less queries!!!)
+        $menu = $helperMapper->getMenu($menuMapper->getMenuIdForPosition($menuId) ?? 1);
 
         return $menu->getItems($tpl, array_replace_recursive(self::DEFAULT_OPTIONS, $options));
     }

--- a/application/libraries/Ilch/Layout/Helper/GetMenus.php
+++ b/application/libraries/Ilch/Layout/Helper/GetMenus.php
@@ -8,12 +8,13 @@
 namespace Ilch\Layout\Helper;
 
 use Ilch\Layout\Base as Layout;
-use Ilch\Layout\Helper\Menu\Mapper;
+use Ilch\Layout\Helper\Menu\Mapper as MenuMapper;
+use Ilch\Layout\Helper\Menu\Model as MenuModel;
 
 class GetMenus
 {
     /** @var Layout */
-    private $layout;
+    private Layout $layout;
 
     /**
      * Injects the layout.
@@ -28,11 +29,11 @@ class GetMenus
     /**
      * Gets all menus.
      *
-     * @return \Ilch\Layout\Helper\Menu\Model[]
+     * @return MenuModel[]
      */
     public function getMenus(): array
     {
-        $helperMapper = new Mapper($this->layout);
+        $helperMapper = new MenuMapper($this->layout);
 
         return $helperMapper->getMenus();
     }

--- a/application/libraries/Ilch/Layout/Helper/Menu/Mapper.php
+++ b/application/libraries/Ilch/Layout/Helper/Menu/Mapper.php
@@ -7,26 +7,30 @@
 
 namespace Ilch\Layout\Helper\Menu;
 
+use Ilch\Database\Mysql;
+use Ilch\Layout\Base;
+use Ilch\Registry;
+
 class Mapper
 {
     /**
-     * @var \Ilch\Database\Mysql
+     * @var Mysql
      */
     protected $db;
 
     /**
-     * @var \Ilch\Layout\Base
+     * @var Base
      */
-    protected $layout;
+    protected Base $layout;
 
     /**
      * Injects layout and gets database.
      *
-     * @param \Ilch\Layout\Base $layout
+     * @param Base $layout
      */
-    public function __construct(\Ilch\Layout\Base $layout)
+    public function __construct(Base $layout)
     {
-        $this->db = \Ilch\Registry::get('db');
+        $this->db = Registry::get('db');
         $this->layout = $layout;
     }
 
@@ -38,13 +42,15 @@ class Mapper
     public function getMenus(): array
     {
         $menus = [];
-        $menuRows = $this->db->select(['id'])
+        $menuRows = $this->db->select(['id', 'title'])
             ->from('menu')
             ->execute()
             ->fetchRows();
 
         foreach ($menuRows as $menuRow) {
-            $menu = $this->getMenu($menuRow['id']);
+            $menu = new Model($this->layout);
+            $menu->setId($menuRow['id']);
+            $menu->setTitle($menuRow['title']);
             $menus[] = $menu;
         }
 


### PR DESCRIPTION
# Description
- Remove dead code from buildMenu function.
- Other smaller changes.

Removed code like below for the link and span class. Unit tests still pass.
```
...
// link classes
if ($parentType === $menuData['items'][$itemId]::TYPE_MENU || array_dot($options, 'menus.a-class')) {
    $aClasses[] = array_dot($options, 'menus.a-class');
} else {
    $aClasses[] = array_dot($options, 'menus.a-class');
}
...
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
