### PR TITLE
Update gitattributes and gitignore for CKEditor 5 v48

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 /development export-ignore
 /build export-ignore
 /tests export-ignore
-/.travis.yml export-ignore
 /phpcs.xml export-ignore
 
 .gitattributes export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,23 @@
 /static/js/choices/node_modules/
 /static/js/tarteaucitron/node_modules/
 
-/static/js/ckeditor5/build/ckeditor.d.ts
-/static/js/ckeditor5/build/plugins/
-/static/js/ckeditor5/node_modules/
+/static/js/ckeditor5/*
+!/static/js/ckeditor5/ckeditor5.css
+!/static/js/ckeditor5/ckeditor5.js
+!/static/js/ckeditor5/emoji-definitions.json
+!/static/js/ckeditor5/LICENSE.md
+!/static/js/ckeditor5/styles.css
+!/static/js/ckeditor5/translations/*.umd.js
+!/static/js/ckeditor5/ckeditor5-ilchps/
+!/static/js/ckeditor5/ckeditor5-ilchmedia/
+
+/static/js/ckeditor5/ckeditor5-ilchps/*
+!/static/js/ckeditor5/ckeditor5-ilchps/dist/browser/index.es.js
+!/static/js/ckeditor5/ckeditor5-ilchps/src/
+
+/static/js/ckeditor5/ckeditor5-ilchmedia/*
+!/static/js/ckeditor5/ckeditor5-ilchmedia/dist/browser/index.es.js
+!/static/js/ckeditor5/ckeditor5-ilchmedia/src/
 
 /tests/config.php
 tests/.phpunit.result.cache


### PR DESCRIPTION
# Description
- Update .gitattributes and .gitignore to ignore files of CKEditor and the custom plugins that we don't need to have in the repo.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
