### PR TITLE
Fix null value error when saving disabled flipswitch settings in advS…

### DIFF
--- a/application/modules/admin/controllers/admin/Layouts.php
+++ b/application/modules/admin/controllers/admin/Layouts.php
@@ -351,7 +351,7 @@ class Layouts extends \Ilch\Controller\Admin
                     $layoutAdvSettingsModel = new LayoutAdvSettingsModel();
                     $layoutAdvSettingsModel->setLayoutKey($layoutKey)
                         ->setKey($key)
-                        ->setValue($this->getRequest()->getPost($key));
+                        ->setValue($this->getRequest()->getPost($key) ?? $value['default'] ?? '');
                     $postedSettings[] = $layoutAdvSettingsModel;
                 }
             }


### PR DESCRIPTION
Beim Speichern der erweiterten Layout-Einstellungen kam es zu einem Fatal Error, 
wenn ein Flipswitch deaktiviert war:

Fatal error: Modules\Admin\Models\LayoutAdvSettings::setValue(): 
Argument #1 ($value) must be of type string, null given...


In advSettingsShowAction() wird nun ein Null-Coalescing-Operator verwendet.
