### PR TITLE
Events: Remove some hardcoded colors

### DIFF
--- a/application/modules/events/config/config.php
+++ b/application/modules/events/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'events',
-        'version' => '1.23.6',
+        'version' => '1.23.7',
         'icon_small' => 'fa-solid fa-ticket',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/events/static/css/events.css
+++ b/application/modules/events/static/css/events.css
@@ -8,7 +8,6 @@ nav {
     padding: 0;
 }
 .event-list > li {
-    background-color: rgb(255, 255, 255);
     box-shadow: 0 0 5px rgba(51, 51, 51, 0.7);
     padding: 0;
     margin: 0 0 20px;
@@ -73,7 +72,6 @@ nav {
 .event-list > li > .adminInfo > ul > li {
     display: table-cell;
     cursor: pointer;
-    color: rgb(30, 30, 30);
     font-size: 11pt;
     font-weight: 300;
     padding: 3px 0;
@@ -124,7 +122,6 @@ nav {
         float: left;
     }
     .event-list > li > .info {
-        background-color: rgb(245, 245, 245);
         overflow: hidden;
     }
     .event-list > li > time,


### PR DESCRIPTION
# Description
Removed some hardcoded colors that are causing problems with darker layouts.

Confirmed that it looks ok in darker and lighter layouts.

E-Sport Layout 
<img width="1920" height="373" alt="grafik" src="https://github.com/user-attachments/assets/1c2c279d-9cd6-4cb5-910b-d3b8d06baace" />

Ilch World of Tanks 
<img width="1166" height="267" alt="grafik" src="https://github.com/user-attachments/assets/05752cbc-3b39-4240-8e2f-bf9880106f36" />

Ilch-Clan 
<img width="1322" height="298" alt="grafik" src="https://github.com/user-attachments/assets/775249cc-ec54-4516-9d58-8520739507e8" />

Fixes #1389

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
