### PR TITLE
Remove unnecessary ui/widget.js file from build

### DIFF
--- a/application/modules/media/views/admin/iframe/upload.php
+++ b/application/modules/media/views/admin/iframe/upload.php
@@ -27,7 +27,6 @@
 </div>
 
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/jquery.knob.min.js') ?>"></script>
-<script src="<?=$this->getVendorUrl('npm-asset/jquery-ui/ui/widget.js') ?>"></script>
 <script src="<?=$this->getStaticUrl('js/blueimp/jquery-file-upload/js/jquery.iframe-transport.js') ?>"></script>
 <script src="<?=$this->getStaticUrl('js/blueimp/jquery-file-upload/js/jquery.fileupload.js') ?>"></script>
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/script.js') ?>"></script>

--- a/application/modules/media/views/admin/iframe/uploadckeditor.php
+++ b/application/modules/media/views/admin/iframe/uploadckeditor.php
@@ -22,7 +22,6 @@
 </div>
 
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/jquery.knob.min.js') ?>"></script>
-<script src="<?=$this->getVendorUrl('npm-asset/jquery-ui/ui/widget.js') ?>"></script>
 <script src="<?=$this->getStaticUrl('js/blueimp/jquery-file-upload/js/jquery.iframe-transport.js') ?>"></script>
 <script src="<?=$this->getStaticUrl('js/blueimp/jquery-file-upload/js/jquery.fileupload.js') ?>"></script>
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/script.js') ?>"></script>

--- a/application/modules/media/views/admin/index/upload.php
+++ b/application/modules/media/views/admin/index/upload.php
@@ -35,7 +35,6 @@ $desc .= '<strong>' . $this->getTrans('max_execution_time') . ' = ' . ini_get('m
 <?=$this->getDialog('infoModal', $this->getTrans('info'), $desc) ?>
 
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/jquery.knob.min.js') ?>"></script>
-<script src="<?=$this->getVendorUrl('npm-asset/jquery-ui/ui/widget.js') ?>"></script>
 <script src="<?=$this->getStaticUrl('js/blueimp/jquery-file-upload/js/jquery.iframe-transport.js') ?>"></script>
 <script src="<?=$this->getStaticUrl('js/blueimp/jquery-file-upload/js/jquery.fileupload.js') ?>"></script>
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/script.js') ?>"></script>

--- a/application/modules/user/views/iframe/upload.php
+++ b/application/modules/user/views/iframe/upload.php
@@ -26,7 +26,6 @@ $ilchUpload = new \Ilch\Upload();
 </div>
 
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/jquery.knob.min.js') ?>"></script>
-<script src="<?=$this->getVendorUrl('npm-asset/jquery-ui/ui/widget.js') ?>"></script>
 <script src="<?=$this->getStaticUrl('js/blueimp/jquery-file-upload/js/jquery.iframe-transport.js') ?>"></script>
 <script src="<?=$this->getStaticUrl('js/blueimp/jquery-file-upload/js/jquery.fileupload.js') ?>"></script>
 <script src="<?=$this->getBaseUrl('application/modules/media/static/js/script.js') ?>"></script>


### PR DESCRIPTION
# Description
ui/widget.js (the jQuery UI widget factory) is one of the component source files that gets concatenated into the full jquery-ui.js (and its minified jquery-ui.min.js).

So we don't need to try to add it. This file is not even part of the vendor folder after build.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
