### PR TITLE
Awards: Bildauswahl und TypeError in treat.php beheben (#1359)

### DIFF
--- a/application/modules/awards/views/admin/index/treat.php
+++ b/application/modules/awards/views/admin/index/treat.php
@@ -94,7 +94,7 @@ $users = $this->get('users');
                         echo '<option ' . $selected . ' value="1_' . $user->getId() . '">' . $this->escape($user->getName()) . '</option>';
                     } ?>
                 </optgroup>
-            <?php if ($awardsMapper->existsTable('teams') && count($teams)) : ?>
+            <?php if ($awardsMapper->existsTable('teams') && !empty($teams)) : ?>
                 <optgroup label="<?=$this->getTrans('team') ?>">
                     <?php
                     foreach ($teams as $team) {

--- a/application/modules/media/views/admin/iframe/index.php
+++ b/application/modules/media/views/admin/iframe/index.php
@@ -85,9 +85,13 @@
 <?php endif; ?>
 
 <?php if ($this->getRequest()->getParam('type') === 'single'): ?>
+    <?php
+    $inputParam = $this->getRequest()->getParam('input');
+    $inputSuffix = ($inputParam !== null && $inputParam !== '') ? (int)$inputParam : '';
+    ?>
     <script>
     $(".image").click(function() {
-        window.top.$('#selectedImage<?=(int)$this->getRequest()->getParam('input') ?>').val($(this).data('url'));
+        window.top.$('#selectedImage<?=$inputSuffix ?>').val($(this).data('url'));
         window.top.$('#mediaModal').modal('hide');
     });
     </script>


### PR DESCRIPTION
 Behebt Issue #1359 – zwei Fehler im Awards-Modul, die durch PR #1348 entstanden sind:                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  1. **Bildauswahl defekt**: In `media/views/admin/iframe/index.php` wurde der `input`-Parameter                                                                                                                                                                                                                                                                                                                                  
     immer mit `(int)` gecastet. Da Awards `type/single` ohne `input`-Parameter aufruft, wurde                                                                                                                                                                                                                                                                                                                                    
     `null` zu `0` – der jQuery-Selektor lautete dann `#selectedImage0` statt `#selectedImage`,                                                                                                                                                                                                                                                                                                                                   
     wodurch die Bildauswahl nicht funktionierte.                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  2. **TypeError in treat.php**: `count($teams)` wirft in PHP 8.x einen `TypeError`, wenn das                                                                                                                                                                                                                                                                                                                                     
     Teams-Modul nicht installiert ist und `$teams` den Wert `null` hat.                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  ## Lösung                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  - `media/views/admin/iframe/index.php`: `(int)`-Cast nur anwenden, wenn der Parameter gesetzt ist,                                                                                                                                                                                                                                                                                                                            
    ansonsten leerer String → Selektor `#selectedImage` bleibt korrekt.                                                                                                                                                                                                                                                                                                                                                           
  - `awards/views/admin/index/treat.php`: `count($teams)` durch `!empty($teams)` ersetzt,                                                                                                                                                                                                                                                                                                                                       
    das mit `null` umgehen kann.                                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  ## Bezug                                
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  - Behebt #1359                                                                                                                                                                                                                                                                                                                                                                                                                  
  - Regressionsfehler aus PR #1348 
