### PR TITLE
Backups: Fix error with argument null

### DIFF
--- a/application/modules/admin/controllers/admin/Backup.php
+++ b/application/modules/admin/controllers/admin/Backup.php
@@ -269,7 +269,7 @@ class Backup extends \Ilch\Controller\Admin
         if ($this->getRequest()->isSecure()) {
             // Look for new backup files that have been uploaded to the backups directory.
             $backupMapper = new BackupMapper();
-            $backups = $backupMapper->getBackups();
+            $backups = $backupMapper->getBackups() ?? [];
             $directory = ROOT_PATH . '/backups/';
             $backupsInDirectory = glob($directory . '*.sql*');
             $newBackupFiles = [];


### PR DESCRIPTION
# Description
- Fix "foreach() argument must be of type array|object, null given"

```
Warning:  foreach() argument must be of type array|object, null given in application\modules\admin\controllers\admin\Backup.php on line 279
Stack trace:
    1. {main}() index.php:0
    2. Ilch\Page->loadPage() index.php:68
    3. Ilch\Page->loadController() application\libraries\Ilch\Page.php:137
    4. Modules\Admin\Controllers\Admin\Backup->refreshAction() application\libraries\Ilch\Page.php:243
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
