### PR TITLE
Events: Veranstaltungen korrekt nach Datum sortieren

### DIFF
--- a/application/modules/events/config/config.php
+++ b/application/modules/events/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'events',
-        'version' => '1.23.7',
+        'version' => '1.23.8',
         'icon_small' => 'fa-solid fa-ticket',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -212,16 +212,13 @@ class Config extends \Ilch\Config\Install
             case "1.22.1":
             case "1.22.2":
             case "1.23.0":
-                // no break
             case "1.23.1":
-                // no break
             case "1.23.2":
-                // no break
             case "1.23.3":
-                // no break
             case "1.23.4":
-                // no break
             case "1.23.5":
+            case "1.23.6":
+            case "1.23.7":
                 // no break
         }
 

--- a/application/modules/events/controllers/admin/Index.php
+++ b/application/modules/events/controllers/admin/Index.php
@@ -65,7 +65,7 @@ class Index extends \Ilch\Controller\Admin
             }
         }
 
-        $this->getView()->set('events', $eventMapper->getEntries());
+        $this->getView()->set('events', $eventMapper->getEntries(), ['start' => 'DESC']);
     }
 
     public function delAction()

--- a/application/modules/events/mappers/Events.php
+++ b/application/modules/events/mappers/Events.php
@@ -101,7 +101,7 @@ class Events extends \Ilch\Mapper
             $pagination->setRowsPerPage($limit);
         }
 
-        return $this->getEntriesBy([new \Ilch\Database\Mysql\Expression\Comparison('`start`', '>', 'NOW()')], [], $pagination);
+        return $this->getEntriesBy([new \Ilch\Database\Mysql\Expression\Comparison('`start`', '>', 'NOW()')], ['start' => 'ASC'] , $pagination);
     }
 
     /**
@@ -129,7 +129,7 @@ class Events extends \Ilch\Mapper
             $pagination->setRowsPerPage($limit);
         }
 
-        return $this->getEntriesBy([new \Ilch\Database\Mysql\Expression\Comparison('`end`', '<', 'NOW()')], [], $pagination);
+        return $this->getEntriesBy([new \Ilch\Database\Mysql\Expression\Comparison('`end`', '<', 'NOW()')], ['start' => 'DESC'] , $pagination);
     }
 
     /**
@@ -151,7 +151,7 @@ class Events extends \Ilch\Mapper
                 new \Ilch\Database\Mysql\Expression\Comparison('`start`', '<', 'NOW()'),
                 new \Ilch\Database\Mysql\Expression\Comparison('`end`', '>', 'NOW()'),
             ],
-            [],
+         ['start' => 'ASC'],
             $pagination
         );
     }


### PR DESCRIPTION
# Description
Listen-Methoden im Mapper übergaben ein leeres Sortier-Array an
getEntriesBy(), wodurch keine ORDER-BY-Klausel gesetzt wurde und die
Einträge in Einfügereihenfolge (älteste zuerst) erschienen.

- getEventListUpcoming: start ASC (nächste zuerst)
- getEventListPast: start DESC (neueste zuerst)
- getEventListCurrent: start ASC
- Admin-Liste: getEntriesBy mit start DESC statt getEntries()

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge

> fix(events): Veranstaltungen korrekt nach Datum sortieren
> 
> Listen-Methoden im Mapper übergaben ein leeres Sortier-Array an
> getEntriesBy(), wodurch keine ORDER-BY-Klausel gesetzt wurde und die
> Einträge in Einfügereihenfolge (älteste zuerst) erschienen.
> 
> - getEventListUpcoming: start ASC (nächste zuerst)
> - getEventListPast: start DESC (neueste zuerst)
> - getEventListCurrent: start ASC
> - Admin-Liste: getEntriesBy mit start DESC statt getEntries()