### PR TITLE
War: Path-Traversal-Schwachstelle bei Icon-Dateinamen beheben   

### DIFF
--- a/application/modules/war/config/config.php
+++ b/application/modules/war/config/config.php
@@ -15,7 +15,7 @@ class Config extends Install
 {
     public $config = [
         'key' => 'war',
-        'version' => '1.16.6',
+        'version' => '1.16.5',
         'icon_small' => 'fa-solid fa-shield',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -406,7 +406,6 @@ class Config extends Install
             case "1.16.2":
             case "1.16.3":
             case "1.16.4":
-            case "1.16.5":
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';


### PR DESCRIPTION
Im Admin-Controller Icons.php des War-Moduls wurde der vom Nutzer eingegebene gameName ungefiltert als Dateiname beim Speichern und Umbenennen von Icon-Dateien verwendet. Durch Eingaben wie ../../config wäre es möglich gewesen, Dateien außerhalb des erlaubten Verzeichnisses zu überschreiben oder zu verschieben (Path Traversal).

Der gameName wird vor der Verwendung als Dateiname durch preg_replace bereinigt – es sind nur noch Kleinbuchstaben, Ziffern, Unterstriche und Bindestriche erlaubt. Alle anderen Zeichen werden entfernt.
