### PR TITLE
Link: Remove getCategorysByParentId

### DIFF
--- a/application/modules/link/mappers/Category.php
+++ b/application/modules/link/mappers/Category.php
@@ -126,18 +126,6 @@ class Category extends \Ilch\Mapper
      *
      * @param int $parentId
      * @return CategoryModel[]|null
-     * @deprecated Use getCategoriesByParentId instead
-     */
-    public function getCategorysByParentId(int $parentId): ?array
-    {
-        return $this->getCategoriesByParentId($parentId);
-    }
-
-    /**
-     * Returns user model found by the id or false if none found.
-     *
-     * @param int $parentId
-     * @return CategoryModel[]|null
      */
     public function getCategoriesByParentId(int $parentId): ?array
     {


### PR DESCRIPTION
# Description
- Remove the deprecated getCategorysByParentId now instead of keeping it around for some time.

It was replaced by getCategoriesByParentId.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
