### PR TITLE
Create GetAdminHmenuTest.php

### DIFF
--- a/application/libraries/Ilch/Layout/Helper/AdminHmenu/Model.php
+++ b/application/libraries/Ilch/Layout/Helper/AdminHmenu/Model.php
@@ -38,7 +38,7 @@ class Model
      */
     public function add(string $key, $value = ''): Model
     {
-        $this->data[$key] = $value;
+        $this->data[] = ['key' => $key, 'value' => $value];
 
         return $this;
     }
@@ -54,11 +54,11 @@ class Model
             return '<div aria-label="breadcrumb"><ol class="breadcrumb">&raquo; &nbsp;<li class="breadcrumb-item active"><a href="' . $this->layout->getUrl('admin/admin/index/index') . '">Admincenter</a></li></ol></div>';
         }
         $html = '<div aria-label="breadcrumb"><ol class="breadcrumb">&raquo; &nbsp;<li class="breadcrumb-item active"><a href="' . $this->layout->getUrl('admin/admin/index/index') . '">Admincenter</a></li>';
-        foreach ($this->data as $key => $value) {
-            if (empty($value)) {
-                $html .= $this->layout->escape($key);
+        foreach ($this->data as $value) {
+            if (empty($value['value'])) {
+                $html .= $this->layout->escape($value['key']);
             } else {
-                $html .= '<li class="breadcrumb-item"><a href="' . $this->layout->getUrl($value) . '">' . $this->layout->escape($key) . '</a></li>';
+                $html .= '<li class="breadcrumb-item"><a href="' . $this->layout->getUrl($value['value']) . '">' . $this->layout->escape($value['key']) . '</a></li>';
             }
         }
         $html .= '</ol></div>';

--- a/tests/libraries/ilch/Layout/Helper/GetAdminHmenuTest.php
+++ b/tests/libraries/ilch/Layout/Helper/GetAdminHmenuTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @copyright Ilch 2
+ * @package ilch_phpunit
+ */
+
+namespace Ilch\Layout\Helper;
+
+use Ilch\Layout\Admin;
+use Ilch\Request;
+use Ilch\Router;
+use Ilch\Translator;
+use PHPUnit\Ilch\DatabaseTestCase;
+
+class GetAdminHmenuTest extends DatabaseTestCase
+{
+    protected Request $request;
+    protected Admin $layout;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request = new Request();
+        $this->request->setModuleName('article');
+        $this->request->setControllerName('index');
+        $this->request->setActionName('index');
+        $this->layout = new Admin($this->request, new Translator(), new Router($this->request), '');
+    }
+
+    public function testGetAdminHmenu()
+    {
+        $test = new GetAdminHmenu($this->layout);
+        $test->getAdminHmenu()
+            ->add('test', ['controller' => 'index', 'action' => 'index']);
+
+        self::assertSame('<div aria-label="breadcrumb"><ol class="breadcrumb">&raquo; &nbsp;<li class="breadcrumb-item active"><a href="/index.php/admin/admin/index/index">Admincenter</a></li><li class="breadcrumb-item"><a href="/index.php/article/index/index">test</a></li></ol></div>', (string)$test->getAdminHmenu());
+    }
+
+    public function testGetAdminHmenuTwoAdditions()
+    {
+        $test = new GetAdminHmenu($this->layout);
+        $test->getAdminHmenu()
+            ->add('test2', ['controller' => 'index', 'action' => 'index'])
+            ->add('test', ['controller' => 'index', 'action' => 'index']);
+
+        self::assertSame('<div aria-label="breadcrumb"><ol class="breadcrumb">&raquo; &nbsp;<li class="breadcrumb-item active"><a href="/index.php/admin/admin/index/index">Admincenter</a></li><li class="breadcrumb-item"><a href="/index.php/article/index/index">test2</a></li><li class="breadcrumb-item"><a href="/index.php/article/index/index">test</a></li></ol></div>', (string)$test->getAdminHmenu());
+    }
+
+    public function testGetAdminHmenuEmptyKey()
+    {
+        $test = new GetAdminHmenu($this->layout);
+        $test->getAdminHmenu()
+            ->add('', ['controller' => 'index', 'action' => 'index']);
+
+        self::assertSame('<div aria-label="breadcrumb"><ol class="breadcrumb">&raquo; &nbsp;<li class="breadcrumb-item active"><a href="/index.php/admin/admin/index/index">Admincenter</a></li><li class="breadcrumb-item"><a href="/index.php/article/index/index"></a></li></ol></div>', (string)$test->getAdminHmenu());
+    }
+
+    public function testGetAdminHmenuEmptyValue()
+    {
+        $test = new GetAdminHmenu($this->layout);
+        $test->getAdminHmenu()
+            ->add('test', []);
+
+        self::assertSame('<div aria-label="breadcrumb"><ol class="breadcrumb">&raquo; &nbsp;<li class="breadcrumb-item active"><a href="/index.php/admin/admin/index/index">Admincenter</a></li>test</ol></div>', (string)$test->getAdminHmenu());
+    }
+
+    public function testGetAdminHmenuEmptyValueOther()
+    {
+        $test = new GetAdminHmenu($this->layout);
+        $test->getAdminHmenu()
+            ->add('test', ['controller' => '', 'action' => '']);
+
+        self::assertSame('<div aria-label="breadcrumb"><ol class="breadcrumb">&raquo; &nbsp;<li class="breadcrumb-item active"><a href="/index.php/admin/admin/index/index">Admincenter</a></li><li class="breadcrumb-item"><a href="/index.php/article//">test</a></li></ol></div>', (string)$test->getAdminHmenu());
+    }
+}

--- a/tests/libraries/ilch/Layout/Helper/GetAdminHmenuTest.php
+++ b/tests/libraries/ilch/Layout/Helper/GetAdminHmenuTest.php
@@ -11,9 +11,9 @@ use Ilch\Layout\Admin;
 use Ilch\Request;
 use Ilch\Router;
 use Ilch\Translator;
-use PHPUnit\Ilch\DatabaseTestCase;
+use PHPUnit\Ilch\TestCase;
 
-class GetAdminHmenuTest extends DatabaseTestCase
+class GetAdminHmenuTest extends TestCase
 {
     protected Request $request;
     protected Admin $layout;


### PR DESCRIPTION
# Description
- Add some unit tests for GetAdminHmenu
- Change AdminHmenu to not use the key as array index.

This caused missing entries in the menu if they ended up having identical keys and therefore in the add function identical array indices.

PR in two commits to test the current implementation with the unit tests before changing it.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
