### PR TITLE
Fix "Implicitly marking parameter as nullable is deprecated"

### DIFF
--- a/application/libraries/Ilch/View.php
+++ b/application/libraries/Ilch/View.php
@@ -52,7 +52,7 @@ class View extends Design\Base
      * @param string $deleteKey
      * @return string
      */
-    public function getSaveBar(string $saveKey = 'saveButton', string $nameKey = null, string $deleteKey = ''): string
+    public function getSaveBar(string $saveKey = 'saveButton', ?string $nameKey = null, string $deleteKey = ''): string
     {
         $html = '<div class="content_savebox">
                     <button type="submit" class="save_button btn btn-secondary" name="save' . $nameKey . '" value="save">


### PR DESCRIPTION
# Description
Fix "Deprecated: Ilch\View::getSaveBar(): Implicitly marking parameter $nameKey as nullable is deprecated, the explicit nullable type must be used instead"

https://www.ilch.de/forum-showposts-58866.html

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
