### PR TITLE
Remove deletion of translation.umd.js

### DIFF
--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -1232,9 +1232,6 @@ class Config extends \Ilch\Config\Install
             case "2.2.10":
                 // Update vendor folder to update Bootstrap to version 5.3.5 and PHPMailer to version 6.10.0.
                 replaceVendorDirectory();
-
-                // Remove no longer existing "translation.umd.js" from CKEditor 5.
-                unlink(ROOT_PATH . '/static/js/ckeditor/translations/translation.umd.js');
                 break;
         }
 


### PR DESCRIPTION
# Description
- Remove deletion of translation.umd.js

Couldn't find that file in the last releases and the path was wrong.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
