### PR TITLE
Events: Add year to the event date

### DIFF
--- a/application/modules/events/static/css/events.css
+++ b/application/modules/events/static/css/events.css
@@ -29,15 +29,16 @@ nav {
 }
 .event-list > li > time > .day {
     display: block;
-    font-size: 56pt;
+    font-size: 44pt;
     font-weight: 100;
     line-height: 1;
 }
-.event-list > li time > .month {
+.event-list > li time > .month, .event-list > li time > .year {
     display: block;
-    font-size: 24pt;
+    font-size: 18pt;
     font-weight: 900;
     line-height: 1;
+    padding: 2px 0;
 }
 .event-list > li > img {
     width: 100%;

--- a/application/modules/events/views/index/index.php
+++ b/application/modules/events/views/index/index.php
@@ -33,6 +33,7 @@ $entrantsMapper = $this->get('entrantsMapper');
                                 <time>
                                     <span class="day"><?=$date->format('j') ?></span>
                                     <span class="month"><?=$this->getTrans($date->format('M')) ?></span>
+                                    <span class="year"><?=$this->getTrans($date->format('Y')) ?></span>
                                 </time>
                                 <div class="info">
                                     <h2 class="title"><a href="<?=$this->getUrl('events/show/event/id/' . $event->getId()) ?>"><?=$this->escape($event->getTitle()) ?></a></h2>
@@ -96,6 +97,7 @@ $entrantsMapper = $this->get('entrantsMapper');
                             <time>
                                 <span class="day"><?=$date->format('j', true) ?></span>
                                 <span class="month"><?=$this->getTrans($date->format('M', true)) ?></span>
+                                <span class="year"><?=$this->getTrans($date->format('Y')) ?></span>
                             </time>
                             <div class="info">
                                 <h2 class="title"><a href="<?=$this->getUrl('events/show/event/id/' . $event->getId()) ?>"><?=$this->escape($event->getTitle()) ?></a></h2>
@@ -156,6 +158,7 @@ $entrantsMapper = $this->get('entrantsMapper');
                             <time>
                                 <span class="day"><?=$date->format('j', true) ?></span>
                                 <span class="month"><?=$this->getTrans($date->format('M', true)) ?></span>
+                                <span class="year"><?=$this->getTrans($date->format('Y')) ?></span>
                             </time>
                             <div class="info">
                                 <h2 class="title"><a href="<?=$this->getUrl('events/show/event/id/' . $event->getId()) ?>"><?=$this->escape($event->getTitle()) ?></a></h2>

--- a/application/modules/events/views/show/current.php
+++ b/application/modules/events/views/show/current.php
@@ -25,6 +25,7 @@ $entrantsMapper = $this->get('entrantsMapper');
                             <time>
                                 <span class="day"><?=$date->format('j') ?></span>
                                 <span class="month"><?=$this->getTrans($date->format('M')) ?></span>
+                                <span class="year"><?=$this->getTrans($date->format('Y')) ?></span>
                             </time>
                             <div class="info">
                                 <h2 class="title"><a href="<?=$this->getUrl('events/show/event/id/' . $event->getId()) ?>"><?=$this->escape($event->getTitle()) ?></a></h2>

--- a/application/modules/events/views/show/participation.php
+++ b/application/modules/events/views/show/participation.php
@@ -25,6 +25,7 @@ $entrantsMapper = $this->get('entrantsMapper');
                             <time>
                                 <span class="day"><?=$date->format('j', true) ?></span>
                                 <span class="month"><?=$this->getTrans($date->format('M', true)) ?></span>
+                                <span class="year"><?=$this->getTrans($date->format('Y'), true) ?></span>
                             </time>
                             <div class="info">
                                 <h2 class="title"><a href="<?=$this->getUrl('events/show/event/id/' . $event->getId()) ?>"><?=$this->escape($event->getTitle()) ?></a></h2>

--- a/application/modules/events/views/show/past.php
+++ b/application/modules/events/views/show/past.php
@@ -25,6 +25,7 @@ $entrantsMapper = $this->get('entrantsMapper');
                             <time>
                                 <span class="day"><?=$date->format('j') ?></span>
                                 <span class="month"><?=$this->getTrans($date->format('M')) ?></span>
+                                <span class="year"><?=$this->getTrans($date->format('Y')) ?></span>
                             </time>
                             <div class="info">
                                 <h2 class="title"><a href="<?=$this->getUrl('events/show/event/id/' . $event->getId()) ?>"><?=$this->escape($event->getTitle()) ?></a></h2>

--- a/application/modules/events/views/show/upcoming.php
+++ b/application/modules/events/views/show/upcoming.php
@@ -25,6 +25,7 @@ $entrantsMapper = $this->get('entrantsMapper');
                             <time>
                                 <span class="day"><?=$date->format('j') ?></span>
                                 <span class="month"><?=$this->getTrans($date->format('M')) ?></span>
+                                <span class="year"><?=$this->getTrans($date->format('Y')) ?></span>
                             </time>
                             <div class="info">
                                 <h2 class="title"><a href="<?=$this->getUrl('events/show/event/id/' . $event->getId()) ?>"><?=$this->escape($event->getTitle()) ?></a></h2>


### PR DESCRIPTION
# Description
- Add year to the event date.

If events of multiple years are shown then the date of the event becomes unclear. This is even more the case if all or most of the titles of the event don't contain the year.

<img width="1322" height="298" alt="grafik" src="https://github.com/user-attachments/assets/61911106-62ed-44df-b296-5a5e4833cafd" />

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
