### PR TITLE
GitHub CI: Test with latest MySQL and limit jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,8 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        mysql-versions: ['5.7']
+        php-versions: ['7.4', '8.4']
+        mysql-versions: ['5.7', 'latest']
 
     services:
       mysql:

--- a/tests/PHPUnit/Ilch/DatabaseTestCase.php
+++ b/tests/PHPUnit/Ilch/DatabaseTestCase.php
@@ -135,8 +135,7 @@ abstract class DatabaseTestCase extends \PHPUnit\Framework\TestCase
 
         $db->query('SET FOREIGN_KEY_CHECKS = 0;');
         foreach ($tableList as $table) {
-            $sql = 'DROP TABLE IF EXISTS ' . $table;
-            $db->query($sql);
+            $db->drop($table, true);
         }
         $db->query('SET FOREIGN_KEY_CHECKS = 1;');
     }


### PR DESCRIPTION
# Description
- Make sure table names are quoted by backticks by using the drop function of the QueryBuilder.
- GitHub CI: Test with latest MySQL and limit jobs

Limit jobs needed to be run by only testing with oldest and newest supported PHP version.
We previously ran 8 jobs. This would have increased to at least 14 (all PHP versions and MySQL 5.7 and latest).

Thanks to @PrivatePHPCoder for finding the cause of the issue https://github.com/IlchCMS/Ilch-2.0/issues/1201#issuecomment-2902169517

The unit tests failed because since MySQL 8.0 "groups" is a reserved word:
https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-new-8-0-G

Fixes #1201
