### PR TITLE
Fix: usort() erhält nun immer ein Array in search.php

### DIFF
--- a/application/modules/admin/views/admin/modules/search.php
+++ b/application/modules/admin/views/admin/modules/search.php
@@ -76,7 +76,8 @@ if (empty($modulesOnUpdateServer)) {
 }
 
 // Sort the modules by name
-usort($modulesOnUpdateServer, 'custom_sort');
+$items = is_array($modulesOnUpdateServer) ? $modulesOnUpdateServer : (array) $modulesOnUpdateServer;
+usort($items, 'custom_sort');
 ?>
 
 <div id="modules" class="table-responsive">


### PR DESCRIPTION
Behebt den Fehler im Adminbereich -> Module -> Suche