### PR TITLE
Fix von PHP_CodeSniffer gemeldete Fehler (#1418)

### DIFF
--- a/application/modules/away/mappers/Away.php
+++ b/application/modules/away/mappers/Away.php
@@ -64,7 +64,7 @@ class Away extends \Ilch\Mapper
 
     public function existsTable($table): bool
     {
-        return $this->db()->ifTableExists('[prefix]_'.$table);
+        return $this->db()->ifTableExists('[prefix]_' . $table);
     }
 
     /**

--- a/application/modules/gallery/controllers/admin/Settings.php
+++ b/application/modules/gallery/controllers/admin/Settings.php
@@ -105,4 +105,3 @@ class Settings extends Admin
         }
     }
 }
-

--- a/application/modules/newsletter/boxes/Newsletter.php
+++ b/application/modules/newsletter/boxes/Newsletter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/config/config.php
+++ b/application/modules/newsletter/config/config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/controllers/Index.php
+++ b/application/modules/newsletter/controllers/Index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/controllers/admin/Index.php
+++ b/application/modules/newsletter/controllers/admin/Index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/controllers/admin/Receiver.php
+++ b/application/modules/newsletter/controllers/admin/Receiver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/mappers/Newsletter.php
+++ b/application/modules/newsletter/mappers/Newsletter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/mappers/Subscriber.php
+++ b/application/modules/newsletter/mappers/Subscriber.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/models/Newsletter.php
+++ b/application/modules/newsletter/models/Newsletter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/models/Subscriber.php
+++ b/application/modules/newsletter/models/Subscriber.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/translations/de.php
+++ b/application/modules/newsletter/translations/de.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/newsletter/translations/en.php
+++ b/application/modules/newsletter/translations/en.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Ilch 2
  * @package ilch

--- a/application/modules/shop/controllers/Index.php
+++ b/application/modules/shop/controllers/Index.php
@@ -539,7 +539,7 @@ class Index extends Frontend
             }
             $items = $itemsMapper->getShopItems(['items.id' => $itemVariantIds, 'items.status' => 1]);
 
-            foreach($propertyVariants as $propertyVariant) {
+            foreach ($propertyVariants as $propertyVariant) {
                 if (!isset($items[$propertyVariant->getItemVariantId()])) {
                     unset($propertyVariants[$propertyVariant->getId()]);
                 }
@@ -569,7 +569,7 @@ class Index extends Frontend
                     $variants[$propertyVariant->getItemVariantId()]['property'] ?? $variants[$propertyVariant->getItemVariantId()]['property'] = $properties[$propertyVariant->getPropertyId()]->getName();
                 }
 
-                foreach($propertyTranslations as $propertyTranslation) {
+                foreach ($propertyTranslations as $propertyTranslation) {
                     if ($propertyTranslation->getPropertyId() == $propertyVariant->getPropertyId()) {
                         $variants[$propertyVariant->getItemVariantId()]['property'] = $propertyTranslation->getText();
                         break;
@@ -584,7 +584,7 @@ class Index extends Frontend
                     $variants[$propertyVariant->getItemVariantId()]['value'] ?? $variants[$propertyVariant->getItemVariantId()]['value'] = $propertyValues[$propertyVariant->getValueId()]->getValue();
                 }
 
-                foreach($propertyValuesTranslations as $propertyValueTranslation) {
+                foreach ($propertyValuesTranslations as $propertyValueTranslation) {
                     if ($propertyValueTranslation->getValueId() == $propertyVariant->getValueId()) {
                         $variants[$propertyVariant->getItemVariantId()]['value'] = $propertyValueTranslation->getText();
                         break;

--- a/application/modules/shop/controllers/admin/Items.php
+++ b/application/modules/shop/controllers/admin/Items.php
@@ -197,14 +197,14 @@ class Items extends Admin
         // Get the translations for the properties.
         $propertiesTranslations = $propertiesIds ? $propertiesTranslationsMapper->getTranslationsByLocaleAndPropertyIds($this->getTranslator()->getLocale(), $propertiesIds) : [];
         $propertyTranslationAssoc = [];
-        foreach($propertiesTranslations as $propertyTranslation) {
+        foreach ($propertiesTranslations as $propertyTranslation) {
             $propertyTranslationAssoc[$propertyTranslation->getPropertyId()] = $propertyTranslation->getText();
         }
 
         // Get the translations for the values.
         $propertyValuesTranslations = $propertiesValues ? $propertyvaluestranslationsMapper->getTranslationsByLocaleAndValueIds($this->getTranslator()->getLocale(), array_keys($propertiesValues)) ?? [] : [];
         $propertyValueTranslationAssoc = [];
-        foreach($propertyValuesTranslations as $propertyValueTranslation) {
+        foreach ($propertyValuesTranslations as $propertyValueTranslation) {
             $propertyValueTranslationAssoc[$propertyValueTranslation->getValueId()] = $propertyValueTranslation->getText();
         }
 
@@ -266,7 +266,7 @@ class Items extends Admin
                     $usedValueIds[$propertyVariant->getValueId()] = $propertyVariant;
                 }
 
-                foreach($this->getRequest()->getPost('valueCheckbox') ?? [] as $propertyValue) {
+                foreach ($this->getRequest()->getPost('valueCheckbox') ?? [] as $propertyValue) {
                     if (!isset($usedValueIds[$propertyValue])) {
                         // Variant doesn't already exist. Save the variant as a new product.
                         // Set initial values suitable for a variant of a product.

--- a/application/modules/shop/controllers/admin/Properties.php
+++ b/application/modules/shop/controllers/admin/Properties.php
@@ -204,7 +204,7 @@ class Properties extends Admin
                 // Don't delete values that are currently in use.
                 $propertyValues = $propertyValueMapper->getValuesByPropertyId($propertyId) ?? [];
                 $valueInUse = false;
-                foreach($propertyValues as $propertyValue) {
+                foreach ($propertyValues as $propertyValue) {
                     if (in_array($propertyValue->getId(), $this->getRequest()->getPost('values-ids'))) {
                         continue;
                     }
@@ -234,7 +234,7 @@ class Properties extends Admin
 
                 // Get currently existing property value translations and delete no longer existing ones.
                 $propertyValuesTranslations = $propertyValues ? $propertyValuesTranslationsMapper->getTranslations(['value_id' => array_keys($propertyValues)]) ?? [] : [];
-                foreach($propertyValuesTranslations as $propertyValueTranslation) {
+                foreach ($propertyValuesTranslations as $propertyValueTranslation) {
                     if (in_array($propertyValueTranslation->getId(), $this->getRequest()->getPost('propertyValueTrans_id'))) {
                         continue;
                     }
@@ -242,7 +242,7 @@ class Properties extends Admin
                 }
 
                 // Save property value translations.
-                foreach($this->getRequest()->getPost('propertyValueTrans_id') ?? [] as $i => $value) {
+                foreach ($this->getRequest()->getPost('propertyValueTrans_id') ?? [] as $i => $value) {
                     if (!$this->getRequest()->getPost('propertyValueTrans_locale')[$i] || !$this->getRequest()->getPost('propertyValueTrans_text')[$i]) {
                         continue;
                     }

--- a/application/modules/shop/mappers/Items.php
+++ b/application/modules/shop/mappers/Items.php
@@ -118,7 +118,7 @@ class Items extends Mapper
      */
     public function getCountOfItemsPerCategory(array $catIds = [], int $status = 1): array
     {
-        if (empty($catIds)){
+        if (empty($catIds)) {
             return [];
         }
         $itemsArray = $this->db()->select(['cat_id', 'count' => 'COUNT(id)'])
@@ -127,7 +127,7 @@ class Items extends Mapper
             ->group(['cat_id'])
             ->execute()
             ->fetchRows();
-        
+
         return array_column($itemsArray, 'count', 'cat_id');
     }
 


### PR DESCRIPTION
 # Description

  Behebt die in #1418 dokumentierten PSR12-Verstöße, die von PHP_CodeSniffer
  gemeldet wurden. Es handelt sich ausschließlich um Code-Style-Korrekturen —
  keine Verhaltens- oder Logikänderung.

  Betroffene Module und Korrekturen:

  - **away** – `mappers/Away.php`: fehlende Leerzeichen um den Konkatenationsoperator (`.`)
  - **gallery** – `controllers/admin/Settings.php`: überzählige Leerzeile am Dateiende entfernt
  - **newsletter** (11 Dateien): fehlende Leerzeile zwischen den Header-Blöcken,
    d. h. Leerzeile nach dem öffnenden `<?php`-Tag
    (boxes/, config/, controllers/, controllers/admin/, mappers/, models/, translations/)
  - **shop** – Controller und Mapper: fehlendes Leerzeichen nach `foreach`,
    fehlendes Leerzeichen nach schließender Klammer sowie Trailing-Whitespace
    in `mappers/Items.php`

  Verifiziert mit `squizlabs/php_codesniffer:^4` gegen die `phpcs.xml` (PSR12):
  nach den Änderungen melden die vier Module 0 Verstöße.

  Fixes #1418

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

  ## AI usage disclosure

  - [ ] No AI assistance used
  - [x] AI-assisted

  If AI-assisted, briefly state:
  - Tools used (e.g., GitHub Copilot, ChatGPT, Claude): Claude (Claude Code)
  - What was generated by the tool (code, tests, docs, commit message, etc.):
    Anwenden der phpcbf-Autofixes bzw. manuelle Style-Korrekturen, Commit-Message und PR-Beschreibung
  - Extent of AI use (single snippet, file, entire feature — approximate %):
    reine PSR12-Style-Fixes über mehrere Dateien, keine Logikänderung (~100 % der Änderungszeilen, aber rein formatierend)
  - Verification steps performed (tests, manual review, security checks):
    phpcs-Lauf gegen phpcs.xml (0 Verstöße), `php -l` auf den geänderten Dateien, manuelle Diff-Durchsicht
  - License/IP check performed for AI outputs (yes/no + short note):
    yes – keine externen Code-Snippets übernommen, nur Formatierung bestehenden Repository-Codes

  # This PR has been tested in the following browsers:

  Nicht zutreffend – reine Code-Style-Änderung ohne Auswirkung auf das Laufzeitverhalten oder die Ausgabe.
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Opera
  - [ ] Edge