### PR TITLE
Shoutbox: Add pagination, usercache and fix error

### DIFF
--- a/application/modules/shoutbox/boxes/views/shoutbox.php
+++ b/application/modules/shoutbox/boxes/views/shoutbox.php
@@ -199,7 +199,7 @@ $config = \Ilch\Registry::get('config');
                 <?php endforeach; ?>
             <?php else : ?>
                 <tr>
-                    <td><?=$this->getTrans('noEntrys') ?></td>
+                    <td><?=$this->getTrans('noEntries') ?></td>
                 </tr>
             <?php endif; ?>
         </table>

--- a/application/modules/shoutbox/config/config.php
+++ b/application/modules/shoutbox/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'shoutbox',
-        'version' => '1.6.3',
+        'version' => '1.6.4',
         'icon_small' => 'fa-solid fa-bullhorn',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -75,17 +75,13 @@ class Config extends \Ilch\Config\Install
     {
         switch ($installedVersion) {
             case "1.0":
-                // no break
             case "1.1":
-                // no break
             case "1.2":
                 // Convert table to new character set and collate
                 $this->db()->query('ALTER TABLE `[prefix]_shoutbox` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
                 // no break
             case "1.3.0":
-                // no break
             case "1.4.0":
-                // no break
             case "1.4.1":
                 // Update description
                 foreach ($this->config['languages'] as $key => $value) {
@@ -103,6 +99,7 @@ class Config extends \Ilch\Config\Install
             case "1.6.0":
             case "1.6.1":
             case "1.6.2":
+            case "1.6.3":
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';

--- a/application/modules/shoutbox/config/config.php
+++ b/application/modules/shoutbox/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'shoutbox',
-        'version' => '1.6.4',
+        'version' => '1.7.0',
         'icon_small' => 'fa-solid fa-bullhorn',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -55,6 +55,8 @@ class Config extends \Ilch\Config\Install
 
         $databaseConfig = new \Ilch\Config\Database($this->db());
         $databaseConfig->delete('shoutbox_limit')
+            ->delete('shoutbox_messagesPerPageAdmincenter')
+            ->delete('shoutbox_messagesPerPage')
             ->delete('shoutbox_maxtextlength')
             ->delete('shoutbox_writeaccess');
     }
@@ -100,6 +102,7 @@ class Config extends \Ilch\Config\Install
             case "1.6.1":
             case "1.6.2":
             case "1.6.3":
+                // no break
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';

--- a/application/modules/shoutbox/config/config.php
+++ b/application/modules/shoutbox/config/config.php
@@ -45,6 +45,8 @@ class Config extends \Ilch\Config\Install
 
         $databaseConfig = new \Ilch\Config\Database($this->db());
         $databaseConfig->set('shoutbox_limit', '5')
+            ->set('shoutbox_messagesPerPageAdmincenter', '20')
+            ->set('shoutbox_messagesPerPage', '20')
             ->set('shoutbox_maxtextlength', '50')
             ->set('shoutbox_writeaccess', '1,2');
     }
@@ -102,6 +104,10 @@ class Config extends \Ilch\Config\Install
             case "1.6.1":
             case "1.6.2":
             case "1.6.3":
+                // Add default values for new settings.
+                $databaseConfig = new \Ilch\Config\Database($this->db());
+                $databaseConfig->set('shoutbox_messagesPerPageAdmincenter', '20')
+                    ->set('shoutbox_messagesPerPage', '20');
                 // no break
         }
 

--- a/application/modules/shoutbox/controllers/Index.php
+++ b/application/modules/shoutbox/controllers/Index.php
@@ -21,7 +21,7 @@ class Index extends \Ilch\Controller\Frontend
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('menuShoutbox'), ['action' => 'index']);
 
-        $pagination->setRowsPerPage($this->getConfig()->get('defaultPaginationObjects'));
+        $pagination->setRowsPerPage($this->getConfig()->get('shoutbox_messagesPerPage') ?: $this->getConfig()->get('defaultPaginationObjects'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $shoutboxEntries = $shoutboxMapper->getEntriesBy([], ['id' => 'DESC'], $pagination);

--- a/application/modules/shoutbox/controllers/Index.php
+++ b/application/modules/shoutbox/controllers/Index.php
@@ -8,17 +8,40 @@
 namespace Modules\Shoutbox\Controllers;
 
 use Modules\Shoutbox\Mappers\Shoutbox as ShoutboxMapper;
+use Modules\User\Mappers\User as UserMapper;
 
 class Index extends \Ilch\Controller\Frontend
 {
     public function indexAction()
     {
         $shoutboxMapper = new ShoutboxMapper();
+        $userMapper = new UserMapper();
+        $pagination = new \Ilch\Pagination();
 
         $this->getLayout()->getHmenu()
                 ->add($this->getTranslator()->trans('menuShoutbox'), ['action' => 'index']);
 
-        $this->getView()->set('shoutbox', $shoutboxMapper->getShoutbox());
+        $pagination->setRowsPerPage($this->getConfig()->get('defaultPaginationObjects'));
+        $pagination->setPage($this->getRequest()->getParam('page'));
+
+        $shoutboxEntries = $shoutboxMapper->getEntriesBy([], ['id' => 'DESC'], $pagination);
+        $userNameCache = [];
+
+        foreach ($shoutboxEntries as $entry) {
+            if (!isset($userNameCache[$entry->getUid()])) {
+                // User not in cache.
+                $user = $userMapper->getUserById($entry->getUid());
+
+                if ($user) {
+                    $userNameCache[$entry->getUid()] = $user->getName();
+                }
+            }
+        }
+
+        $this->getView()->set('dummyUserName', $userMapper->getDummyUser()->getName());
+        $this->getView()->set('userNames', $userNameCache);
+        $this->getView()->set('shoutbox', $shoutboxEntries);
+        $this->getView()->set('pagination', $pagination);
     }
 
     /**

--- a/application/modules/shoutbox/controllers/admin/Index.php
+++ b/application/modules/shoutbox/controllers/admin/Index.php
@@ -51,6 +51,7 @@ class Index extends \Ilch\Controller\Admin
     {
         $shoutboxMapper = new ShoutboxMapper();
         $userMapper = new UserMapper();
+        $pagination = new \Ilch\Pagination();
 
         $this->getLayout()->getAdminHmenu()
                 ->add($this->getTranslator()->trans('menuShoutbox'), ['action' => 'index'])
@@ -62,8 +63,27 @@ class Index extends \Ilch\Controller\Admin
             }
         }
 
-        $this->getView()->set('userMapper', $userMapper);
-        $this->getView()->set('shoutbox', $shoutboxMapper->getShoutbox());
+        $pagination->setRowsPerPage($this->getConfig()->get('defaultPaginationObjects'));
+        $pagination->setPage($this->getRequest()->getParam('page'));
+
+        $shoutboxEntries = $shoutboxMapper->getEntriesBy([], ['id' => 'DESC'], $pagination);
+        $userNameCache = [];
+
+        foreach ($shoutboxEntries as $entry) {
+            if (!isset($userNameCache[$entry->getUid()])) {
+                // User not in cache.
+                $user = $userMapper->getUserById($entry->getUid());
+
+                if ($user) {
+                    $userNameCache[$entry->getUid()] = $user->getName();
+                }
+            }
+        }
+
+        $this->getView()->set('dummyUserName',$userMapper->getDummyUser()->getName());
+        $this->getView()->set('userNames', $userNameCache);
+        $this->getView()->set('shoutbox', $shoutboxEntries);
+        $this->getView()->set('pagination', $pagination);
     }
 
     public function deleteAction()

--- a/application/modules/shoutbox/controllers/admin/Index.php
+++ b/application/modules/shoutbox/controllers/admin/Index.php
@@ -80,7 +80,7 @@ class Index extends \Ilch\Controller\Admin
             }
         }
 
-        $this->getView()->set('dummyUserName',$userMapper->getDummyUser()->getName());
+        $this->getView()->set('dummyUserName', $userMapper->getDummyUser()->getName());
         $this->getView()->set('userNames', $userNameCache);
         $this->getView()->set('shoutbox', $shoutboxEntries);
         $this->getView()->set('pagination', $pagination);

--- a/application/modules/shoutbox/controllers/admin/Index.php
+++ b/application/modules/shoutbox/controllers/admin/Index.php
@@ -63,7 +63,7 @@ class Index extends \Ilch\Controller\Admin
             }
         }
 
-        $pagination->setRowsPerPage($this->getConfig()->get('defaultPaginationObjects'));
+        $pagination->setRowsPerPage($this->getConfig()->get('shoutbox_messagesPerPageAdmincenter') ?: $this->getConfig()->get('defaultPaginationObjects'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
         $shoutboxEntries = $shoutboxMapper->getEntriesBy([], ['id' => 'DESC'], $pagination);

--- a/application/modules/shoutbox/controllers/admin/Settings.php
+++ b/application/modules/shoutbox/controllers/admin/Settings.php
@@ -51,8 +51,10 @@ class Settings extends \Ilch\Controller\Admin
 
         if ($this->getRequest()->isPost()) {
             $validation = Validation::create($this->getRequest()->getPost(), [
-                'limit'         => 'required|min:1',
-                'maxtextlength' => 'required|min:20',
+                'limit'         => 'required|integer|min:1',
+                'maxtextlength' => 'required|integer|min:20',
+                'messagesPerPage' => 'required|integer|min:1',
+                'messagesPerPageAdmincenter' => 'required|integer|min:1',
             ]);
 
             if ($validation->isValid()) {
@@ -63,6 +65,8 @@ class Settings extends \Ilch\Controller\Admin
                 }
 
                 $this->getConfig()->set('shoutbox_limit', $this->getRequest()->getPost('limit'))
+                    ->set('shoutbox_messagesPerPage', $this->getRequest()->getPost('messagesPerPage'))
+                    ->set('shoutbox_messagesPerPageAdmincenter', $this->getRequest()->getPost('messagesPerPageAdmincenter'))
                     ->set('shoutbox_maxtextlength', $this->getRequest()->getPost('maxtextlength'))
                     ->set('shoutbox_writeaccess', $writeAccess);
 
@@ -78,6 +82,8 @@ class Settings extends \Ilch\Controller\Admin
         }
 
         $this->getView()->set('limit', $this->getConfig()->get('shoutbox_limit'))
+            ->set('messagesPerPage', $this->getConfig()->get('shoutbox_messagesPerPage'))
+            ->set('messagesPerPageAdmincenter', $this->getConfig()->get('shoutbox_messagesPerPageAdmincenter'))
             ->set('maxtextlength', $this->getConfig()->get('shoutbox_maxtextlength'))
             ->set('userGroupList', $userGroupMapper->getGroupList())
             ->set('writeAccess', $this->getConfig()->get('shoutbox_writeaccess'));

--- a/application/modules/shoutbox/translations/de.php
+++ b/application/modules/shoutbox/translations/de.php
@@ -12,7 +12,7 @@ return [
     'name' => 'Name',
     'archive' => 'Archiv',
     'message' => 'Nachricht',
-    'noEntrys' => 'Keine Einträge vorhanden',
+    'noEntries' => 'Keine Einträge vorhanden',
     'numberOfMessagesDisplayed' => 'Anzahl angezeigter Nachrichten',
     'maximumTextLength' => 'Maximale Textlänge',
     'settings' => 'Einstellungen',

--- a/application/modules/shoutbox/translations/de.php
+++ b/application/modules/shoutbox/translations/de.php
@@ -14,6 +14,8 @@ return [
     'message' => 'Nachricht',
     'noEntries' => 'Keine Einträge vorhanden',
     'numberOfMessagesDisplayed' => 'Anzahl angezeigter Nachrichten',
+    'messagesPerPageAdmincenter' => 'Nachrichten pro Seite im Admincenter',
+    'messagesPerPage' => 'Nachrichten pro Seite',
     'maximumTextLength' => 'Maximale Textlänge',
     'settings' => 'Einstellungen',
     'answer' => 'Antworten',

--- a/application/modules/shoutbox/translations/en.php
+++ b/application/modules/shoutbox/translations/en.php
@@ -14,6 +14,8 @@ return [
     'message' => 'Message',
     'noEntries' => 'No entries exist',
     'numberOfMessagesDisplayed' => 'Number of messages displayed',
+    'messagesPerPageAdmincenter' => 'Messages per page in admincenter',
+    'messagesPerPage' => 'Messages per page',
     'maximumTextLength' => 'Maximum text length',
     'settings' => 'Settings',
     'answer' => 'Answer',

--- a/application/modules/shoutbox/translations/en.php
+++ b/application/modules/shoutbox/translations/en.php
@@ -12,7 +12,7 @@ return [
     'name' => 'Name',
     'archive' => 'Archive',
     'message' => 'Message',
-    'noEntrys' => 'No entries exist',
+    'noEntries' => 'No entries exist',
     'numberOfMessagesDisplayed' => 'Number of messages displayed',
     'maximumTextLength' => 'Maximum text length',
     'settings' => 'Settings',

--- a/application/modules/shoutbox/views/admin/index/index.php
+++ b/application/modules/shoutbox/views/admin/index/index.php
@@ -2,7 +2,14 @@
 
 /** @var \Ilch\View $this */
 
-$userMapper = $this->get('userMapper');
+/** @var string[] $userNames */
+$userNames = $this->get('userNames');
+
+/** @var string $dummyUserName */
+$dummyUserName = $this->get('dummyUserName');
+
+/** @var \Ilch\Pagination $pagination */
+$pagination = $this->get('pagination');
 ?>
 <h1><?=$this->getTrans('manage') ?></h1>
 <?php if ($this->get('shoutbox') != '') : ?>
@@ -37,8 +44,8 @@ $userMapper = $this->get('userMapper');
                             <?php if ($shoutbox->getUid() == '0') : ?>
                                 <td><?=$this->escape($shoutbox->getName()) ?></td>
                             <?php else : ?>
-                                <?php $user = $userMapper->getUserById($shoutbox->getUid()) ?>
-                                <td><a href="<?=$this->getUrl('user/profil/index/user/' . $user->getId()) ?>" target="_blank"><?=$this->escape($user ? $user->getName() : $userMapper->getDummyUser()->getName()) ?></a></td>
+                                <?php $userName = $userNames[$shoutbox->getUid()] ?? $dummyUserName ?>
+                                <td><a href="<?=$this->getUrl('user/profil/index/user/' . $shoutbox->getUid()) ?>" target="_blank"><?=$this->escape($userName) ?></a></td>
                             <?php endif; ?>
                             <td><?=$date->format('d.m.Y H:i', true) ?></td>
                             <td><?=$this->escape($shoutbox->getTextarea()) ?></td>
@@ -49,6 +56,7 @@ $userMapper = $this->get('userMapper');
         </div>
         <?=$this->getListBar(['delete' => 'delete']) ?>
     </form>
+    <?=$pagination->getHtml($this, ['action' => 'index']) ?>
 <?php else : ?>
-    <?=$this->getTrans('noEntrys') ?>
+    <?=$this->getTrans('noEntries') ?>
 <?php endif; ?>

--- a/application/modules/shoutbox/views/admin/settings/index.php
+++ b/application/modules/shoutbox/views/admin/settings/index.php
@@ -5,17 +5,30 @@
 <h1><?=$this->getTrans('settings') ?></h1>
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
-    <div class="row mb-3<?=$this->validation()->hasError('limit') ? ' has-error' : '' ?>">
-        <label for="limit" class="col-xl-2 col-form-label">
-            <?=$this->getTrans('numberOfMessagesDisplayed') ?>
+    <div class="row mb-3<?=$this->validation()->hasError('messagesPerPageAdmincenter') ? ' has-error' : '' ?>">
+        <label for="messagesPerPageAdmincenter" class="col-xl-2 col-form-label">
+            <?=$this->getTrans('messagesPerPageAdmincenter') ?>
         </label>
         <div class="col-xl-1">
             <input type="number"
                    class="form-control"
-                   id="limit"
-                   name="limit"
+                   id="messagesPerPageAdmincenter"
+                   name="messagesPerPageAdmincenter"
                    min="1"
-                   value="<?=$this->originalInput('limit', $this->get('limit')) ?>">
+                   value="<?=$this->originalInput('messagesPerPageAdmincenter', $this->get('messagesPerPageAdmincenter')) ?>">
+        </div>
+    </div>
+    <div class="row mb-3<?=$this->validation()->hasError('messagesPerPage') ? ' has-error' : '' ?>">
+        <label for="messagesPerPage" class="col-xl-2 col-form-label">
+            <?=$this->getTrans('messagesPerPage') ?>
+        </label>
+        <div class="col-xl-1">
+            <input type="number"
+                   class="form-control"
+                   id="messagesPerPage"
+                   name="messagesPerPage"
+                   min="1"
+                   value="<?=$this->originalInput('messagesPerPage', $this->get('messagesPerPage')) ?>">
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('maxtextlength') ? ' has-error' : '' ?>">
@@ -57,6 +70,20 @@
                     </option>
                 <?php endforeach; ?>
             </select>
+        </div>
+    </div>
+    <h1><?=$this->getTrans('boxSettings') ?></h1>
+    <div class="row mb-3<?=$this->validation()->hasError('limit') ? ' has-error' : '' ?>">
+        <label for="limit" class="col-xl-2 col-form-label">
+            <?=$this->getTrans('numberOfMessagesDisplayed') ?>
+        </label>
+        <div class="col-xl-1">
+            <input type="number"
+                   class="form-control"
+                   id="limit"
+                   name="limit"
+                   min="1"
+                   value="<?=$this->originalInput('limit', $this->get('limit')) ?>">
         </div>
     </div>
     <?=$this->getSaveBar() ?>

--- a/application/modules/shoutbox/views/admin/settings/index.php
+++ b/application/modules/shoutbox/views/admin/settings/index.php
@@ -58,7 +58,8 @@
                 /** @var \Modules\User\Models\Group $groupList */
                 foreach ($this->get('userGroupList') as $groupList) : ?>
                     <option value="<?=$groupList->getId() ?>"
-                        <?php $writeAccess = explode(',', $this->originalInput('writeAccess', $this->get('writeAccess')));
+                        <?php $writeAccess = $this->originalInput('writeAccess', $this->get('writeAccess')) ?>
+                        <?php $writeAccess = is_array($writeAccess) ? $writeAccess : explode(',', $writeAccess);
                         foreach ($writeAccess as $access) {
                             if ($groupList->getId() == $access) {
                                 echo 'selected="selected"';

--- a/application/modules/shoutbox/views/index/index.php
+++ b/application/modules/shoutbox/views/index/index.php
@@ -2,7 +2,14 @@
 
 /** @var \Ilch\View $this */
 
-$userMapper = new \Modules\User\Mappers\User();
+/** @var string[] $userNames */
+$userNames = $this->get('userNames');
+
+/** @var string $dummyUserName */
+$dummyUserName = $this->get('dummyUserName');
+
+/** @var \Ilch\Pagination $pagination */
+$pagination = $this->get('pagination');
 ?>
 <h1><?=$this->getTrans('menuShoutbox') ?></h1>
 <?php if ($this->get('shoutbox')) : ?>
@@ -17,9 +24,9 @@ $userMapper = new \Modules\User\Mappers\User();
                         <b><?=$this->escape($shoutbox->getName()) ?>:</b> <span class="small"><?=$date->format('d.m.Y H:i', true) ?></span>
                     </td>
                 <?php else : ?>
-                    <?php $user = $userMapper->getUserById($shoutbox->getUid()) ?>
+                    <?php $userName = $userNames[$shoutbox->getUid()] ?? $dummyUserName ?>
                     <td>
-                        <b><a href="<?=$this->getUrl('user/profil/index/user/' . $user->getId()) ?>"><?=$this->escape($user ? $user->getName() : $userMapper->getDummyUser()->getName()) ?></a></b>: <span class="small"><?=$date->format('d.m.Y H:i', true) ?></span>
+                        <a href="<?=$this->getUrl('user/profil/index/user/' . $shoutbox->getUid()) ?>"><b><?=$this->escape($userName) ?></b></a>: <span class="small"><?=$date->format('d.m.Y H:i', true) ?></span>
                     </td>
                 <?php endif; ?>
             </tr>
@@ -28,6 +35,7 @@ $userMapper = new \Modules\User\Mappers\User();
             </tr>
         <?php endforeach; ?>
     </table>
+    <?=$pagination->getHtml($this, ['action' => 'index']) ?>
 <?php else : ?>
-    <?=$this->getTrans('noEntrys') ?>
+    <?=$this->getTrans('noEntries') ?>
 <?php endif; ?>


### PR DESCRIPTION
# Description
- Add pagination to the view in admincenter and frontend.
- Cache the displayed usernames instead of getting them for every user multiple times.
- Fix error when the user no longer exists.
- Add settings for the number of messages per page for the admincenter and the normal page.
- Fix error with the write access settings when another setting was invalid.

https://www.ilch.de/forum-showposts-58906.html

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
