### PR TITLE
DebugMode: Respect global settings and invalidate opcache

### DIFF
--- a/application/libraries/Ilch/Config/File.php
+++ b/application/libraries/Ilch/Config/File.php
@@ -41,9 +41,10 @@ class File
      *
      * @param string $fileName
      */
-    public function loadConfigFromFile($fileName)
+    public function loadConfigFromFile(string $fileName)
     {
         if (file_exists($fileName)) {
+            opcache_invalidate($fileName);
             require $fileName;
         }
 
@@ -57,11 +58,11 @@ class File
     /**
      * Saves the whole config in a file.
      *
-     * @param  string $fileName
+     * @param string $fileName
      * @return bool   true on success, false if the file could not be written
      *                (e.g. missing write permissions on the config file).
      */
-    public function saveConfigToFile($fileName)
+    public function saveConfigToFile(string $fileName): bool
     {
         $fileString = '<?php';
         $fileString .= "\n";

--- a/index.php
+++ b/index.php
@@ -26,9 +26,6 @@ if (file_exists($configFile)) {
 if ($debugMode) {
     @ini_set('display_errors', 'on');
     error_reporting(E_ALL);
-} else {
-    @ini_set('display_errors', 'off');
-    error_reporting(0);
 }
 
 $isHttps = $_SERVER['HTTPS'] ?? $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? null;


### PR DESCRIPTION
# Description
- Respect global settings when deactivating the debug mode in Ilch.
- Invalidate opcache in loadConfigFromFile.

Respect global settings when deactivating the debug mode in Ilch instead of setting error_reporting to 0. The server might be configured to log to file with E_ALL & ~E_DEPRECATED & ~E_STRICT.
Call opcache_invalidate in loadConfigFromFile before calling require to read the config file. Without this the change to the setting wasn't immediately visible.

Quote from php.ini of PHP 8.2:
```
; display_errors
;   Default Value: On
;   Development Value: On
;   Production Value: Off

; error_reporting
;   Default Value: E_ALL
;   Development Value: E_ALL
;   Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT

; log_errors
;   Default Value: Off
;   Development Value: On
;   Production Value: On
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
