### PR TITLE
Add a PHP_CodeSniffer GitHub workflow

### DIFF
--- a/.github/workflows/phpcs.yaml
+++ b/.github/workflows/phpcs.yaml
@@ -1,0 +1,44 @@
+name: PHPCS (changed files)
+
+on:
+  pull_request:
+    paths:
+      - '**.php'
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code (fetch all history)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP and PHP_CodeSniffer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: phpcs
+
+      - name: Determine changed PHP files
+        id: changed
+        run: |
+          # ensure base/head refs exist for diff
+          git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} || true
+          git fetch origin ${{ github.event.pull_request.head.ref }}:refs/remotes/origin/${{ github.event.pull_request.head.ref }} || true
+
+          # list added/modified PHP files between base..head (ignore deletions)
+          FILES=$(git diff --name-only --diff-filter=AM origin/${{ github.event.pull_request.base.ref }}..origin/${{ github.event.pull_request.head.ref }} -- '*.php' || true)
+
+          if [ -z "$FILES" ]; then
+            echo "files=" >> $GITHUB_OUTPUT
+          else
+            echo "files=$(echo $FILES | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run PHPCS on changed files
+        if: steps.changed.outputs.files != ''
+        run: |
+          echo "Running PHPCS on: ${{ steps.changed.outputs.files }}"
+          # Choose the standard you prefer (PSR12 shown here)
+          phpcs -p --extensions=php ${{ steps.changed.outputs.files }}

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@ header('Content-Type: text/html; charset=utf-8');
 $serverTimeZone = @date_default_timezone_get();
 date_default_timezone_set('UTC');
 
-define('VERSION', '2.2.16');
+define('VERSION', '2.2.17');
 define('SERVER_TIMEZONE', $serverTimeZone);
 define('DEFAULT_MODULE', 'page');
 define('DEFAULT_LAYOUT', 'index');

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,7 @@
 
     <exclude-pattern>./modules/layouts/</exclude-pattern>
     <exclude-pattern>./modules/**/views/*.php</exclude-pattern>
+    <exclude-pattern>./modules/shop/static/class/fpdf</exclude-pattern>
 
     <exclude-pattern>./application/libraries/Captcha</exclude-pattern>
     <exclude-pattern>./application/libraries/Thumb</exclude-pattern>


### PR DESCRIPTION
# Description
- Add a PHP_CodeSniffer GitHub workflow.
- Exclude FPDF as it would contribute 11721 errors.

I think this can be added without bringing the entire development to an halt as we are dealing with ~90 errors for all files and folders in the application folder.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] AI-assisted

If AI-assisted, briefly state:
- Tools used (e.g., GitHub Copilot, ChatGPT, Claude): GPT-5-mini
- What was generated by the tool (code, tests, docs, commit message, etc.): Used it to change the phpcompat workflow for phpcs
- Extent of AI use (single snippet, file, entire feature — approximate %): 80%, changed to use phpcs from shivammathur/setup-php
- Verification steps performed (tests, manual review, security checks): manual review
- License/IP check performed for AI outputs (yes/no + short note): Yes. Looks good.