### PR TITLE
Downloads: Add option for visibility of downloads #1284

### DIFF
--- a/application/modules/downloads/config/config.php
+++ b/application/modules/downloads/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'downloads',
-        'version' => '1.14.3',
+        'version' => '1.15.0',
         'icon_small' => 'fa-regular fa-circle-down',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -38,6 +38,8 @@ class Config extends \Ilch\Config\Install
 
     public function uninstall()
     {
+        $this->db()->drop('downloads_access', true);
+        $this->db()->drop('downloads_files_access', true);
         $this->db()->drop('downloads_files', true);
         $this->db()->drop('downloads_items', true);
 
@@ -68,7 +70,25 @@ class Config extends \Ilch\Config\Install
                   `title` VARCHAR(255) NOT NULL,
                   `description` VARCHAR(255) NOT NULL,
                   PRIMARY KEY (`id`)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;';
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
+
+                CREATE TABLE IF NOT EXISTS `[prefix]_downloads_access` (
+                    `item_id` INT(11) NOT NULL,
+                    `group_id` INT(11) NOT NULL,
+                    INDEX `FK_[prefix]_downloads_access_downloads_items` (`item_id`) USING BTREE,
+                    INDEX `FK_[prefix]_downloads_access_groups` (`group_id`) USING BTREE,
+                    CONSTRAINT `FK_[prefix]_downloads_access_downloads_items` FOREIGN KEY (`item_id`) REFERENCES `[prefix]_downloads_items` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    CONSTRAINT `FK_[prefix]_downloads_access_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+                CREATE TABLE IF NOT EXISTS `[prefix]_downloads_files_access` (
+                    `file_id` INT(11) NOT NULL,
+                    `group_id` INT(11) NOT NULL,
+                    INDEX `FK_[prefix]_downloads_files_access_downloads_files` (`file_id`) USING BTREE,
+                    INDEX `FK_[prefix]_downloads_files_access_groups` (`group_id`) USING BTREE,
+                    CONSTRAINT `FK_[prefix]_downloads_files_access_downloads_files` FOREIGN KEY (`file_id`) REFERENCES `[prefix]_downloads_files` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    CONSTRAINT `FK_[prefix]_downloads_files_access_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;';
     }
 
     public function getUpdate(string $installedVersion): string
@@ -143,6 +163,27 @@ class Config extends \Ilch\Config\Install
                     $this->db()->query('ALTER TABLE `[prefix]_downloads_files` ADD CONSTRAINT `FK_[prefix]_downloads_files_[prefix]_downloads_items` FOREIGN KEY (`item_id`) REFERENCES `[prefix]_downloads_items` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE;');
                 }
                 // no break
+            case "1.14.3":
+                // Create new tables "downloads_access" and "downloads_files_access".
+                $this->db()->queryMulti('CREATE TABLE IF NOT EXISTS `[prefix]_downloads_access` (
+                    `item_id` INT(11) NOT NULL,
+                    `group_id` INT(11) NOT NULL,
+                    INDEX `FK_[prefix]_downloads_access_downloads_items` (`item_id`) USING BTREE,
+                    INDEX `FK_[prefix]_downloads_access_groups` (`group_id`) USING BTREE,
+                    CONSTRAINT `FK_[prefix]_downloads_access_downloads_items` FOREIGN KEY (`item_id`) REFERENCES `[prefix]_downloads_items` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    CONSTRAINT `FK_[prefix]_downloads_access_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+                CREATE TABLE IF NOT EXISTS `[prefix]_downloads_files_access` (
+                    `file_id` INT(11) NOT NULL,
+                    `group_id` INT(11) NOT NULL,
+                    INDEX `FK_[prefix]_downloads_files_access_downloads_files` (`file_id`) USING BTREE,
+                    INDEX `FK_[prefix]_downloads_files_access_groups` (`group_id`) USING BTREE,
+                    CONSTRAINT `FK_[prefix]_downloads_files_access_downloads_files` FOREIGN KEY (`file_id`) REFERENCES `[prefix]_downloads_files` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    CONSTRAINT `FK_[prefix]_downloads_files_access_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;');
+                // no break
+
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';

--- a/application/modules/downloads/config/config.php
+++ b/application/modules/downloads/config/config.php
@@ -49,7 +49,17 @@ class Config extends \Ilch\Config\Install
 
     public function getInstallSql(): string
     {
-        return 'CREATE TABLE IF NOT EXISTS `[prefix]_downloads_files` (
+        return 'CREATE TABLE IF NOT EXISTS `[prefix]_downloads_items` (
+                  `id` INT(11) NOT NULL AUTO_INCREMENT,
+                  `sort` INT(11) NULL DEFAULT 0,
+                  `parent_id` INT(11) NULL DEFAULT 0,
+                  `type` TINYINT(1) NOT NULL,
+                  `title` VARCHAR(255) NOT NULL,
+                  `description` VARCHAR(255) NOT NULL,
+                  PRIMARY KEY (`id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
+
+                CREATE TABLE IF NOT EXISTS `[prefix]_downloads_files` (
                   `id` INT(11) NOT NULL AUTO_INCREMENT,
                   `file_id` INT(11) NOT NULL,
                   `file_title` VARCHAR(255) NOT NULL DEFAULT \'\',
@@ -60,16 +70,6 @@ class Config extends \Ilch\Config\Install
                   PRIMARY KEY (`id`) USING BTREE,
                   INDEX `FK_[prefix]_downloads_files_[prefix]_downloads_items` (`item_id`) USING BTREE,
                   CONSTRAINT `FK_[prefix]_downloads_files_[prefix]_downloads_items` FOREIGN KEY (`item_id`) REFERENCES `[prefix]_downloads_items` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
-
-                CREATE TABLE IF NOT EXISTS `[prefix]_downloads_items` (
-                  `id` INT(11) NOT NULL AUTO_INCREMENT,
-                  `sort` INT(11) NULL DEFAULT 0,
-                  `parent_id` INT(11) NULL DEFAULT 0,
-                  `type` TINYINT(1) NOT NULL,
-                  `title` VARCHAR(255) NOT NULL,
-                  `description` VARCHAR(255) NOT NULL,
-                  PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
                 CREATE TABLE IF NOT EXISTS `[prefix]_downloads_access` (

--- a/application/modules/downloads/controllers/Index.php
+++ b/application/modules/downloads/controllers/Index.php
@@ -12,6 +12,7 @@ use Ilch\Controller\Frontend;
 use Ilch\Pagination;
 use Modules\Downloads\Mappers\Downloads as DownloadsMapper;
 use Modules\Downloads\Mappers\File as FileMapper;
+use Modules\Downloads\Models\DownloadsItem;
 use Modules\Downloads\Models\File as FileModel;
 
 class Index extends Frontend
@@ -23,6 +24,13 @@ class Index extends Frontend
 
         $downloadsItems = $downloadsMapper->getDownloadsItemsByParent(0);
 
+        $downloadsItems = $this->checkAccess($downloadsItems);
+        $subItems = [];
+        foreach ($downloadsItems as $downloadItem) {
+            $subItems[$downloadItem->getId()] = $downloadsMapper->getDownloadsItemsByParent($downloadItem->getId());
+        }
+        $subItems = $this->checkAccess($subItems);
+
         $this->getLayout()->getTitle()
                 ->add($this->getTranslator()->trans('downloads'));
         $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('downloads'));
@@ -30,8 +38,52 @@ class Index extends Frontend
                 ->add($this->getTranslator()->trans('menuDownloadsOverview'), ['action' => 'index']);
 
         $this->getView()->set('downloadsItems', $downloadsItems);
-        $this->getView()->set('downloadsMapper', $downloadsMapper);
+        $this->getView()->set('subItems', $subItems);
         $this->getView()->set('fileMapper', $fileMapper);
+    }
+
+    /**
+     *  Check if the user or guest has access to the downloadsItems.
+     *
+     * @param DownloadsItem[]|FileModel $downloadsItems
+     * @return array
+     */
+    private function checkAccess($downloadsItems)
+    {
+        if (!($this->getUser() && $this->getUser()->isAdmin())) {
+            // Check which downloadsItems should be visible for the user or guest.
+            $downloadsItemsVisible = [];
+            foreach ($downloadsItems ?? [] as $key => $downloadsItem) {
+                if (!is_array($downloadsItem)) {
+                    if (empty($downloadsItem->getAccess())) {
+                        // Visible for everyone.
+                        $downloadsItemsVisible[$key] = $downloadsItem;
+                        continue;
+                    }
+
+                    if (is_in_array(explode(',', $downloadsItem->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ?: [3])) {
+                        $downloadsItemsVisible[$key] = $downloadsItem;
+                    }
+                } else {
+                    // Subitems
+                    foreach ($downloadsItem as $downloadItem) {
+                        if (empty($downloadItem->getAccess())) {
+                            // Visible for everyone.
+                            $downloadsItemsVisible[$key][] = $downloadItem;
+                            continue;
+                        }
+
+                        if (is_in_array(explode(',', $downloadItem->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ?: [3])) {
+                            $downloadsItemsVisible[$key][] = $downloadItem;
+                        }
+                    }
+                }
+            }
+
+            $downloadsItems = $downloadsItemsVisible;
+        }
+
+        return $downloadsItems;
     }
 
     public function showAction()
@@ -42,6 +94,7 @@ class Index extends Frontend
 
         $id = $this->getRequest()->getParam('id');
         $downloads = $downloadsMapper->getDownloadsById($id);
+        $downloads = $this->checkAccess($downloads);
 
         $this->getLayout()->getTitle()
                 ->add($this->getTranslator()->trans('downloads'));
@@ -49,7 +102,7 @@ class Index extends Frontend
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('menuDownloadsOverview'), ['action' => 'index']);
 
-        if ($downloads !== null) {
+        if (!empty($downloads)) {
             $this->getLayout()->getTitle()
                     ->add($downloads->getTitle());
             $this->getLayout()->set('metaDescription', $this->getTranslator()->trans('downloads') . ' - ' . $downloads->getDesc());
@@ -60,7 +113,7 @@ class Index extends Frontend
         $pagination->setRowsPerPage(!$this->getConfig()->get('downloads_downloadsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
-        $this->getView()->set('files', $fileMapper->getFilesByItemId($id, $pagination));
+        $this->getView()->set('files', ($downloads) ? $fileMapper->getFilesByItemId($id, $pagination) : []);
         $this->getView()->set('pagination', $pagination);
     }
 
@@ -71,6 +124,7 @@ class Index extends Frontend
 
         $id = $this->getRequest()->getParam('id');
         $file = $fileMapper->getFileById($id);
+        $file = $this->checkAccess($file);
 
         $this->getLayout()->getTitle()
                 ->add($this->getTranslator()->trans('downloads'));
@@ -78,7 +132,7 @@ class Index extends Frontend
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('menuDownloadsOverview'), ['action' => 'index']);
 
-        if ($file !== null) {
+        if (!empty($file)) {
             $download = $downloadsMapper->getDownloadsById($file->getItemId());
 
             $this->getLayout()->getTitle()
@@ -116,7 +170,7 @@ class Index extends Frontend
             }
         }
 
-        $this->getView()->set('file', $file);
+        $this->getView()->set('file', ($file) ?: null);
         $this->getView()->set('commentsKey', 'downloads/index/showfile/id/' . $id);
     }
 }

--- a/application/modules/downloads/controllers/admin/File.php
+++ b/application/modules/downloads/controllers/admin/File.php
@@ -11,6 +11,7 @@ use Ilch\Controller\Admin;
 use Modules\Downloads\Mappers\File as FileMapper;
 use Modules\Downloads\Models\File as FileModel;
 use Ilch\Validation;
+use Modules\User\Mappers\Group as UserGroupMapper;
 
 class File extends Admin
 {
@@ -56,6 +57,7 @@ class File extends Admin
     public function treatFileAction()
     {
         $fileMapper = new FileMapper();
+        $userGroupMapper = new UserGroupMapper();
         $id = (int)$this->getRequest()->getParam('id');
 
         if ($this->getRequest()->getPost()) {
@@ -67,7 +69,8 @@ class File extends Admin
             $post = [
                 'fileTitle' => $this->getRequest()->getPost('fileTitle'),
                 'fileImage' => $fileImage,
-                'fileDesc' => $this->getRequest()->getPost('fileDesc')
+                'fileDesc' => $this->getRequest()->getPost('fileDesc'),
+                'access' => $this->getRequest()->getPost('access')
             ];
 
             $validation = Validation::create($post, ['fileTitle' => 'required', 'fileImage' => 'url']);
@@ -81,6 +84,7 @@ class File extends Admin
                 $model->setFileImage($fileImage);
                 $model->setFileTitle($this->getRequest()->getPost('fileTitle'));
                 $model->setFileDesc($fileDesc);
+                $model->setAccess(implode(',', $this->getRequest()->getPost('access') ?? []));
                 $fileMapper->saveFileTreat($model);
 
                 $this->addMessage('saveSuccess');
@@ -90,5 +94,6 @@ class File extends Admin
         }
 
         $this->getView()->set('file', $fileMapper->getFileById($id));
+        $this->getView()->set('userGroupList', $userGroupMapper->getGroupList());
     }
 }

--- a/application/modules/downloads/controllers/admin/Index.php
+++ b/application/modules/downloads/controllers/admin/Index.php
@@ -11,6 +11,7 @@ use Ilch\Controller\Admin;
 use Modules\Downloads\Mappers\Downloads as DownloadsMapper;
 use Modules\Downloads\Mappers\File as FileMapper;
 use Modules\Downloads\Models\DownloadsItem;
+use Modules\User\Mappers\Group as UserGroupMapper;
 
 class Index extends Admin
 {
@@ -44,6 +45,7 @@ class Index extends Admin
 
         $downloadsMapper = new DownloadsMapper();
         $fileMapper = new FileMapper();
+        $userGroupMapper = new UserGroupMapper();
 
         // Saves the item tree to database.
         if ($this->getRequest()->isPost()) {
@@ -82,6 +84,7 @@ class Index extends Admin
                         $downloadsItem->setType($item['type']);
                         $downloadsItem->setTitle($item['title']);
                         $downloadsItem->setDesc($item['desc']);
+                        $downloadsItem->setAccess($item['access']);
                         $newId = $downloadsMapper->saveItem($downloadsItem);
 
                         if (isset($tmpId)) {
@@ -119,5 +122,6 @@ class Index extends Admin
         $this->getView()->set('downloadsItems', $downloadsItems);
         $this->getView()->set('downloadsMapper', $downloadsMapper);
         $this->getView()->set('fileMapper', $fileMapper);
+        $this->getView()->set('userGroupList', $userGroupMapper->getGroupList());
     }
 }

--- a/application/modules/downloads/mappers/Access.php
+++ b/application/modules/downloads/mappers/Access.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Downloads\Mappers;
+
+use Ilch\Mapper;
+
+/**
+ * Mapper so handle the access rights for DownloadsItems and Files.
+ *
+ * @since 1.15.0
+ */
+class Access extends Mapper
+{
+    /**
+     * @var string
+     */
+    public string $accessTable = 'downloads_access';
+
+    /**
+     * @var string
+     */
+    public string $accessFilesTable = 'downloads_files_access';
+
+    /**
+     * Save access rights for a DownloadsItem.
+     *
+     * @param int $itemId
+     * @param string|null $access
+     * @return void
+     * @since 1.15.0
+     */
+    public function save(int $itemId, ?string $access)
+    {
+        $this->saveAccess($itemId, $access);
+    }
+
+    /**
+     * Save access rights for a file.
+     *
+     * @param int $fileId
+     * @param string|null $access
+     * @return void
+     * @since 1.15.0
+     */
+    public function saveFileAccess(int $fileId, ?string $access)
+    {
+        $this->saveAccess($fileId, $access, true);
+    }
+
+    /**
+     * Save access rights for a file or a DownloadsItem.
+     *
+     * @param int $id
+     * @param string|null $access
+     * @param bool $isFileId
+     * @return void
+     * @since 1.15.0
+     */
+    private function saveAccess(int $id, ?string $access, bool $isFileId = false)
+    {
+        if ($access === null) {
+            return;
+        }
+
+        $columnName = ($isFileId) ? 'file_id' : 'item_id';
+        $tableName = ($isFileId) ? $this->accessFilesTable : $this->accessTable;
+
+        $this->db()->delete($tableName)
+            ->where([$columnName => $id])
+            ->execute();
+
+        $access = explode(',', $access);
+
+        $preparedRows = [];
+        foreach ($access as $groupId) {
+            if ($groupId) {
+                $preparedRows[] = [$id, $groupId];
+            }
+        }
+
+        if (count($preparedRows)) {
+            // Add access rights in chunks of 25 to the table.
+            $chunks = array_chunk($preparedRows, 25);
+            foreach ($chunks as $chunk) {
+                $this->db()->insert($tableName)
+                    ->columns([$columnName, 'group_id'])
+                    ->values($chunk)
+                    ->execute();
+            }
+        }
+    }
+}

--- a/application/modules/downloads/mappers/Downloads.php
+++ b/application/modules/downloads/mappers/Downloads.php
@@ -9,6 +9,7 @@ namespace Modules\Downloads\Mappers;
 
 use Ilch\Mapper;
 use Modules\Downloads\Models\DownloadsItem;
+use Modules\Downloads\Mappers\Access as AccessMapper;
 
 class Downloads extends Mapper
 {
@@ -20,8 +21,10 @@ class Downloads extends Mapper
     public function getDownloadsItems(): ?array
     {
         $items = [];
-        $itemRows = $this->db()->select('*')
-            ->from('downloads_items')
+        $itemRows = $this->db()->select(['di.id', 'di.type', 'di.title', 'di.description', 'di.parent_id'])
+            ->from(['di' => 'downloads_items'])
+            ->join(['da' => 'downloads_access'], 'da.item_id = di.id', 'LEFT', ['access' => 'GROUP_CONCAT(DISTINCT da.group_id)'])
+            ->group(['di.id'])
             ->order(['sort' => 'ASC'])
             ->execute()
             ->fetchRows();
@@ -37,6 +40,7 @@ class Downloads extends Mapper
             $itemModel->setTitle($itemRow['title']);
             $itemModel->setDesc($itemRow['description']);
             $itemModel->setParentId($itemRow['parent_id']);
+            $itemModel->setAccess($itemRow['access'] ?? '');
             $items[] = $itemModel;
         }
 
@@ -52,12 +56,14 @@ class Downloads extends Mapper
     public function getDownloadsItemsByParent(int $itemId): ?array
     {
         $items = [];
-        $itemRows = $this->db()->select('*')
-                ->from('downloads_items')
-                ->where(['parent_id' => $itemId])
-                ->order(['sort' => 'ASC'])
-                ->execute()
-                ->fetchRows();
+        $itemRows = $this->db()->select(['di.id', 'di.type', 'di.title', 'di.description'])
+            ->from(['di' => 'downloads_items'])
+            ->join(['da' => 'downloads_access'], 'da.item_id = di.id', 'LEFT', ['access' => 'GROUP_CONCAT(DISTINCT da.group_id)'])
+            ->where(['parent_id' => $itemId])
+            ->group(['di.id'])
+            ->order(['sort' => 'ASC'])
+            ->execute()
+            ->fetchRows();
 
         if (empty($itemRows)) {
             return null;
@@ -70,6 +76,7 @@ class Downloads extends Mapper
             $itemModel->setTitle($itemRow['title']);
             $itemModel->setDesc($itemRow['description']);
             $itemModel->setParentId($itemId);
+            $itemModel->setAccess($itemRow['access'] ?? '');
             $items[] = $itemModel;
         }
 
@@ -84,12 +91,13 @@ class Downloads extends Mapper
      */
     public function getDownloadsById(int $id): ?DownloadsItem
     {
-        $itemRows = $this->db()->select('*')
-                ->from('downloads_items')
-                ->where(['id' => $id])
-                ->order(['sort' => 'ASC'])
-                ->execute()
-                ->fetchAssoc();
+        $itemRows = $this->db()->select(['di.id', 'di.type', 'di.title', 'di.description', 'di.parent_id'])
+            ->from(['di' => 'downloads_items'])
+            ->join(['da' => 'downloads_access'], 'da.item_id = di.id', 'LEFT', ['access' => 'GROUP_CONCAT(DISTINCT da.group_id)'])
+            ->where(['id' => $id])
+            ->order(['sort' => 'ASC'])
+            ->execute()
+            ->fetchAssoc();
 
         if (empty($itemRows)) {
             return null;
@@ -101,6 +109,7 @@ class Downloads extends Mapper
         $itemModel->setTitle($itemRows['title']);
         $itemModel->setDesc($itemRows['description']);
         $itemModel->setParentId($itemRows['parent_id']);
+        $itemModel->setAccess($itemRow['access'] ?? '');
 
         return $itemModel;
     }
@@ -143,6 +152,10 @@ class Downloads extends Mapper
                 ->values($fields)
                 ->execute();
         }
+
+        // Store access rights.
+        $accessMapper = new AccessMapper();
+        $accessMapper->save($itemId, $downloadsItem->getAccess());
 
         return $itemId;
     }

--- a/application/modules/downloads/mappers/File.php
+++ b/application/modules/downloads/mappers/File.php
@@ -11,6 +11,7 @@ use Ilch\Database\Mysql\Result;
 use Ilch\Mapper;
 use Ilch\Pagination;
 use Modules\Downloads\Models\File as FileModel;
+use Modules\Downloads\Mappers\Access as AccessMapper;
 
 class File extends Mapper
 {
@@ -25,7 +26,9 @@ class File extends Mapper
         $fileRow = $this->db()->select(['g.file_id', 'g.item_id', 'fileid' => 'g.id', 'g.visits', 'g.file_title', 'g.file_description', 'g.file_image', 'm.url', 'm.id', 'm.url_thumb'])
             ->from(['g' => 'downloads_files'])
             ->join(['m' => 'media'], 'g.file_id = m.id', 'LEFT')
+            ->join(['da' => 'downloads_files_access'], 'da.file_id = g.id', 'LEFT', ['access' => 'GROUP_CONCAT(DISTINCT da.group_id)'])
             ->where(['g.id' => $id])
+            ->group(['g.id'])
             ->execute()
             ->fetchAssoc();
 
@@ -42,6 +45,7 @@ class File extends Mapper
         $entryModel->setFileDesc($fileRow['file_description']);
         $entryModel->setItemId($fileRow['item_id']);
         $entryModel->setVisits($fileRow['visits']);
+        $entryModel->setAccess($fileRow['access'] ?? '');
 
         return $entryModel;
     }
@@ -57,7 +61,9 @@ class File extends Mapper
         $fileRow = $this->db()->select(['g.file_id', 'g.item_id', 'fileid' => 'g.id', 'g.visits', 'g.file_title', 'g.file_description', 'g.file_image', 'm.url', 'm.id', 'm.url_thumb'])
             ->from(['g' => 'downloads_files'])
             ->join(['m' => 'media'], 'g.file_id = m.id', 'LEFT')
+            ->join(['da' => 'downloads_files_access'], ['da.file_id = g.id'], 'LEFT', ['access' => 'GROUP_CONCAT(DISTINCT da.group_id)'])
             ->where(['g.item_id' => $itemId])
+            ->group(['g.id'])
             ->order(['g.id' => 'DESC'])
             ->limit(1)
             ->execute()
@@ -74,6 +80,7 @@ class File extends Mapper
         $entryModel->setFileImage($fileRow['file_image']);
         $entryModel->setFileDesc($fileRow['file_description']);
         $entryModel->setVisits($fileRow['visits']);
+        $entryModel->setAccess($fileRow['access'] ?? '');
 
         return $entryModel;
     }
@@ -105,7 +112,9 @@ class File extends Mapper
         $sql = $this->db()->select(['g.item_id', 'fileid' => 'g.id', 'g.file_title', 'g.file_image', 'g.file_description', 'g.visits', 'm.url', 'm.url_thumb'])
             ->from(['g' => 'downloads_files'])
             ->join(['m' => 'media'], 'g.file_image = m.url', 'LEFT')
+            ->join(['da' => 'downloads_files_access'], 'da.file_id = g.id', 'LEFT', ['access' => 'GROUP_CONCAT(DISTINCT da.group_id)'])
             ->where(['g.item_id' => $itemId])
+            ->group(['g.id'])
             ->order(['g.id' => 'DESC']);
 
         if ($pagination !== null) {
@@ -130,6 +139,7 @@ class File extends Mapper
             $fileModel->setFileDesc($entry['file_description']);
             $fileModel->setVisits($entry['visits']);
             $fileModel->setItemId($entry['item_id']);
+            $fileModel->setAccess($entry['access'] ?? '');
             $entries[] = $fileModel;
         }
 
@@ -194,5 +204,8 @@ class File extends Mapper
             ->values(['file_title' => $model->getFileTitle(), 'file_image' => $model->getFileImage(), 'file_description' => $model->getFileDesc()])
             ->where(['id' => $model->getId()])
             ->execute();
+
+        $accessMapper = new AccessMapper();
+        $accessMapper->saveFileAccess($model->getId(), $model->getAccess());
     }
 }

--- a/application/modules/downloads/models/DownloadsItem.php
+++ b/application/modules/downloads/models/DownloadsItem.php
@@ -59,6 +59,13 @@ class DownloadsItem extends Model
     protected ?string $desc = null;
 
     /**
+     * Access rights of the item.
+     *
+     * @var string|null
+     */
+    protected ?string $access = null;
+
+    /**
      * Gets the id.
      *
      * @return int|null
@@ -176,5 +183,27 @@ class DownloadsItem extends Model
     public function setDesc(string $desc)
     {
         $this->desc = $desc;
+    }
+
+    /**
+     * Get the access rights of the item.
+     *
+     * @return string|null
+     */
+    public function getAccess(): ?string
+    {
+        return $this->access;
+    }
+
+    /**
+     * Set the access rights of the item.
+     *
+     * @param string $access
+     * @return $this
+     */
+    public function setAccess(string $access): DownloadsItem
+    {
+        $this->access = $access;
+        return $this;
     }
 }

--- a/application/modules/downloads/models/File.php
+++ b/application/modules/downloads/models/File.php
@@ -68,6 +68,13 @@ class File extends Model
     protected string $file_url;
 
     /**
+     * The access rights of the file.
+     *
+     * @var string|null
+     */
+    protected ?string $access = null;
+
+    /**
      * @var string
      */
     private string $filethumb;
@@ -250,5 +257,27 @@ class File extends Model
     public function setFileUrl(string $fileUrl)
     {
         $this->file_url = $fileUrl;
+    }
+
+    /**
+     * Get the access rights of the file.
+     *
+     * @return string|null
+     */
+    public function getAccess(): ?string
+    {
+        return $this->access;
+    }
+
+    /**
+     * Set the access rights of the file.
+     *
+     * @param string $access
+     * @return $this
+     */
+    public function setAccess(string $access): File
+    {
+        $this->access = $access;
+        return $this;
     }
 }

--- a/application/modules/downloads/translations/de.php
+++ b/application/modules/downloads/translations/de.php
@@ -25,6 +25,7 @@ return [
     'menuActionDownloadsInsertFile' => 'Datei auswählen',
     'menuActionDownloadsEdit' => 'Downloads Bearbeiten',
     'selectcat' => 'Kategorie auswählen',
+    'access' => 'Sichtbar für',
     'downloadsedit' => 'Downloads bearbeiten',
     'title' => 'Name',
     'type' => 'Art',

--- a/application/modules/downloads/translations/en.php
+++ b/application/modules/downloads/translations/en.php
@@ -25,6 +25,7 @@ return [
     'menuActionDownloadsInsertFile' => 'Select file',
     'menuActionDownloadsEdit' => 'Downloads edit',
     'selectcat' => 'Select category',
+    'access' => 'Visible for',
     'downloadsedit' => 'Edit downloads',
     'title' => 'Title',
     'type' => 'Type',

--- a/application/modules/downloads/views/admin/file/treatfile.php
+++ b/application/modules/downloads/views/admin/file/treatfile.php
@@ -63,6 +63,22 @@ if ($file->getFileImage() != '') {
                                       rows="8"><?=$this->escape($file->getFileDesc()) ?></textarea>
                         </div>
                     </div>
+                    <div class="row mb-3">
+                        <label for="access" class="col-xl-2 col-form-label"><?=$this->getTrans('access') ?></label>
+                        <div class="col-xl-8">
+                            <select class="choices-select form-control"
+                                    id="access"
+                                    name="access[]"
+                                    data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>"
+                                    multiple>
+                                <?php
+                                /** @var \Modules\User\Models\Group $group */
+                                foreach ($this->get('userGroupList') as $group) : ?>
+                                    <option value="<?=$group->getId() ?>"<?=(in_array($group->getId(), explode(',', $file->getAccess()))) ? ' selected' : '' ?>><?=$this->escape($group->getName()) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -78,4 +94,9 @@ if ($file->getFileImage() != '') {
         ->addMediaButton($this->getUrl('admin/media/iframe/index/type/single/'))
         ->addUploadController($this->getUrl('admin/media/index/upload'))
 ?>
+
+choicesAccess = new Choices('#access', {
+    ...choicesOptions,
+    searchEnabled: true
+});
 </script>

--- a/application/modules/downloads/views/admin/index/index.php
+++ b/application/modules/downloads/views/admin/index/index.php
@@ -30,6 +30,7 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
                     <input type="hidden" class="hidden_title" name="items[' . $item->getId() . '][title]" value="' . $item->getTitle() . '" />
                     <input type="hidden" class="hidden_desc" name="items[' . $item->getId() . '][desc]" value="' . $item->getDesc() . '" />
                     <input type="hidden" class="hidden_type" name="items[' . $item->getId() . '][type]" value="' . $item->getType() . '" />
+                    <input type="hidden" class="hidden_access" name="items[' . $item->getId() . '][access]" value="' . $item->getAccess() . '" />
                     <span></span>
                 </span>
                 <span class="title">' . $item->getTitle() . '</span>
@@ -115,6 +116,22 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
             </div>
             <div class="dyn"></div>
             <div class="row mb-3">
+                <label for="access" class="col-xl-3 col-form-label"><?=$this->getTrans('access') ?></label>
+                <div class="col-xl-6">
+                    <select class="choices-select form-control"
+                            id="access"
+                            name="user[groups][]"
+                            data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>"
+                            multiple>
+                        <?php
+                        /** @var \Modules\User\Models\Group $group */
+                        foreach ($this->get('userGroupList') as $group) : ?>\n\
+                            <option value="<?=$group->getId() ?>"><?=$this->escape($group->getName()) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+            </div>
+            <div class="row mb-3">
                 <label class="col-xl-3 col-form-label"></label>
                 <div class="col-xl-6 actions">
                     <input type="button" class="btn btn-outline-secondary" id="menuItemAdd" value="<?=$this->getTrans('downloadsItemAdd') ?>">
@@ -134,6 +151,7 @@ function resetBox() {
     .val('')
     .removeAttr('checked')
     .removeAttr('selected');
+    choicesAccess.removeActiveItems();
 
     $('#type').change();
 }
@@ -158,6 +176,13 @@ $(document).ready (
             startCollapsed: false,
             protectRoot: true
         });
+
+        let choicesAccess;
+        choicesAccess = new Choices('#access', {
+            ...choicesOptions,
+            searchEnabled: true
+        });
+
         $('.disclose').on('click', function () {
             $(this).closest('li').toggleClass('mjs-nestedSortable-collapsed').toggleClass('mjs-nestedSortable-expanded');
             $(this).find('i').toggleClass('fa-circle-minus').toggleClass('fa-circle-plus');
@@ -229,11 +254,14 @@ $(document).ready (
 
             }
 
+            const accessVal = choicesAccess.getValue(true).join(',');
+
             $('<li id="tmp_'+itemId+'"><div><span class="disclose"><span>'
                     +'<input type="hidden" class="hidden_id" name="items[tmp_'+itemId+'][id]" value="tmp_'+itemId+'" />'
                     +'<input type="hidden" class="hidden_title" name="items[tmp_'+itemId+'][title]" value="'+$('#title').val()+'" />'
                     +'<input type="hidden" class="hidden_desc" name="items[tmp_'+itemId+'][desc]" value="'+$('#desc').val()+'" />'
                     +'<input type="hidden" class="hidden_type" name="items[tmp_'+itemId+'][type]" value="'+$('#type').val()+'" />'
+                    +'<input type="hidden" class="hidden_access" name="items[tmp_'+itemId+'][access]" value="'+ accessVal +'" />'
                     +'</span></span><span class="title">'+$('#title').val()+'</span><span class="item_delete"><i class="fa-solid fa-circle-xmark"></i></span></div></li>').appendTo(append);
             itemId++;
             resetBox();
@@ -241,28 +269,33 @@ $(document).ready (
         );
 
         $('.sortable').on('click', '.item_edit', function() {
-           $('.actions').html('<input type="button" class="btn" id="menuItemEdit" value="<?=$this->getTrans('edit') ?>">\n\
+            $('.actions').html('<input type="button" class="btn" id="menuItemEdit" value="<?=$this->getTrans('edit') ?>">\n\
                                <input type="button" class="btn" id="menuItemEditCancel" value="<?=$this->getTrans('cancel') ?>">');
-           $('#title').val($(this).parent().find('.hidden_title').val());
-           $('#desc').val($(this).parent().find('.hidden_desc').val());
-           $('#type').val($(this).parent().find('.hidden_type').val());
-           $('#id').val($(this).closest('li').attr('id'));
-           $('#type').change();
+            $('#title').val($(this).parent().find('.hidden_title').val());
+            $('#desc').val($(this).parent().find('.hidden_desc').val());
+            $('#type').val($(this).parent().find('.hidden_type').val());
+            $('#id').val($(this).closest('li').attr('id'));
+            $('#type').change();
+
+            let hidden_access_values = $(this).parent().find('.hidden_access').val().split(',').map(value => value.trim());
+            choicesAccess.removeActiveItems();
+            choicesAccess.setChoiceByValue(hidden_access_values);
         });
 
         $('#downloadsForm').on('click', '#menuItemEdit', function () {
-                if ($('#title').val() == '') {
-                    alert(<?=json_encode($this->getTrans('missingTitle')) ?>);
-                    return;
-                }
-
-                $('#'+$('#id').val()).find('.title:first').text($('#title').val());
-                $('#'+$('#id').val()).find('.hidden_title:first').val($('#title').val());
-                $('#'+$('#id').val()).find('.hidden_desc:first').val($('#desc').val());
-                $('#'+$('#id').val()).find('.hidden_type:first').val($('#type').val());
-                resetBox();
+            if ($('#title').val() == '') {
+                alert(<?=json_encode($this->getTrans('missingTitle')) ?>);
+                return;
             }
-        );
+
+            const accessVal = choicesAccess.getValue(true).join(',');
+            $('#'+$('#id').val()).find('.title:first').text($('#title').val());
+            $('#'+$('#id').val()).find('.hidden_title:first').val($('#title').val());
+            $('#'+$('#id').val()).find('.hidden_desc:first').val($('#desc').val());
+            $('#'+$('#id').val()).find('.hidden_type:first').val($('#type').val());
+            $('#'+$('#id').val()).find('.hidden_access:first').val(accessVal);
+            resetBox();
+        });
 
         $('#downloadsForm').on('click', '#menuItemEditCancel', function() {
             $('.actions').html('<input type="button" class="btn" id="menuItemAdd" value="Menuitem hinzufügen">');

--- a/application/modules/downloads/views/index/index.php
+++ b/application/modules/downloads/views/index/index.php
@@ -31,7 +31,6 @@
 }
 .lib-panel .lib-row.lib-desc {
     position: relative;
-    height: 100%;
     display: block;
     font-size: 13px;
 }
@@ -60,18 +59,17 @@
 /** @var \Modules\Downloads\Models\DownloadsItem[]|null $downloadsItems */
 $downloadsItems = $this->get('downloadsItems');
 
+/** @var \Modules\Downloads\Models\DownloadsItem[]|null $subItems */
+$subItems = $this->get('subItems');
+
 /**
  * @param \Modules\Downloads\Models\DownloadsItem $item
  * @param \Ilch\View $obj
  */
 function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
 {
-    /** @var \Modules\Downloads\Mappers\Downloads $downloadsMapper */
-    $downloadsMapper = $obj->get('downloadsMapper');
     /** @var \Modules\Downloads\Mappers\File $fileMapper */
     $fileMapper = $obj->get('fileMapper');
-
-    $subItems = $downloadsMapper->getDownloadsItemsByParent($item->getId());
     $fileCount = $fileMapper->getCountOfFilesByItemId($item->getId());
 
     if ($item->getType() === 0) {
@@ -110,11 +108,6 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
                 </div>
             </div>';
     }
-    if (!empty($subItems)) {
-        foreach ($subItems as $subItem) {
-            rec($subItem, $obj);
-        }
-    }
 }
 ?>
 <div class="row">
@@ -124,6 +117,9 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
             if (!empty($downloadsItems)) {
                 foreach ($downloadsItems as $item) {
                     rec($item, $this);
+                    foreach($subItems[$item->getId()] as $subItem) {
+                        rec($subItem, $this);
+                    }
                 }
             } else {
                 echo $this->getTrans('noDownloads');


### PR DESCRIPTION
# Description
> Add the option to define the visibility of downloads based on user groups, similar to how it works for forums.

In an earlier issue it was requested that this should also be possible for single downloads.
> es wäre schön wenn man einzelnen Downloads zuweisen kann welche Gruppe die sehen kann

This was done for categories, downloads and files.

Fixes #449
Fixes #1284

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## AI usage disclosure
- [X] AI-assisted

If AI-assisted, briefly state:
- Tools used (e.g., GitHub Copilot, ChatGPT, Claude): **GPT-5 mini via Duck.ai**
- What was generated by the tool (code, tests, docs, commit message, etc.): **Single code lines for the usage of choices.js to fix issue in application/modules/downloads/views/admin/index/index.php. See https://github.com/Choices-js/Choices**
- Extent of AI use (single snippet, file, entire feature — approximate %): **<5%**
- Verification steps performed (tests, manual review, security checks): **manual review and testing**
- License/IP check performed for AI outputs (yes/no + short note): **Yes. Single code lines for the usage of choices.js**

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
