### PR TITLE
fix: Zeilenenden in var_export_short_syntax und FunctionsTest korrigiert

### DIFF
--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -304,7 +304,7 @@ function var_export_short_syntax($var, string $indent = ''): string
                     . ($indexed ? '' : var_export_short_syntax($key) . ' => ')
                     . var_export_short_syntax($value, "$indent    ");
             }
-            return "[\n" . implode(",\n", $r) . "\n" . $indent . ']';
+            return '[' . PHP_EOL . implode(',' . PHP_EOL, $r) . PHP_EOL . $indent . ']';
         case 'boolean':
             return $var ? 'TRUE' : 'FALSE';
         default:

--- a/tests/libraries/ilch/FunctionsTest.php
+++ b/tests/libraries/ilch/FunctionsTest.php
@@ -131,7 +131,7 @@ class FunctionsTest extends TestCase
     public function dpForTestUrlGetContents(): array
     {
         return [
-            'valid url' => ['params' => ['url' => 'https://raw.githubusercontent.com/IlchCMS/Ilch-2.0/master/development/.gitignore'], '/vendor' . PHP_EOL . '/bin/*' . PHP_EOL],
+            'valid url' => ['params' => ['url' => 'https://raw.githubusercontent.com/IlchCMS/Ilch-2.0/master/development/.gitignore'], '/vendor' . "\n" . '/bin/*' . "\n"],
             'invalid url' => ['params' => ['url' => ''], false],
         ];
     }


### PR DESCRIPTION
Unter Windows schlugen 2 Tests wegen unterschiedlicher Zeilenenden fehl:

- `var_export_short_syntax()` nutzte hardcoded `\n` statt dem betriebssystemspezifischen `PHP_EOL`
- Der Datenprovider in `testUrlGetContents` verwendete `PHP_EOL` um gegen eine Datei von GitHub 
  zu testen, die jedoch immer Unix-Zeilenenden (`\n`) liefert – unabhängig vom Betriebssystem
  
Alle 820 Tests laufen unter Windows (XAMPP) fehlerfrei durch:

PHPUnit 9.6.34 by Sebastian Bergmann and contributors.                        
                                                                              
...............................................................  63 / 820 (  7%)
............................................................... 126 / 820 ( 15%)
............................................................... 189 / 820 ( 23%)
............................................................... 252 / 820 ( 30%)
............................................................... 315 / 820 ( 38%)
............................................................... 378 / 820 ( 46%)
............................................................... 441 / 820 ( 53%)
............................................................... 504 / 820 ( 61%)
............................................................... 567 / 820 ( 69%)
............................................................... 630 / 820 ( 76%)
............................................................... 693 / 820 ( 84%)
............................................................... 756 / 820 ( 92%)
............................................................... 819 / 820 ( 99%)
.                                                               820 / 820 (100%)

Time: 01:54.437, Memory: 48.00 MB

OK (820 tests, 2626 assertions)
