### PR TITLE
Fix wrong breadcrumb parameter in comment admin show action

### DIFF
--- a/application/modules/comment/controllers/admin/Index.php
+++ b/application/modules/comment/controllers/admin/Index.php
@@ -71,7 +71,7 @@ class Index extends \Ilch\Controller\Admin
         $this->getLayout()->getAdminHmenu()
             ->add($this->getTranslator()->trans('menuComments'), ['action' => 'index'])
             ->add($this->getTranslator()->trans('manage'), ['action' => 'index'])
-            ->add($modules ? $modules->getName() : $this->getLayout()->escape($this->getRequest()->getParam('key')), ['action' => 'show', 'module' => $module]);
+            ->add($modules ? $modules->getName() : $this->getLayout()->escape($this->getRequest()->getParam('key')), ['action' => 'show', 'key' => $module]);
 
         if ($this->getRequest()->getPost('action') === 'delete' && $this->getRequest()->getPost('check_comments')) {
             foreach ($this->getRequest()->getPost('check_comments') as $commentId) {


### PR DESCRIPTION
## Zusammenfassung
Dieser PR behebt einen falschen Routenparameter im Breadcrumb der Kommentar-Adminansicht.

## Änderungen
- ersetze im Breadcrumb von `Modules\Comment\Controllers\Admin\Index::showAction()` den Parameter `module` durch `key`

## Warum
`showAction()` liest den Wert über `$this->getRequest()->getParam('key')`, der Breadcrumb-Link wurde aber mit `module` erzeugt. Dadurch zeigte der Breadcrumb auf eine inkonsistente URL.

## Test
- `php -l application/modules/comment/controllers/admin/Index.php`

Closes #1313