### PR TITLE
Feature/debug mode config toggle

### DIFF
--- a/application/libraries/Ilch/Config/File.php
+++ b/application/libraries/Ilch/Config/File.php
@@ -57,7 +57,9 @@ class File
     /**
      * Saves the whole config in a file.
      *
-     * @param string $fileName
+     * @param  string $fileName
+     * @return bool   true on success, false if the file could not be written
+     *                (e.g. missing write permissions on the config file).
      */
     public function saveConfigToFile($fileName)
     {
@@ -66,6 +68,7 @@ class File
         $fileString .= '$config = ' . var_export_short_syntax($this->configData) . ';';
         $fileString .= "\n";
         $fileString .= '';
-        file_put_contents($fileName, $fileString);
+
+        return file_put_contents($fileName, $fileString) !== false;
     }
 }

--- a/application/libraries/Ilch/Page.php
+++ b/application/libraries/Ilch/Page.php
@@ -94,11 +94,8 @@ class Page
 
         if (($this->fileConfig->get('dbUser')) !== null) {
             // Cms is installed
-            if ($this->fileConfig->get('debugModus') === false) {
-                @ini_set('display_errors', 'off');
-                error_reporting(0);
-            }
-
+            // Note: debug mode (error display + DebugBar) is determined centrally in index.php
+            // from the "debugModus" config key, so no error_reporting handling is needed here.
             $dbFactory = new Database\Factory();
             $db = $dbFactory->getInstanceByConfig($this->fileConfig);
             $databaseConfig = new Config\Database($db);

--- a/application/libraries/Ilch/Page.php
+++ b/application/libraries/Ilch/Page.php
@@ -94,7 +94,7 @@ class Page
 
         if (($this->fileConfig->get('dbUser')) !== null) {
             // Cms is installed
-            // Note: debug mode (error display + DebugBar) is determined centrally in index.php
+            // Note: debug mode (PHP error display) is determined centrally in index.php
             // from the "debugModus" config key, so no error_reporting handling is needed here.
             $dbFactory = new Database\Factory();
             $db = $dbFactory->getInstanceByConfig($this->fileConfig);

--- a/application/modules/admin/controllers/admin/Settings.php
+++ b/application/modules/admin/controllers/admin/Settings.php
@@ -117,7 +117,8 @@ class Settings extends \Ilch\Controller\Admin
                 'hmenuFixed' => 'required|numeric|integer|min:0|max:1',
                 'htmlPurifier' => 'required|numeric|integer|min:0|max:1',
                 'updateserver' => 'required|url',
-                'captcha' => 'required|numeric|integer|min:0|max:3'
+                'captcha' => 'required|numeric|integer|min:0|max:3',
+                'debugModus' => 'required|numeric|integer|min:0|max:1'
             ];
 
             if ((int)$this->getRequest()->getPost('captcha') >= 1) {
@@ -147,6 +148,9 @@ class Settings extends \Ilch\Controller\Admin
                 }
                 $this->getConfig()->set('disable_purifier', !$this->getRequest()->getPost('htmlPurifier'));
                 $this->getConfig()->set('updateserver', $this->getRequest()->getPost('updateserver'));
+                // debugModus lives in the file config (application/config.php), because index.php
+                // reads it before the database is available.
+                $this->setDebugModus((bool) $this->getRequest()->getPost('debugModus'));
 
                 $this->addMessage('saveSuccess');
             } else {
@@ -179,6 +183,33 @@ class Settings extends \Ilch\Controller\Admin
         $this->getView()->set('groupList', $groupMapper->getGroupList());
         $this->getView()->set('updateserver', $this->getConfig()->get('updateserver'));
         $this->getView()->set('updateservers', $updateserversMapper->getUpdateservers());
+        $this->getView()->set('debugModus', $this->getDebugModus());
+    }
+
+    /**
+     * Reads the debugModus flag from the file config (application/config.php).
+     *
+     * @return bool
+     */
+    private function getDebugModus(): bool
+    {
+        $fileConfig = new \Ilch\Config\File();
+        $fileConfig->loadConfigFromFile(CONFIG_PATH . '/config.php');
+
+        return (bool) $fileConfig->get('debugModus');
+    }
+
+    /**
+     * Writes the debugModus flag to the file config, keeping all other entries intact.
+     *
+     * @param bool $debugModus
+     */
+    private function setDebugModus(bool $debugModus): void
+    {
+        $fileConfig = new \Ilch\Config\File();
+        $fileConfig->loadConfigFromFile(CONFIG_PATH . '/config.php');
+        $fileConfig->set('debugModus', $debugModus);
+        $fileConfig->saveConfigToFile(CONFIG_PATH . '/config.php');
     }
 
     public function maintenanceAction()

--- a/application/modules/admin/controllers/admin/Settings.php
+++ b/application/modules/admin/controllers/admin/Settings.php
@@ -150,13 +150,13 @@ class Settings extends \Ilch\Controller\Admin
                 $this->getConfig()->set('updateserver', $this->getRequest()->getPost('updateserver'));
                 // debugModus lives in the file config (application/config.php), because index.php
                 // reads it before the database is available.
-                if (!$this->setDebugModus((bool) $this->getRequest()->getPost('debugModus'))) {
+                if ($this->setDebugModus((bool) $this->getRequest()->getPost('debugModus'))) {
+                    $this->addMessage('saveSuccess');
+                } else {
                     // The file config could not be written (e.g. missing write permissions),
                     // so the toggle would silently have no effect without this warning.
                     $this->addMessage('debugModusSaveError', 'danger');
                 }
-
-                $this->addMessage('saveSuccess');
             } else {
                 $this->addMessage($validation->getErrorBag()->getErrorMessages(), 'danger', true);
             }

--- a/application/modules/admin/controllers/admin/Settings.php
+++ b/application/modules/admin/controllers/admin/Settings.php
@@ -150,7 +150,11 @@ class Settings extends \Ilch\Controller\Admin
                 $this->getConfig()->set('updateserver', $this->getRequest()->getPost('updateserver'));
                 // debugModus lives in the file config (application/config.php), because index.php
                 // reads it before the database is available.
-                $this->setDebugModus((bool) $this->getRequest()->getPost('debugModus'));
+                if (!$this->setDebugModus((bool) $this->getRequest()->getPost('debugModus'))) {
+                    // The file config could not be written (e.g. missing write permissions),
+                    // so the toggle would silently have no effect without this warning.
+                    $this->addMessage('debugModusSaveError', 'danger');
+                }
 
                 $this->addMessage('saveSuccess');
             } else {
@@ -202,14 +206,16 @@ class Settings extends \Ilch\Controller\Admin
     /**
      * Writes the debugModus flag to the file config, keeping all other entries intact.
      *
-     * @param bool $debugModus
+     * @param  bool $debugModus
+     * @return bool true on success, false if the config file could not be written.
      */
-    private function setDebugModus(bool $debugModus): void
+    private function setDebugModus(bool $debugModus): bool
     {
         $fileConfig = new \Ilch\Config\File();
         $fileConfig->loadConfigFromFile(CONFIG_PATH . '/config.php');
         $fileConfig->set('debugModus', $debugModus);
-        $fileConfig->saveConfigToFile(CONFIG_PATH . '/config.php');
+
+        return $fileConfig->saveConfigToFile(CONFIG_PATH . '/config.php');
     }
 
     public function maintenanceAction()

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -167,6 +167,8 @@ return [
     'menuLayout' => 'Layout',
     'menuLayouts' => 'Layouts',
     'menuSettings' => 'Einstellungen',
+    'debugModus' => 'Debug-Modus',
+    'debugModusInfo' => 'Zeigt PHP-Fehler und die Debug-Leiste an. Nur für die Entwicklung aktivieren, im Live-Betrieb ausschalten.',
     'menuMaintenance' => 'Wartungsarbeiten',
     'menuBackup' => 'Datenbank-Backup',
     'createBackupInfoText' => '<p>"CREATE DATABASE-Befehl hinzufügen" möchte man aktiviert haben, wenn beim Import die Datenbank mit gleicher Bezeichnung erstellt werden soll.

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -168,7 +168,7 @@ return [
     'menuLayouts' => 'Layouts',
     'menuSettings' => 'Einstellungen',
     'debugModus' => 'Debug-Modus',
-    'debugModusInfo' => 'Zeigt PHP-Fehler und die Debug-Leiste an. Nur für die Entwicklung aktivieren, im Live-Betrieb ausschalten.',
+    'debugModusInfo' => 'Zeigt PHP-Fehlermeldungen an. Nur für die Entwicklung aktivieren, im Live-Betrieb ausschalten.',
     'debugModusSaveError' => 'Der Debug-Modus konnte nicht gespeichert werden. Bitte die Schreibrechte der Datei application/config.php prüfen.',
     'menuMaintenance' => 'Wartungsarbeiten',
     'menuBackup' => 'Datenbank-Backup',

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -168,7 +168,7 @@ return [
     'menuLayouts' => 'Layouts',
     'menuSettings' => 'Einstellungen',
     'debugModus' => 'Debug-Modus',
-    'debugModusInfo' => 'Zeigt PHP-Fehlermeldungen an. Nur für die Entwicklung aktivieren, im Live-Betrieb ausschalten.',
+    'debugModusInfo' => 'Zeigt PHP-Fehlermeldungen an. Nur für die Fehlerdiagnose aktivieren, im Live-Betrieb ausschalten.',
     'debugModusSaveError' => 'Der Debug-Modus konnte nicht gespeichert werden. Bitte die Schreibrechte der Datei application/config.php prüfen.',
     'menuMaintenance' => 'Wartungsarbeiten',
     'menuBackup' => 'Datenbank-Backup',

--- a/application/modules/admin/translations/de.php
+++ b/application/modules/admin/translations/de.php
@@ -169,6 +169,7 @@ return [
     'menuSettings' => 'Einstellungen',
     'debugModus' => 'Debug-Modus',
     'debugModusInfo' => 'Zeigt PHP-Fehler und die Debug-Leiste an. Nur für die Entwicklung aktivieren, im Live-Betrieb ausschalten.',
+    'debugModusSaveError' => 'Der Debug-Modus konnte nicht gespeichert werden. Bitte die Schreibrechte der Datei application/config.php prüfen.',
     'menuMaintenance' => 'Wartungsarbeiten',
     'menuBackup' => 'Datenbank-Backup',
     'createBackupInfoText' => '<p>"CREATE DATABASE-Befehl hinzufügen" möchte man aktiviert haben, wenn beim Import die Datenbank mit gleicher Bezeichnung erstellt werden soll.

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -168,7 +168,7 @@ return [
     'menuLayouts' => 'Layouts',
     'menuSettings' => 'Settings',
     'debugModus' => 'Debug mode',
-    'debugModusInfo' => 'Shows PHP errors and the debug bar. Enable only for development, turn it off on live sites.',
+    'debugModusInfo' => 'Shows PHP error messages. Enable only for development, turn it off on live sites.',
     'debugModusSaveError' => 'The debug mode could not be saved. Please check the write permissions of the file application/config.php.',
     'menuMaintenance' => 'Maintenance',
     'menuBackup' => 'Database backup',

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -167,6 +167,8 @@ return [
     'menuLayout' => 'Layout',
     'menuLayouts' => 'Layouts',
     'menuSettings' => 'Settings',
+    'debugModus' => 'Debug mode',
+    'debugModusInfo' => 'Shows PHP errors and the debug bar. Enable only for development, turn it off on live sites.',
     'menuMaintenance' => 'Maintenance',
     'menuBackup' => 'Database backup',
     'createBackupInfoText' => '<p>Enable "Add CREATE DATABASE statement" to create the database with the previous name on import.

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -169,6 +169,7 @@ return [
     'menuSettings' => 'Settings',
     'debugModus' => 'Debug mode',
     'debugModusInfo' => 'Shows PHP errors and the debug bar. Enable only for development, turn it off on live sites.',
+    'debugModusSaveError' => 'The debug mode could not be saved. Please check the write permissions of the file application/config.php.',
     'menuMaintenance' => 'Maintenance',
     'menuBackup' => 'Database backup',
     'createBackupInfoText' => '<p>Enable "Add CREATE DATABASE statement" to create the database with the previous name on import.

--- a/application/modules/admin/translations/en.php
+++ b/application/modules/admin/translations/en.php
@@ -168,7 +168,7 @@ return [
     'menuLayouts' => 'Layouts',
     'menuSettings' => 'Settings',
     'debugModus' => 'Debug mode',
-    'debugModusInfo' => 'Shows PHP error messages. Enable only for development, turn it off on live sites.',
+    'debugModusInfo' => 'Shows PHP error messages. Enable only for debugging, turn it off on live sites.',
     'debugModusSaveError' => 'The debug mode could not be saved. Please check the write permissions of the file application/config.php.',
     'menuMaintenance' => 'Maintenance',
     'menuBackup' => 'Database backup',

--- a/application/modules/admin/views/admin/settings/index.php
+++ b/application/modules/admin/views/admin/settings/index.php
@@ -300,7 +300,7 @@
                 <label for="debugModus-off" class="flipswitch-label flipswitch-label-off"><?= $this->getTrans('off') ?></label>
                 <span class="flipswitch-selection"></span>
             </div>
-            <small class="form-text text-muted"><?= $this->getTrans('debugModusInfo') ?></small>
+            <div class="form-text" style="clear: both;"><?= $this->getTrans('debugModusInfo') ?></div>
         </div>
     </div>
 

--- a/application/modules/admin/views/admin/settings/index.php
+++ b/application/modules/admin/views/admin/settings/index.php
@@ -170,6 +170,21 @@
                    value="<?= $this->escape($this->get('defaultPaginationObjects')) ?>" />
         </div>
     </div>
+    <div id="debugModus" class="row mb-3">
+        <div class="col-xl-2 col-form-label">
+            <?= $this->getTrans('debugModus') ?>:
+        </div>
+        <div class="col-xl-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="debugModus-on" name="debugModus" value="1" <?= $this->get('debugModus') ? 'checked="checked"' : '' ?> />
+                <label for="debugModus-on" class="flipswitch-label flipswitch-label-on"><?= $this->getTrans('on') ?></label>
+                <input type="radio" class="flipswitch-input" id="debugModus-off" name="debugModus" value="0" <?= !$this->get('debugModus') ? 'checked="checked"' : '' ?> />
+                <label for="debugModus-off" class="flipswitch-label flipswitch-label-off"><?= $this->getTrans('off') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+            <div class="form-text" style="clear: both;"><?= $this->getTrans('debugModusInfo') ?></div>
+        </div>
+    </div>
 
     <h1><?= $this->getTrans('captcha') ?></h1>
     <div class="row mb-3">
@@ -286,21 +301,6 @@
                 <label for="hmenuFixed-off" class="flipswitch-label flipswitch-label-off"><?= $this->getTrans('off') ?></label>
                 <span class="flipswitch-selection"></span>
             </div>
-        </div>
-    </div>
-    <div id="debugModus" class="row mb-3">
-        <div class="col-xl-2 col-form-label">
-            <?= $this->getTrans('debugModus') ?>:
-        </div>
-        <div class="col-xl-4">
-            <div class="flipswitch">
-                <input type="radio" class="flipswitch-input" id="debugModus-on" name="debugModus" value="1" <?= $this->get('debugModus') ? 'checked="checked"' : '' ?> />
-                <label for="debugModus-on" class="flipswitch-label flipswitch-label-on"><?= $this->getTrans('on') ?></label>
-                <input type="radio" class="flipswitch-input" id="debugModus-off" name="debugModus" value="0" <?= !$this->get('debugModus') ? 'checked="checked"' : '' ?> />
-                <label for="debugModus-off" class="flipswitch-label flipswitch-label-off"><?= $this->getTrans('off') ?></label>
-                <span class="flipswitch-selection"></span>
-            </div>
-            <div class="form-text" style="clear: both;"><?= $this->getTrans('debugModusInfo') ?></div>
         </div>
     </div>
 

--- a/application/modules/admin/views/admin/settings/index.php
+++ b/application/modules/admin/views/admin/settings/index.php
@@ -288,6 +288,21 @@
             </div>
         </div>
     </div>
+    <div id="debugModus" class="row mb-3">
+        <div class="col-xl-2 col-form-label">
+            <?= $this->getTrans('debugModus') ?>:
+        </div>
+        <div class="col-xl-4">
+            <div class="flipswitch">
+                <input type="radio" class="flipswitch-input" id="debugModus-on" name="debugModus" value="1" <?= $this->get('debugModus') ? 'checked="checked"' : '' ?> />
+                <label for="debugModus-on" class="flipswitch-label flipswitch-label-on"><?= $this->getTrans('on') ?></label>
+                <input type="radio" class="flipswitch-input" id="debugModus-off" name="debugModus" value="0" <?= !$this->get('debugModus') ? 'checked="checked"' : '' ?> />
+                <label for="debugModus-off" class="flipswitch-label flipswitch-label-off"><?= $this->getTrans('off') ?></label>
+                <span class="flipswitch-selection"></span>
+            </div>
+            <small class="form-text text-muted"><?= $this->getTrans('debugModusInfo') ?></small>
+        </div>
+    </div>
 
     <h1><?= $this->getTrans('updateserver') ?></h1>
     <div class="table-responsive">

--- a/application/modules/admin/views/admin/settings/index.php
+++ b/application/modules/admin/views/admin/settings/index.php
@@ -182,7 +182,7 @@
                 <label for="debugModus-off" class="flipswitch-label flipswitch-label-off"><?= $this->getTrans('off') ?></label>
                 <span class="flipswitch-selection"></span>
             </div>
-            <div class="form-text" style="clear: both;"><?= $this->getTrans('debugModusInfo') ?></div>
+            <div class="form-text"><?= $this->getTrans('debugModusInfo') ?></div>
         </div>
     </div>
 

--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -414,7 +414,7 @@ class Index extends \Ilch\Controller\Frontend
                 $fileConfig->set('dbPassword', $_SESSION['install']['dbPassword']);
                 $fileConfig->set('dbName', $_SESSION['install']['dbName']);
                 $fileConfig->set('dbPrefix', $_SESSION['install']['dbPrefix']);
-                // Default to off so a fresh production install does not expose errors or the DebugBar.
+                // Default to off so a fresh production install does not expose PHP error messages.
                 // Can be toggled afterwards in the admin settings.
                 $fileConfig->set('debugModus', false);
                 $fileConfig->saveConfigToFile(CONFIG_PATH . '/config.php');

--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -414,6 +414,9 @@ class Index extends \Ilch\Controller\Frontend
                 $fileConfig->set('dbPassword', $_SESSION['install']['dbPassword']);
                 $fileConfig->set('dbName', $_SESSION['install']['dbName']);
                 $fileConfig->set('dbPrefix', $_SESSION['install']['dbPrefix']);
+                // Default to off so a fresh production install does not expose errors or the DebugBar.
+                // Can be toggled afterwards in the admin settings.
+                $fileConfig->set('debugModus', false);
                 $fileConfig->saveConfigToFile(CONFIG_PATH . '/config.php');
 
                 // Initialize install database.

--- a/index.php
+++ b/index.php
@@ -11,8 +11,8 @@ if (!version_compare(PHP_VERSION, PHPVERSION, '>=')) {
 }
 
 // Determine debug mode from the file config (application/config.php).
-// This single setting controls both the PHP error display and the DebugBar.
-// Defaults to off when the key is absent, so production stays quiet by default.
+// This setting controls the PHP error display (and, only in the developer version of Ilch,
+// the DebugBar). Defaults to off when the key is absent, so production stays quiet by default.
 $debugMode = false;
 $configFile = __DIR__ . '/application/config.php';
 if (file_exists($configFile)) {

--- a/index.php
+++ b/index.php
@@ -10,8 +10,26 @@ if (!version_compare(PHP_VERSION, PHPVERSION, '>=')) {
     die('Ilch CMS 2 needs at least php version ' . PHPVERSION);
 }
 
-@ini_set('display_errors', 'on');
-error_reporting(E_ALL);
+// Determine debug mode from the file config (application/config.php).
+// This single setting controls both the PHP error display and the DebugBar.
+// Defaults to off when the key is absent, so production stays quiet by default.
+$debugMode = false;
+$configFile = __DIR__ . '/application/config.php';
+if (file_exists($configFile)) {
+    require $configFile;
+    if (!empty($config['debugModus'])) {
+        $debugMode = (bool) $config['debugModus'];
+    }
+    unset($config);
+}
+
+if ($debugMode) {
+    @ini_set('display_errors', 'on');
+    error_reporting(E_ALL);
+} else {
+    @ini_set('display_errors', 'off');
+    error_reporting(0);
+}
 
 $isHttps = $_SERVER['HTTPS'] ?? $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? null;
 $isHttps = $isHttps && (strcasecmp('on', $isHttps) == 0 || strcasecmp('https', $isHttps) == 0);
@@ -35,7 +53,7 @@ define('VERSION', '2.2.17');
 define('SERVER_TIMEZONE', $serverTimeZone);
 define('DEFAULT_MODULE', 'page');
 define('DEFAULT_LAYOUT', 'index');
-define('DEBUG_MODE', true);
+define('DEBUG_MODE', $debugMode);
 
 // Path could not be under root.
 define('ROOT_PATH', __DIR__);


### PR DESCRIPTION
# Description

Bisher war der Debug-Modus fest verdrahtet: In `index.php` stand `define('DEBUG_MODE', true)`, sodass die DebugBar **immer** lief, und `display_errors` wurde nur dann abgeschaltet, wenn `debugModus` in der Config **explizit** auf `false` stand. Standardmäßig (Key nicht gesetzt) gab eine Installation also PHP-Fehler und die Debug-Leiste auch im Live-Betrieb preis — ein Informationsleck.

Dieser PR koppelt sowohl die PHP-Fehleranzeige als auch die DebugBar an einen einzigen `debugModus`-Schlüssel in der Datei-Config (`application/config.php`), der früh in `index.php` gelesen wird:

- `index.php` liest `debugModus` vor dem Definieren von `DEBUG_MODE` und setzt `display_errors`/`error_reporting` daraus. **Standard ist aus**, wenn der Key fehlt.
- Der nun redundante Fehler-Schalter wird aus `Page::loadCms()` entfernt.
- Die Admin-Einstellungen erhalten einen Debug-Modus-Schalter (schreibt in die Datei-Config, nicht in die DB, da `index.php` den Wert vor dem DB-Zugriff braucht).
- Der Installer schreibt `debugModus => false` in eine frische `config.php`.
- de/en-Übersetzungen für die neue Einstellung.

Zusätzlich wird ein stilles Fehlerverhalten beim Speichern der Datei-Config behoben: `Ilch\Config\File::saveConfigToFile()` gibt jetzt `bool` zurück (Ergebnis von `file_put_contents`), statt einen fehlgeschlagenen Schreibvorgang zu verschlucken. Der neue Debug-Schalter nutzt das — konnte `application/config.php` nicht geschrieben werden (z. B. fehlende Schreibrechte), erscheint die Meldung `debugModusSaveError`, statt fälschlich Erfolg zu melden. Der Installer bleibt abwärtskompatibel (ignoriert den Rückgabewert weiterhin).

Fixes:
- Der Hinweistext unter dem Schalter wird sauber unter dem Flipswitch ausgerichtet (<div class="form-text"> mit clear: both

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## AI usage disclosure

- [ ] No AI assistance used
- [x] AI-assisted

If AI-assisted, briefly state:
- Tools used ( Claude): **Claude (Claude Code)**
- What was generated by the tool (code, tests, docs, commit message, etc.): **Analyse des Codes, Prüfung/Review der Änderungen, Commit-Messages und diese PR-Beschreibung**
- Extent of AI use (single snippet, file, entire feature — approximate %): **KI-gestützte Analyse und Review; Commit-Messages und PR-Beschreibung KI-generiert. Inhaltliche Verantwortung und finale Kontrolle liegen beim Contributor.**
- Verification steps performed (tests, manual review, security checks): **manuelles Code-Review; `php -l` auf den geänderten Dateien (keine Syntaxfehler); Debug-Modus-Schalter lokal getestet (an/aus, Fehleranzeige + DebugBar)**
- License/IP check performed for AI outputs (yes/no + short note): **yes — nur projektinterne Muster (vorhandene Config-/Settings-Mechanik), keine externen Code-Übernahmen**

# This PR has been tested in the following browsers:
- [x ] Chrome
- [x ] Firefox
- [ ] Opera
- [ ] Edge
