### PR TITLE
Handle unknown module keys in the comment admin overview

### DIFF
--- a/application/modules/comment/views/admin/index/index.php
+++ b/application/modules/comment/views/admin/index/index.php
@@ -28,10 +28,11 @@ $locale = $this->get('locale');
             <tbody>
                 <?php if ($this->get('modules')): ?>
                     <?php foreach ($this->get('modules') as $module): ?>
-                        <?php $modules = $modulesMapper->getModulesByKey($module, $locale); ?>
+                        <?php $moduleEntry = $modulesMapper->getModulesByKey($module, $locale); ?>
+                        <?php $moduleName = $moduleEntry ? $this->escape($moduleEntry->getName()) : $this->escape($module); ?>
                         <?php $comments = $commentMapper->getCommentsLikeKey($module); ?>
                         <tr>
-                            <td><a href="<?=$this->getUrl('admin/comment/index/show/key/' . $module) ?>"><?=$modules->getName() ?></a>
+                            <td><a href="<?=$this->getUrl('admin/comment/index/show/key/' . $module) ?>"><?=$moduleName ?></a>
                             <td class="text-center"><?=count($comments) ?></td>
                         </tr>
                     <?php endforeach; ?>


### PR DESCRIPTION
## Zusammenfassung
Dieser PR verhindert einen Fehler in der Kommentar-Adminuebersicht, wenn Kommentare zu unbekannten oder nicht mehr installierten Modul-Keys vorhanden sind.

## Aenderungen
- prueft den Rueckgabewert von `getModulesByKey()` vor dem Zugriff auf `getName()`
- faellt bei fehlendem Moduleintrag auf den Modul-Key als Anzeigenamen zurueck
- escaped den anzuzeigenden Modulnamen bzw. Key vor der Ausgabe

## Warum
`Modules\Admin\Mappers\Module::getModulesByKey()` kann `null` zurueckgeben. In der View wurde jedoch bisher ungeprueft `getName()` aufgerufen. Dadurch konnte die Kommentar-Adminuebersicht bei verwaisten Kommentar-Eintraegen mit einem Fehler abbrechen.

## Test
- `php -l application/modules/comment/views/admin/index/index.php`

Closes #1314