### PR TITLE
Awards: Fix error if filename contains a space

### DIFF
--- a/application/modules/awards/controllers/admin/Index.php
+++ b/application/modules/awards/controllers/admin/Index.php
@@ -129,7 +129,7 @@ class Index extends \Ilch\Controller\Admin
 
             // Add BASE_URL if image starts with application to get a complete URL for validation
             if (!empty($post['image']) && strncmp($post['image'], 'application', 11) === 0) {
-                $post['image'] = BASE_URL . '/' . $post['image'];
+                $post['image'] = BASE_URL . '/' . rawurlencode($post['image']);
             }
 
             Validation::setCustomFieldAliases([


### PR DESCRIPTION
# Description
- Fix error if filename for example contains a space.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
