### PR TITLE
Call invalidateOpcache instead of opcache_invalidate directly

### DIFF
--- a/application/libraries/Ilch/Config/File.php
+++ b/application/libraries/Ilch/Config/File.php
@@ -44,7 +44,7 @@ class File
     public function loadConfigFromFile(string $fileName)
     {
         if (file_exists($fileName)) {
-            opcache_invalidate($fileName);
+            invalidateOpcache($fileName);
             require $fileName;
         }
 


### PR DESCRIPTION
# Description
- Call invalidateOpcache instead of opcache_invalidate directly

opcache_invalidate might not be available to call or the host has restricted the ability to run the function.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

