### PR TITLE
Link: Add options for visibility of categories and links.

### DIFF
--- a/application/modules/link/config/config.php
+++ b/application/modules/link/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'link',
-        'version' => '1.11.2',
+        'version' => '1.12.0',
         'icon_small' => 'fa-solid fa-arrow-up-right-from-square',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -36,13 +36,15 @@ class Config extends \Ilch\Config\Install
 
     public function uninstall()
     {
-        $this->db()->drop('links', true);
+        $this->db()->drop('link_links_access', true);
+        $this->db()->drop('link_access', true);
+        $this->db()->drop('link_links', true);
         $this->db()->drop('link_cats', true);
     }
 
     public function getInstallSql(): string
     {
-        return 'CREATE TABLE IF NOT EXISTS `[prefix]_links` (
+        return 'CREATE TABLE IF NOT EXISTS `[prefix]_link_links` (
                   `id` INT(11) NOT NULL AUTO_INCREMENT,
                   `cat_id` INT(11) NULL DEFAULT 0,
                   `pos` INT(11) NOT NULL DEFAULT 0,
@@ -63,7 +65,25 @@ class Config extends \Ilch\Config\Install
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1;
 
-                INSERT INTO `[prefix]_links` (`id`, `name`, `desc`, `banner`, `link`) VALUES
+                CREATE TABLE IF NOT EXISTS `[prefix]_link_access` (
+                    `cat_id` INT(11) NOT NULL,
+                    `group_id` INT(11) NOT NULL,
+                    INDEX `FK_[prefix]_link_access_groups` (`group_id`) USING BTREE,
+                    INDEX `FK_[prefix]_link_access_link_cats` (`cat_id`) USING BTREE,
+                    CONSTRAINT `FK_[prefix]_link_access_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    CONSTRAINT `FK_[prefix]_link_access_link_cats` FOREIGN KEY (`cat_id`) REFERENCES `[prefix]_link_cats` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+                CREATE TABLE IF NOT EXISTS `[prefix]_link_links_access` (
+                    `link_id` INT(11) NOT NULL,
+                    `group_id` INT(11) NOT NULL,
+                    INDEX `FK_[prefix]_link_links_access_groups` (`group_id`) USING BTREE,
+                    INDEX `FK_[prefix]_link_links_access_links` (`link_id`) USING BTREE,
+                    CONSTRAINT `FK_[prefix]_link_links_access_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    CONSTRAINT `FK_[prefix]_link_links_access_links` FOREIGN KEY (`link_id`) REFERENCES `[prefix]_link_links` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+                INSERT INTO `[prefix]_link_links` (`id`, `name`, `desc`, `banner`, `link`) VALUES
                 (1, "ilch", "Du suchst ein einfach strukturiertes Content Management System? Dann bist du bei ilch genau richtig! ", "https://www.ilch.de/include/images/linkus/468x60.png", "https://ilch.de");';
     }
 
@@ -98,6 +118,28 @@ class Config extends \Ilch\Config\Install
             case "1.10.1":
             case "1.11.0":
             case "1.11.1":
+            case "1.11.2":
+                // Rename table "links" to "link_links".
+                $this->db()->query('RENAME TABLE `[prefix]_links` TO `[prefix]_link_links`;');
+
+                // Create new tables "link_access" and "link_links_access".
+                $this->db()->queryMulti('CREATE TABLE IF NOT EXISTS `[prefix]_link_access` (
+                    `cat_id` INT(11) NOT NULL,
+                    `group_id` INT(11) NOT NULL,
+                    INDEX `FK_[prefix]_link_access_groups` (`group_id`) USING BTREE,
+                    INDEX `FK_[prefix]_link_access_link_cats` (`cat_id`) USING BTREE,
+                    CONSTRAINT `FK_[prefix]_link_access_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    CONSTRAINT `FK_[prefix]_link_access_link_cats` FOREIGN KEY (`cat_id`) REFERENCES `[prefix]_link_cats` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+                CREATE TABLE IF NOT EXISTS `[prefix]_link_links_access` (
+                    `link_id` INT(11) NOT NULL,
+                    `group_id` INT(11) NOT NULL,
+                    INDEX `FK_[prefix]_link_links_access_groups` (`group_id`) USING BTREE,
+                    INDEX `FK_[prefix]_link_links_access_links` (`link_id`) USING BTREE,
+                    CONSTRAINT `FK_[prefix]_link_links_access_groups` FOREIGN KEY (`group_id`) REFERENCES `[prefix]_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    CONSTRAINT `FK_[prefix]_link_links_access_links` FOREIGN KEY (`link_id`) REFERENCES `[prefix]_link_links` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;');
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';

--- a/application/modules/link/controllers/Index.php
+++ b/application/modules/link/controllers/Index.php
@@ -20,6 +20,7 @@ class Index extends \Ilch\Controller\Frontend
         $category = null;
         if ($this->getRequest()->getParam('cat_id')) {
             $category = $categoryMapper->getCategoryById($this->getRequest()->getParam('cat_id'));
+            $category = $this->checkAccess($category);
 
             if (!$category) {
                 $this->redirect()
@@ -43,14 +44,14 @@ class Index extends \Ilch\Controller\Frontend
                 ->add($category->getName(), ['action' => 'index', 'cat_id' => $category->getId()]);
 
             $links = $linkMapper->getLinksByCatId($category->getId());
-            $categorys = $categoryMapper->getCategorysByParentId($category->getId());
+            $categories = $categoryMapper->getCategoriesByParentId($category->getId());
         } else {
             $links = $linkMapper->getLinksByCatId(0);
-            $categorys = $categoryMapper->getCategorysByParentId(0);
+            $categories = $categoryMapper->getCategoriesByParentId(0);
         }
 
-        $this->getView()->set('links', $links);
-        $this->getView()->set('categorys', $categorys);
+        $this->getView()->set('links', $this->checkAccess($links));
+        $this->getView()->set('categories', $this->checkAccess($categories));
     }
 
     public function redirectAction()
@@ -58,6 +59,7 @@ class Index extends \Ilch\Controller\Frontend
         $linkMapper = new LinkMapper();
 
         $linkModel = ($this->getRequest()->getParam('link_id') && is_numeric($this->getRequest()->getParam('link_id'))) ? $linkMapper->getLinkById($this->getRequest()->getParam('link_id') ?? 0) : 0;
+        $linkModel = $this->checkAccess($linkModel);
         if ($linkModel) {
             $linkModel->addHits();
             $linkMapper->save($linkModel);
@@ -66,5 +68,62 @@ class Index extends \Ilch\Controller\Frontend
             exit;
         }
         $this->redirect(['action' => 'index']);
+    }
+
+    private function checkAccess($linkOrCategoryItems)
+    {
+        if (!$linkOrCategoryItems) {
+            // Object is null? Early return.
+            return $linkOrCategoryItems;
+        }
+
+        if (!($this->getUser() && $this->getUser()->isAdmin())) {
+            if (!is_array($linkOrCategoryItems)) {
+                // Single link or category.
+                if (empty($linkOrCategoryItems->getAccess())) {
+                    // Visible for everyone.
+                    return $linkOrCategoryItems;
+                }
+
+                if (is_in_array(explode(',', $linkOrCategoryItems->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ?: [3])) {
+                    return $linkOrCategoryItems;
+                }
+
+                return null;
+            }
+
+            // Check which links or categories should be visible for the user or guest.
+            $linkOrCategoryItemsVisible = [];
+            foreach ($linkOrCategoryItems as $key => $linksOrCategoriesItem) {
+                if (!is_array($linksOrCategoriesItem)) {
+                    if (empty($linksOrCategoriesItem->getAccess())) {
+                        // Visible for everyone.
+                        $linkOrCategoryItemsVisible[$key] = $linksOrCategoriesItem;
+                        continue;
+                    }
+
+                    if (is_in_array(explode(',', $linksOrCategoriesItem->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ?: [3])) {
+                        $linkOrCategoryItemsVisible[$key] = $linksOrCategoriesItem;
+                    }
+                } else {
+                    // Subitems
+                    foreach ($linksOrCategoriesItem as $linkOrCategoryItem) {
+                        if (empty($linkOrCategoryItem->getAccess())) {
+                            // Visible for everyone.
+                            $linkOrCategoryItemsVisible[$key][] = $linkOrCategoryItem;
+                            continue;
+                        }
+
+                        if (is_in_array(explode(',', $linkOrCategoryItem->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ?: [3])) {
+                            $linkOrCategoryItemsVisible[$key][] = $linkOrCategoryItem;
+                        }
+                    }
+                }
+            }
+
+            $linkOrCategoryItems = $linkOrCategoryItemsVisible;
+        }
+
+        return $linkOrCategoryItems;
     }
 }

--- a/application/modules/link/controllers/admin/Index.php
+++ b/application/modules/link/controllers/admin/Index.php
@@ -12,6 +12,7 @@ use Modules\Link\Models\Link as LinkModel;
 use Modules\Link\Mappers\Category as CategoryMapper;
 use Modules\Link\Models\Category as CategoryModel;
 use Ilch\Validation;
+use Modules\User\Mappers\Group as UserGroupMapper;
 
 class Index extends \Ilch\Controller\Admin
 {
@@ -86,10 +87,10 @@ class Index extends \Ilch\Controller\Admin
                 ->add($category->getName(), ['action' => 'index', 'cat_id' => $category->getId()]);
 
             $links = $linkMapper->getLinksByCatId($this->getRequest()->getParam('cat_id'));
-            $categorys = $categoryMapper->getCategorysByParentId($this->getRequest()->getParam('cat_id'));
+            $categories = $categoryMapper->getCategoriesByParentId($this->getRequest()->getParam('cat_id'));
         } else {
             $links = $linkMapper->getLinksByCatId(0);
-            $categorys = $categoryMapper->getCategorysByParentId(0);
+            $categories = $categoryMapper->getCategoriesByParentId(0);
         }
 
         $this->getLayout()->getAdminHmenu()
@@ -127,7 +128,7 @@ class Index extends \Ilch\Controller\Admin
         }
 
         $this->getView()->set('links', $links);
-        $this->getView()->set('categorys', $categorys);
+        $this->getView()->set('categories', $categories);
     }
 
     public function redirectAction()
@@ -180,6 +181,7 @@ class Index extends \Ilch\Controller\Admin
     {
         $categoryMapper = new CategoryMapper();
         $linkMapper = new LinkMapper();
+        $userGroupMapper = new UserGroupMapper();
 
         $model = new LinkModel();
         if ($this->getRequest()->getParam('id')) {
@@ -211,7 +213,7 @@ class Index extends \Ilch\Controller\Admin
                 'link' => $this->getRequest()->getPost('link'),
                 'banner' => $banner,
                 'desc' => $this->getRequest()->getPost('desc'),
-                'catId' => $this->getRequest()->getPost('catId'),
+                'catId' => $this->getRequest()->getPost('catId')
             ];
 
             Validation::setCustomFieldAliases([
@@ -229,7 +231,8 @@ class Index extends \Ilch\Controller\Admin
                     ->setLink($this->getRequest()->getPost('link', ''))
                     ->setBanner($this->getRequest()->getPost('banner', ''))
                     ->setDesc($this->getRequest()->getPost('desc', ''))
-                    ->setCatId($this->getRequest()->getPost('catId', 0));
+                    ->setCatId($this->getRequest()->getPost('catId', 0))
+                    ->setAccess(implode(',', $this->getRequest()->getPost('access') ?? []));
                 $linkMapper->save($model);
 
                 $this->addMessage('saveSuccess');
@@ -243,11 +246,13 @@ class Index extends \Ilch\Controller\Admin
         }
 
         $this->getView()->set('cats', $categoryMapper->getCategories() ?? []);
+        $this->getView()->set('userGroupList', $userGroupMapper->getGroupList());
     }
 
     public function treatCatAction()
     {
         $categorykMapper = new CategoryMapper();
+        $userGroupMapper = new UserGroupMapper();
 
         $model = new CategoryModel();
         if ($this->getRequest()->getParam('id')) {
@@ -279,7 +284,8 @@ class Index extends \Ilch\Controller\Admin
                     $model->setParentID($this->getRequest()->getParam('parentId'));
                 }
                 $model->setName($this->getRequest()->getPost('name'))
-                    ->setDesc($this->getRequest()->getPost('desc'));
+                    ->setDesc($this->getRequest()->getPost('desc'))
+                    ->setAccess(implode(',', $this->getRequest()->getPost('access') ?? []));
                 $categorykMapper->save($model);
 
                 $this->addMessage('saveSuccess');
@@ -291,5 +297,7 @@ class Index extends \Ilch\Controller\Admin
                 ->withErrors($validation->getErrorBag())
                 ->to(array_merge(['action' => 'treatCat'], ($model->getId() ? ['id' => $model->getId()] : [])));
         }
+
+        $this->getView()->set('userGroupList', $userGroupMapper->getGroupList());
     }
 }

--- a/application/modules/link/mappers/Access.php
+++ b/application/modules/link/mappers/Access.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @copyright Ilch 2
+ * @package ilch
+ */
+
+namespace Modules\Link\Mappers;
+
+use Ilch\Mapper;
+
+/**
+ * Mapper so handle the access rights for a category and link.
+ *
+ * @since 1.12.0
+ */
+class Access extends Mapper
+{
+    /**
+     * @var string
+     */
+    public string $accessTable = 'link_access';
+
+    /**
+     * @var string
+     */
+    public string $accessLinksTable = 'link_links_access';
+
+    /**
+     * Save access rights for a category.
+     *
+     * @param int $itemId
+     * @param string|null $access
+     * @return void
+     * @since 1.12.0
+     */
+    public function save(int $itemId, ?string $access)
+    {
+        $this->saveAccess($itemId, $access);
+    }
+
+    /**
+     * Save access rights for a link.
+     *
+     * @param int $linksId
+     * @param string|null $access
+     * @return void
+     * @since 1.12.0
+     */
+    public function saveLinksAccess(int $linksId, ?string $access)
+    {
+        $this->saveAccess($linksId, $access, true);
+    }
+
+    /**
+     * Save access rights for a link or a category.
+     *
+     * @param int $id
+     * @param string|null $access
+     * @param bool $isLinkId
+     * @return void
+     * @since 1.12.0
+     */
+    private function saveAccess(int $id, ?string $access, bool $isLinkId = false)
+    {
+        if ($access === null) {
+            return;
+        }
+
+        $columnName = ($isLinkId) ? 'link_id' : 'cat_id';
+        $tableName = ($isLinkId) ? $this->accessLinksTable : $this->accessTable;
+
+        $this->db()->delete($tableName)
+            ->where([$columnName => $id])
+            ->execute();
+
+        $access = explode(',', $access);
+
+        $preparedRows = [];
+        foreach ($access as $groupId) {
+            if ($groupId) {
+                $preparedRows[] = [$id, $groupId];
+            }
+        }
+
+        if (count($preparedRows)) {
+            // Add access rights in chunks of 25 to the table.
+            $chunks = array_chunk($preparedRows, 25);
+            foreach ($chunks as $chunk) {
+                $this->db()->insert($tableName)
+                    ->columns([$columnName, 'group_id'])
+                    ->values($chunk)
+                    ->execute();
+            }
+        }
+    }
+}

--- a/application/modules/link/mappers/Category.php
+++ b/application/modules/link/mappers/Category.php
@@ -10,17 +10,19 @@ namespace Modules\Link\Mappers;
 use Ilch\Pagination;
 use Modules\Link\Models\Category as CategoryModel;
 use Modules\Link\Mappers\Link as LinkMapper;
+use Modules\Link\Mappers\Access as AccessMapper;
 
 class Category extends \Ilch\Mapper
 {
     /**
      * @var string
      */
-    public $tablename = 'link_cats';
+    public string $tablename = 'link_cats';
+
     /**
-     * @var string
+     * @var string|null
      */
-    public $tablename_entries = null;
+    public ?string $tablename_entries = null;
 
     /**
      */
@@ -57,13 +59,15 @@ class Category extends \Ilch\Mapper
         $select = $this->db()->select();
         $select->fields(['lc.id', 'lc.parent_id', 'lc.pos', 'lc.name', 'lc.desc'])
             ->from(['lc' => $this->tablename])
+            ->join(['ca' => 'link_access'], 'ca.cat_id = lc.id', 'LEFT', ['access' => 'GROUP_CONCAT(DISTINCT ca.group_id)'])
             ->where($where)
             ->order($orderBy);
 
         if ($countEntries) {
-            $select->join(['l' => $this->tablename_entries], ['l.cat_id = lc.id'], 'LEFT', ['count' => 'COUNT(l.id)'])
-                ->group(['lc.id', 'lc.parent_id', 'lc.pos', 'lc.name', 'lc.desc']);
+            $select->join(['l' => $this->tablename_entries], ['l.cat_id = lc.id'], 'LEFT', ['count' => 'COUNT(l.id)']);
         }
+
+        $select->group(['lc.id', 'lc.parent_id', 'lc.pos', 'lc.name', 'lc.desc']);
 
         if ($pagination !== null) {
             $select->limit($pagination->getLimit())
@@ -90,7 +94,7 @@ class Category extends \Ilch\Mapper
     }
 
     /**
-     * Gets categorys.
+     * Gets categories.
      *
      * @param array $where
      * @return CategoryModel[]|null
@@ -122,8 +126,20 @@ class Category extends \Ilch\Mapper
      *
      * @param int $parentId
      * @return CategoryModel[]|null
+     * @deprecated Use getCategoriesByParentId instead
      */
     public function getCategorysByParentId(int $parentId): ?array
+    {
+        return $this->getCategoriesByParentId($parentId);
+    }
+
+    /**
+     * Returns user model found by the id or false if none found.
+     *
+     * @param int $parentId
+     * @return CategoryModel[]|null
+     */
+    public function getCategoriesByParentId(int $parentId): ?array
     {
         return $this->getEntriesBy(['lc.parent_id' => $parentId], ['lc.pos' => 'ASC'], null, true);
     }
@@ -191,12 +207,18 @@ class Category extends \Ilch\Mapper
                 ->values($fields)
                 ->where(['id' => $category->getId()])
                 ->execute();
-            return $category->getId();
+            $id = $category->getId();
         } else {
-            return $this->db()->insert($this->tablename)
+            $id = $this->db()->insert($this->tablename)
                 ->values($fields)
                 ->execute();
         }
+
+        // Store access rights.
+        $accessMapper = new AccessMapper();
+        $accessMapper->save($id, $category->getAccess());
+
+        return $id;
     }
 
     /**

--- a/application/modules/link/mappers/Link.php
+++ b/application/modules/link/mappers/Link.php
@@ -8,6 +8,7 @@
 namespace Modules\Link\Mappers;
 
 use Ilch\Pagination;
+use Modules\Link\Mappers\Access as AccessMapper;
 use Modules\Link\Models\Link as LinkModel;
 
 class Link extends \Ilch\Mapper
@@ -15,7 +16,7 @@ class Link extends \Ilch\Mapper
     /**
      * @var string
      */
-    public $tablename = 'links';
+    public string $tablename = 'link_links';
 
     /**
      * returns if the module is installed.
@@ -40,7 +41,9 @@ class Link extends \Ilch\Mapper
         $select = $this->db()->select();
         $select->fields(['l.id', 'l.cat_id', 'l.pos', 'l.name', 'l.desc', 'l.banner', 'l.link', 'l.hits'])
             ->from(['l' => $this->tablename])
+            ->join(['la' => 'link_links_access'], 'la.link_id = l.id', 'LEFT', ['access' => 'GROUP_CONCAT(DISTINCT la.group_id)'])
             ->where($where)
+            ->group(['l.id'])
             ->order($orderBy);
 
         if ($pagination !== null) {
@@ -136,12 +139,18 @@ class Link extends \Ilch\Mapper
                 ->values($fields)
                 ->where(['id' => $link->getId()])
                 ->execute();
-            return $link->getId();
+            $id = $link->getId();
         } else {
-            return $this->db()->insert($this->tablename)
+            $id = $this->db()->insert($this->tablename)
                 ->values($fields)
                 ->execute();
         }
+
+        // Store access rights.
+        $accessMapper = new AccessMapper();
+        $accessMapper->saveLinksAccess($id, $link->getAccess());
+
+        return $id;
     }
 
     /**

--- a/application/modules/link/models/Category.php
+++ b/application/modules/link/models/Category.php
@@ -14,37 +14,49 @@ class Category extends \Ilch\Mapper
      *
      * @var int
      */
-    private $id = 0;
+    protected int $id = 0;
+
     /**
      * The position of the category.
      *
      * @var int
      */
-    protected $position = 0;
+    protected int $position = 0;
+
     /**
      * The name of the category.
      *
      * @var string
      */
-    private $name = '';
+    protected string $name = '';
+
     /**
      * The catid of the category.
      *
      * @var int
      */
-    private $cat = 0;
+    protected int $cat = 0;
+
     /**
      * The description of the category.
      *
      * @var string
      */
-    private $desc = '';
+    protected string $desc = '';
+
     /**
      * The links count of the category.
      *
-     * @var integer
+     * @var int
      */
-    private $linksCount = 0;
+    protected int $linksCount = 0;
+
+    /**
+     * The access rights of the category.
+     *
+     * @var string
+     */
+    protected string $access = '';
 
     /**
      * @param array $entries
@@ -69,6 +81,9 @@ class Category extends \Ilch\Mapper
         }
         if (isset($entries['count'])) {
             $this->setLinksCount($entries['count']);
+        }
+        if (isset($entries['access'])) {
+            $this->setAccess($entries['access']);
         }
 
         return $this;
@@ -226,8 +241,30 @@ class Category extends \Ilch\Mapper
                 'name'      => $this->getName(),
                 'desc'      => $this->getDesc(),
                 'parent_id' => $this->getParentId(),
-                'pos'       => $this->getPosition()
+                'pos'       => $this->getPosition(),
             ]
         );
+    }
+
+    /**
+     * Get the access rights of the category.
+     *
+     * @return string
+     */
+    public function getAccess(): string
+    {
+        return $this->access;
+    }
+
+    /**
+     * Sets the access rights of the category.
+     *
+     * @param string $access
+     * @return $this
+     */
+    public function setAccess(string $access): Category
+    {
+        $this->access = $access;
+        return $this;
     }
 }

--- a/application/modules/link/models/Link.php
+++ b/application/modules/link/models/Link.php
@@ -14,56 +14,63 @@ class Link extends \Ilch\Model
      *
      * @var int
      */
-    protected $id = 0;
+    protected int $id = 0;
 
     /**
      * The position of the link.
      *
      * @var int
      */
-    protected $position = 0;
+    protected int $position = 0;
 
     /**
      * The name of the link.
      *
      * @var string
      */
-    protected $name = '';
+    protected string $name = '';
 
     /**
      * The link of the link.
      *
      * @var string
      */
-    protected $link = '';
+    protected string $link = '';
 
     /**
      * The banner of the link.
      *
      * @var string
      */
-    protected $banner = '';
+    protected string $banner = '';
 
     /**
      * The category of the link.
      *
      * @var int
      */
-    protected $cat_id = 0;
+    protected int $cat_id = 0;
 
     /**
      * The category of the link.
      *
      * @var string
      */
-    protected $desc = '';
+    protected string $desc = '';
 
     /**
      * The category of the link.
      *
      * @var int
      */
-    protected $hits = 0;
+    protected int $hits = 0;
+
+    /**
+     * The access rights of the link.
+     *
+     * @var string
+     */
+    protected string $access = '';
 
     /**
      * @param array $entries
@@ -94,6 +101,9 @@ class Link extends \Ilch\Model
         }
         if (isset($entries['hits'])) {
             $this->setHits($entries['hits']);
+        }
+        if (isset($entries['access'])) {
+            $this->setAccess($entries['access']);
         }
         return $this;
     }
@@ -311,8 +321,30 @@ class Link extends \Ilch\Model
                 'desc'      => $this->getDesc(),
                 'cat_id'    => $this->getCatId(),
                 'pos'       => $this->getPosition(),
-                'hits'      => $this->getHits()
+                'hits'      => $this->getHits(),
             ]
         );
+    }
+
+    /**
+     * Get the access rights of the link.
+     *
+     * @return string
+     */
+    public function getAccess(): string
+    {
+        return $this->access;
+    }
+
+    /**
+     * Set the access rights of the link.
+     *
+     * @param string $access
+     * @return $this
+     */
+    public function setAccess(string $access): Link
+    {
+        $this->access = $access;
+        return $this;
     }
 }

--- a/application/modules/link/translations/de.php
+++ b/application/modules/link/translations/de.php
@@ -26,4 +26,5 @@ return [
     'deleteFailed' => 'Es befinden sich noch Einträge in der Kategorie',
     'linkInfoText' => 'Die Links einer Kategorie können innerhalb der Kategorie bearbeitet werden. Links und Kategorien können durch ziehen und ablegen sortiert werden.',
     'categoryNotFound' => 'Kategorie nicht gefunden.',
+    'access' => 'Sichtbar für',
 ];

--- a/application/modules/link/translations/en.php
+++ b/application/modules/link/translations/en.php
@@ -26,4 +26,5 @@ return [
     'deleteFailed' => 'There are still entries in the category',
     'linkInfoText' => 'The links of a category can be edited inside the category. Links and categories can be sorted by drag and drop.',
     'categoryNotFound' => 'Category not found.',
+    'access' => 'Visible for',
 ];

--- a/application/modules/link/views/admin/index/index.php
+++ b/application/modules/link/views/admin/index/index.php
@@ -2,8 +2,8 @@
 
 /** @var \Ilch\View $this */
 
-/** @var \Modules\Link\Models\Category[]|null $categorys */
-$categorys = $this->get('categorys');
+/** @var \Modules\Link\Models\Category[]|null $categories */
+$categories = $this->get('categories');
 
 /** @var \Modules\Link\Models\Link[]|null $links */
 $links = $this->get('links');
@@ -16,7 +16,7 @@ $links = $this->get('links');
 </h1>
 <form id="downloadsForm" method="POST" action="">
     <?=$this->getTokenField() ?>
-    <?php if ($categorys) : ?>
+    <?php if ($categories) : ?>
         <div class="table-responsive">
             <table class="table table-hover table-striped">
                 <colgroup>
@@ -37,7 +37,7 @@ $links = $this->get('links');
                 </thead>
                 <tbody id="sortableCat">
                     <?php
-                    foreach ($categorys as $category) :
+                    foreach ($categories as $category) :
                         $getDesc = $this->escape($category->getDesc());
                         if ($getDesc != '') {
                             $getDesc = '&raquo; ' . $getDesc;

--- a/application/modules/link/views/admin/index/treatCat.php
+++ b/application/modules/link/views/admin/index/treatCat.php
@@ -33,5 +33,28 @@ $cat = $this->get('category');
                       rows="3"><?=$this->escape($this->originalInput('desc', $cat->getDesc())) ?></textarea>
         </div>
     </div>
+    <div class="row mb-3">
+        <label for="access" class="col-xl-2 col-form-label"><?=$this->getTrans('access') ?></label>
+        <div class="col-xl-4">
+            <select class="choices-select form-control"
+                    id="access"
+                    name="access[]"
+                    data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>"
+                    multiple>
+                <?php
+                /** @var \Modules\User\Models\Group $group */
+                foreach ($this->get('userGroupList') as $group) : ?>
+                    <option value="<?=$group->getId() ?>"<?=(in_array($group->getId(), explode(',', $cat->getAccess()))) ? ' selected' : '' ?>><?=$this->escape($group->getName()) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+    </div>
     <?=$this->getSaveBar($cat->getId() ? 'updateButton' : 'addButton') ?>
 </form>
+
+<script>
+    choicesAccess = new Choices('#access', {
+        ...choicesOptions,
+        searchEnabled: true
+    });
+</script>

--- a/application/modules/link/views/admin/index/treatLink.php
+++ b/application/modules/link/views/admin/index/treatLink.php
@@ -78,6 +78,22 @@ $cats = $this->get('cats');
             </select>
         </div>
     </div>
+    <div class="row mb-3">
+        <label for="access" class="col-xl-2 col-form-label"><?=$this->getTrans('access') ?></label>
+        <div class="col-xl-4">
+            <select class="choices-select form-control"
+                    id="access"
+                    name="access[]"
+                    data-placeholder="<?=$this->getTrans('selectAssignedGroups') ?>"
+                    multiple>
+                <?php
+                /** @var \Modules\User\Models\Group $group */
+                foreach ($this->get('userGroupList') as $group) : ?>
+                    <option value="<?=$group->getId() ?>"<?=(in_array($group->getId(), explode(',', $link->getAccess()))) ? ' selected' : '' ?>><?=$this->escape($group->getName()) ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+    </div>
     <?=$this->getSaveBar($link->getId() ? 'updateButton' : 'addButton') ?>
 </form>
 
@@ -88,4 +104,9 @@ $cats = $this->get('cats');
         ->addInputId('_1')
         ->addUploadController($this->getUrl('admin/media/index/upload'))
 ?>
+
+choicesAccess = new Choices('#access', {
+    ...choicesOptions,
+    searchEnabled: true
+});
 </script>

--- a/application/modules/link/views/index/index.php
+++ b/application/modules/link/views/index/index.php
@@ -2,14 +2,14 @@
 
 /** @var \Ilch\View $this */
 
-/** @var \Modules\Link\Models\Category[]|null $categorys */
-$categorys = $this->get('categorys');
+/** @var \Modules\Link\Models\Category[]|null $categories */
+$categories = $this->get('categories');
 
 /** @var \Modules\Link\Models\Link[]|null $links */
 $links = $this->get('links');
 ?>
 <h1><?=$this->getTrans('menuLinks') ?></h1>
-<?php if ($categorys) : ?>
+<?php if ($categories) : ?>
     <div class="table-responsive">
         <table class="table table-hover table-striped">
             <colgroup>
@@ -20,7 +20,7 @@ $links = $this->get('links');
                 <th><?=$this->getTrans('category') ?></th>
                 <th class="text-center"><?=$this->getTrans('links') ?></th>
             </tr>
-            <?php foreach ($categorys as $category) : ?>
+            <?php foreach ($categories as $category) : ?>
             <tr>
                 <?php
                 $getDesc = $this->escape($category->getDesc());


### PR DESCRIPTION
# Description
- Add options for visibility of categories and links.
- Fixed "categorys" typos
- Renamed table "links" to "link_links". The key of the module is "link".
- Deprecated getCategorysByParentId() and added getCategoriesByParentId() as replacement.
- Other smaller code and code style improvements.

Fixes #1285

Based on work from a previous PR: #1383

# Known issue
- The number of links in a category is counted with the database query. For the user or guest not visible links are getting counted too.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
