### PR TITLE
Events: Fix error when passing null to setLatLong

### DIFF
--- a/application/modules/events/controllers/Index.php
+++ b/application/modules/events/controllers/Index.php
@@ -180,7 +180,7 @@ class Index extends \Ilch\Controller\Frontend
 
                 if (!$imageError) {
                     if ($this->getConfig()->get('event_google_maps_api_key') != '') {
-                        $eventModel->setLatLong($eventMapper->getLatLongFromAddress($this->getRequest()->getPost('place'), $this->getConfig()->get('event_google_maps_api_key')));
+                        $eventModel->setLatLong($eventMapper->getLatLongFromAddress($this->getRequest()->getPost('place'), $this->getConfig()->get('event_google_maps_api_key')) ?? '');
                     }
 
                     $groups = '';


### PR DESCRIPTION
# Description
getLatLongFromAddress can return null. Pass an empty string to setLatLong in that case.

Fixes #1393

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
