### PR TITLE
Escape senderEmail in contact form

### DIFF
--- a/application/modules/contact/views/index/index.php
+++ b/application/modules/contact/views/index/index.php
@@ -51,7 +51,7 @@
                        class="form-control"
                        id="email"
                        name="senderEmail"
-                       value="<?=$this->originalInput('senderEmail') ?>" />
+                       value="<?=$this->escape($this->originalInput('senderEmail')) ?>" />
             </div>
         </div>
         <div class="row mb-3<?=$this->validation()->hasError('message') ? ' has-error' : '' ?>">


### PR DESCRIPTION
## Zusammenfassung
Dieser PR behebt eine ungefilterte Ausgabe im Kontaktformular nach einem Validierungsfehler.

## Aenderungen
- escaped `senderEmail` vor der Ausgabe im `value`-Attribut
- richtet das Verhalten an den bereits korrekt maskierten Nachbarfeldern `senderName` und `message` aus

## Warum
Nach einem fehlgeschlagenen Formular-Submit wurde der zuvor eingegebene Wert von `senderEmail` ungefiltert wieder in das HTML geschrieben. Dadurch konnten reflektierte HTML- oder Script-Inhalte in die Seite gelangen.

## Test
- `php -l application/modules/contact/views/index/index.php`

Closes #1315