### PR TITLE
history V1.10.2

### DIFF
--- a/application/modules/history/config/config.php
+++ b/application/modules/history/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'history',
-        'version' => '1.10.1',
+        'version' => '1.10.2',
         'icon_small' => 'fa-solid fa-clock-rotate-left',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -26,7 +26,7 @@ class Config extends \Ilch\Config\Install
             ],
         ],
         'ilchCore' => '2.2.0',
-        'phpVersion' => '7.3'
+        'phpVersion' => '7.4'
     ];
 
     public function install()
@@ -113,6 +113,11 @@ class Config extends \Ilch\Config\Install
                 }
                 // no break
             case "1.9.0":
+                // no break
+            case "1.10.0":
+                // no break
+            case "1.10.1":
+                // no break
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';

--- a/application/modules/history/views/admin/index/treat.php
+++ b/application/modules/history/views/admin/index/treat.php
@@ -17,7 +17,7 @@ $history = $this->get('history');
         <label for="date" class="col-lg-2 col-form-label">
             <?=$this->getTrans('date') ?>:
         </label>
-        <div id="date" class="col-lg-2 input-group ilch-date date form_datetime">
+        <div id="date" class="col-lg-2 input-group date form_datetime">
             <?php
             $getDate = new \Ilch\Date($history->getDate() ?? 'now');
             ?>
@@ -60,7 +60,7 @@ $history = $this->get('history');
         <label for="symbol" class="col-xl-2 col-form-label">
             <?=$this->getTrans('symbol') ?>:
         </label>
-        <div class="col-xl-2 input-group ilch-date">
+        <div class="col-xl-2 input-group">
             <span class="input-group-text">
                 <span id="chosensymbol" class="<?=$this->originalInput('symbol', $history->getType())  ?>"></span>
             </span>
@@ -79,7 +79,7 @@ $history = $this->get('history');
         <label for="color" class="col-xl-2 col-form-label">
             <?=$this->getTrans('color') ?>:
         </label>
-        <div class="col-xl-2 input-group ilch-date">
+        <div class="col-xl-2 input-group">
             <input class="form-control color {hash:true}"
                    id="color"
                    name="color"


### PR DESCRIPTION
# Description
PHP-Version auf 7.4 gesetzt.
nicht mehr nötige "ilch-date" CSS-Klasse entfernt ( [#1232](https://github.com/IlchCMS/Ilch-2.0/issues/1232) ).

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [x] Firefox
- [ ] Opera
- [ ] Edge
