### PR TITLE
Update CI: Test against PHP 8.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4', '8.4']
+        php-versions: ['7.4', '8.5']
         mysql-versions: ['5.7', 'latest']
 
     services:
@@ -66,7 +66,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.4']
+        php-versions: ['8.5']
         mariadb-versions: ['10.5', 'latest']
 
     services:


### PR DESCRIPTION
# Description
- Update CI: Test against PHP 8.5

PHP 8.5 was released on Nov 20, 2025.
