### PR TITLE
gallery: remove hardcoded colors

### DIFF
--- a/application/modules/gallery/config/config.php
+++ b/application/modules/gallery/config/config.php
@@ -15,7 +15,7 @@ class Config extends Install
 {
     public $config = [
         'key' => 'gallery',
-        'version' => '1.24.1',
+        'version' => '1.24.2',
         'icon_small' => 'fa-regular fa-image',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/gallery/static/css/gallery.css
+++ b/application/modules/gallery/static/css/gallery.css
@@ -10,7 +10,6 @@
 .lib-panel .row,
 .lib-panel .col-md-6 {
     padding: 0;
-    background-color: #FFFFFF;
     margin-left: auto;
     margin-right: auto;
 }
@@ -20,7 +19,6 @@
 }
 
 .lib-panel .lib-row.lib-header {
-    background-color: #FFFFFF;
     font-size: 20px;
     padding: 10px 20px 0 20px;
 }


### PR DESCRIPTION
# Description
Remove hardcoded colors that are causing problems with darker layouts.

Ilch World of Tanks 
<img width="1166" height="347" alt="grafik" src="https://github.com/user-attachments/assets/2244e71d-c2d2-47b8-8960-b7f1e7803aa0" />

Ilch-Clan 
<img width="1322" height="401" alt="grafik" src="https://github.com/user-attachments/assets/27104a2c-afda-48d6-93c0-267e1e9fe1e5" />

Fixes #1388

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
