### PR TITLE
Admincenter: Improve module menu css

### DIFF
--- a/application/modules/admin/layouts/index.php
+++ b/application/modules/admin/layouts/index.php
@@ -125,7 +125,7 @@ $accesses = $this->get('accesses');
 <!-- HEADER -->
 <header id="header">
     <!-- TOP NAVBAR -->
-    <nav class="navbar navbar-expand-lg topnavbar navbar-light bg-light" style="padding:0px;">
+    <nav class="navbar navbar-expand-lg topnavbar navbar-light bg-light">
         <!-- TOP NAVBAR LEFT -->
         <div class="navbar-header leftbar">
             <?php if ($this->hasSidebar()) : ?>
@@ -171,9 +171,9 @@ $accesses = $this->get('accesses');
                     if ($user->hasAccess('module_' . $module->getKey()) || ($module->getKey() == 'article' && ($accesses && $accesses->hasAccess('Admin', null, $accesses::TYPE_ARTICLE)))) {
                         $content = $module->getContentForLocale($this->getTranslator()->getLocale());
                         if (strncmp($module->getIconSmall(), 'fa-', 3) === 0) {
-                            $smallIcon = '<i class="fa ' . $module->getIconSmall() . '" style="padding-right: 5px;"></i>';
+                            $smallIcon = '<i class="fa ' . $module->getIconSmall() . '"></i>';
                         } else {
-                            $smallIcon = '<img style="padding-right: 5px;" src="' . $this->getStaticUrl('../application/modules/' . $module->getKey() . '/config/' . $module->getIconSmall()) . '" />';
+                            $smallIcon = '<img src="' . $this->getStaticUrl('../application/modules/' . $module->getKey() . '/config/' . $module->getIconSmall()) . '" />';
                         }
 
                         if ($accesses && ($accesses->hasAccess('Admin_' . $module->getKey(), $module->getKey()))) {

--- a/application/modules/admin/static/css/admin.css
+++ b/application/modules/admin/static/css/admin.css
@@ -844,12 +844,15 @@ nav > ul > li:hover > ul::before, nav > ul > li:hover > ul > li::before {
 }
 
 #ilch_dropdown .list-group-horizontal .list-group-item {
-    display: inline-flex;
     background: none;
     margin-bottom: 0;
     margin-left: 0;
     margin-right: 0;
     border: none;
+}
+
+.list-group-item i, .list-group-item img {
+    margin-right: 5px;
 }
 
 #ilch_dropdown .list-group-item:hover, .list-group-item {


### PR DESCRIPTION
# Description
- Admincenter: Improve module menu css
- Removed inline css

Space between icon and text wasn't equal.
Text was lower than the icon.

Before
<img width="830" height="277" alt="before" src="https://github.com/user-attachments/assets/b8ac4978-cb50-45b1-8054-8dfeab919c9c" />

After
<img width="900" height="458" alt="after" src="https://github.com/user-attachments/assets/36397f14-8659-4d29-ad64-576a445d8c17" />

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
