### PR TITLE
CKEditor controls shine through choices

### DIFF
--- a/static/css/bootstrap-choices.css
+++ b/static/css/bootstrap-choices.css
@@ -24,3 +24,6 @@
 .choices__list--single .choices__item {
     border: 0 !important;
 }
+.choices__list--dropdown {
+  --choices-z-index: 2;
+}


### PR DESCRIPTION
# Description
CKEditor controls shine through choices. Increase the z-index for the choices dropdown to avoid this.

An extreme example of this issue with the CKEditor behind the menu:
<img width="488" height="299" alt="grafik" src="https://github.com/user-attachments/assets/c08b8051-5a79-49d9-b78a-88a6c2b334c3" />


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
