### PR TITLE
Remove code no longer needed with PHP 8.1, update dependencies, workflows and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4', '8.5']
+        php-versions: ['8.1', '8.5']
         mysql-versions: ['5.7', 'latest']
 
     services:

--- a/.github/workflows/php-quality.yaml
+++ b/.github/workflows/php-quality.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP (composer + tools)
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           tools: composer,phpcs,phplint
 
       - name: Install Composer dependencies (including PHPCompatibility)
@@ -70,4 +70,4 @@ jobs:
         if: steps.changed.outputs.files != ''
         run: |
           echo "Running PHPCompatibility on: ${{ steps.changed.outputs.files }}"
-          vendor/bin/phpcs -p --standard=PHPCompatibility --runtime-set testVersion 7.4- --extensions=php ${{ steps.changed.outputs.files }}
+          vendor/bin/phpcs -p --standard=PHPCompatibility --runtime-set testVersion 8.1- --extensions=php ${{ steps.changed.outputs.files }}

--- a/application/libraries/Captcha/Captcha.php
+++ b/application/libraries/Captcha/Captcha.php
@@ -203,8 +203,8 @@ class Captcha
     protected function ImageAllocate()
     {
         // Cleanup
-        if (!empty($this->im)) {            
-            $this->deprecatedImageDestroy();
+        if (!empty($this->im)) {
+            unset($this->im);
         }
 
         $this->im = imagecreatetruecolor($this->width * $this->scale, $this->height * $this->scale);
@@ -421,7 +421,7 @@ class Captcha
             $this->width * $this->scale, $this->height * $this->scale
         );
 
-        $this->deprecatedImageDestroy();
+        unset($this->im);
 
         $this->im = $imResampled;
     }
@@ -445,18 +445,6 @@ class Captcha
      */
     protected function Cleanup()
     {
-        $this->deprecatedImageDestroy();
-    }
-
-    /**
-     * The call of this function (and this function) can be replaced by just unset() if we no longer need to support PHP 8.0 or older.
-     */
-    protected function deprecatedImageDestroy()
-    {
-        if (PHP_VERSION_ID >= 80000) {
-            unset($this->im);
-        } else {
-            imagedestroy($this->im);
-        }
+        unset($this->im);
     }
 }

--- a/application/libraries/Ilch/Functions.php
+++ b/application/libraries/Ilch/Functions.php
@@ -267,14 +267,7 @@ function url_get_contents(string $url, bool $write_cache = true, bool $ignoreCac
             CURLOPT_URL            => $url,
         ]);
         $output = curl_exec($ch);
-
-        // Can be replaced with just "unset($ch);" if we no longer need to support PHP 8.0 or older.
-        if (PHP_VERSION_ID >= 80000) {
-            unset($ch);
-        } else {
-            // phpcs:ignore
-            curl_close($ch);
-        }
+        unset($ch);
 
         // save the file if there's data
         if ($output && $write_cache) {

--- a/application/libraries/Ilch/Transfer.php
+++ b/application/libraries/Ilch/Transfer.php
@@ -627,13 +627,7 @@ class Transfer
     private function curlClose()
     {
         if (is_resource($this->transferUrl)) {
-            // Can be replaced with just "unset($this->transferUrl);" if we no longer need to support PHP 8.0 or older.
-            if (PHP_VERSION_ID >= 80000) {
-                unset($this->transferUrl);
-            } else {
-                // phpcs:ignore
-                curl_close($this->transferUrl);
-            }
+            unset($this->transferUrl);
         }
     }
 

--- a/application/libraries/Thumb/Thumbnail.php
+++ b/application/libraries/Thumb/Thumbnail.php
@@ -740,13 +740,13 @@ class Thumbnail
     public function __destruct()
     {
         if (is_resource($this->im)) {
-            $this->deprecatedImageDestroy($this->im);
+            unset($this->im);
         }
         if (is_resource($this->thumb)) {
-            $this->deprecatedImageDestroy($this->thumb);
+            unset($this->thumb);
         }
         if (is_resource($this->newimage)) {
-            $this->deprecatedImageDestroy($this->newimage);
+            unset($this->newimage);
         }
     }
 
@@ -1143,8 +1143,8 @@ class Thumbnail
         if ($this->Chmodlevel != '') {
             chmod($this->Thumblocation . $this->Thumbprefix . basename($this->image), octdec($this->Chmodlevel));
         }
-        $this->deprecatedImageDestroy($this->im);
-        $this->deprecatedImageDestroy($this->thumb);
+        unset($this->im);
+        unset($this->thumb);
     }
 
     /**
@@ -1167,8 +1167,8 @@ class Thumbnail
                 imagepng($this->thumb);
                 break;
         }
-        $this->deprecatedImageDestroy($this->im);
-        $this->deprecatedImageDestroy($this->thumb);
+        unset($this->im);
+        unset($this->thumb);
         exit;
     }
 
@@ -1188,7 +1188,7 @@ class Thumbnail
             $this->newimage = imagecreatefrompng($this->Watermarkpng);
             $wpos = explode(' ', str_replace('%', '', $this->Watermarkposition));
             imagecopymerge($this->im, $this->newimage, min(max(imagesx($this->im) * ($wpos[0] / 100) - 0.5 * imagesx($this->newimage), 0), imagesx($this->im) - imagesx($this->newimage)), min(max(imagesy($this->im) * ($wpos[1] / 100) - 0.5 * imagesy($this->newimage), 0), imagesy($this->im) - imagesy($this->newimage)), 0, 0, imagesx($this->newimage), imagesy($this->newimage), intval($this->Watermarktransparency));
-            $this->deprecatedImageDestroy($this->newimage);
+            unset($this->newimage);
         }
     }
 
@@ -1292,32 +1292,17 @@ class Thumbnail
             $random3 = 1;
             $random4 = 1;
         }
-        if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
-            if ($this->Clipcorner[3] && $random1) {
-                imagefilledpolygon($this->im, $points_tl, $bgcolor);
-            }
-            if ($this->Clipcorner[4] && $random2) {
-                imagefilledpolygon($this->im, $points_bl, $bgcolor);
-            }
-            if ($this->Clipcorner[5] && $random3) {
-                imagefilledpolygon($this->im, $points_tr, $bgcolor);
-            }
-            if ($this->Clipcorner[6] && $random4) {
-                imagefilledpolygon($this->im, $points_br, $bgcolor);
-            }
-        } else {
-            if ($this->Clipcorner[3] && $random1) {
-                imagefilledpolygon($this->im, $points_tl, count($points_tl) / 2, $bgcolor);
-            }
-            if ($this->Clipcorner[4] && $random2) {
-                imagefilledpolygon($this->im, $points_bl, count($points_bl) / 2, $bgcolor);
-            }
-            if ($this->Clipcorner[5] && $random3) {
-                imagefilledpolygon($this->im, $points_tr, count($points_tr) / 2, $bgcolor);
-            }
-            if ($this->Clipcorner[6] && $random4) {
-                imagefilledpolygon($this->im, $points_br, count($points_br) / 2, $bgcolor);
-            }
+        if ($this->Clipcorner[3] && $random1) {
+            imagefilledpolygon($this->im, $points_tl, $bgcolor);
+        }
+        if ($this->Clipcorner[4] && $random2) {
+            imagefilledpolygon($this->im, $points_bl, $bgcolor);
+        }
+        if ($this->Clipcorner[5] && $random3) {
+            imagefilledpolygon($this->im, $points_tr, $bgcolor);
+        }
+        if ($this->Clipcorner[6] && $random4) {
+            imagefilledpolygon($this->im, $points_br, $bgcolor);
         }
     }
 
@@ -1354,7 +1339,7 @@ class Thumbnail
         if (file_exists($this->Borderpng)) {
             $borderim = imagecreatefrompng($this->Borderpng);
             imagecopyresampled($this->thumb, $borderim, $this->bind_offset, 0, 0, 0, $this->thumbx - $this->shadow_offset - $this->bind_offset, $this->thumby - $this->shadow_offset, imagesx($borderim), imagesy($borderim));
-            $this->deprecatedImageDestroy($borderim);
+            unset($borderim);
         }
     }
 
@@ -1509,10 +1494,10 @@ class Thumbnail
                     }
                 }
             }
-            $this->deprecatedImageDestroy($this->im);
+            unset($this->im);
             $this->im = imagecreatetruecolor(imagesx($this->newimage), imagesy($this->newimage));
             imagecopy($this->im, $this->newimage, 0, 0, 0, 0, imagesx($this->newimage), imagesy($this->newimage));
-            $this->deprecatedImageDestroy($this->newimage);
+            unset($this->newimage);
             $this->size[0] = imagesx($this->im);
             $this->size[1] = imagesy($this->im);
         }
@@ -1567,10 +1552,10 @@ class Thumbnail
                 }
             }
         }
-        $this->deprecatedImageDestroy($this->im);
+        unset($this->im);
         $this->im = imagecreatetruecolor(imagesx($this->newimage), imagesy($this->newimage));
         imagecopy($this->im, $this->newimage, 0, 0, 0, 0, imagesx($this->newimage), imagesy($this->newimage));
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
         $this->size[0] = imagesx($this->im);
         $this->size[1] = imagesy($this->im);
     }
@@ -1620,10 +1605,10 @@ class Thumbnail
             imagefilledrectangle($this->newimage, 0, 0, imagesx($this->newimage), imagesy($this->newimage), imagecolorallocate($this->newimage, hexdec(substr($this->Polaroidframecolor, 1, 2)), hexdec(substr($this->Polaroidframecolor, 3, 2)), hexdec(substr($this->Polaroidframecolor, 5, 2))));
         }
         imagecopy($this->newimage, $this->im, 0, 0, $crop2, $crop4, $this->size[0] - $crop2 - $crop3, $this->size[1] - $crop4 - $crop5);
-        $this->deprecatedImageDestroy($this->im);
+        unset($this->im);
         $this->im = imagecreatetruecolor(imagesx($this->newimage), imagesy($this->newimage));
         imagecopy($this->im, $this->newimage, 0, 0, 0, 0, imagesx($this->newimage), imagesy($this->newimage));
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
         $this->size[0] = imagesx($this->im);
         $this->size[1] = imagesy($this->im);
     }
@@ -1640,10 +1625,10 @@ class Thumbnail
         $centerx = floor(($squaresize - $this->thumbx) / 2);
         $centery = floor(($squaresize - $this->thumby) / 2);
         imagecopy($this->newimage, $this->thumb, $centerx, $centery, 0, 0, $this->thumbx, $this->thumby);
-        $this->deprecatedImageDestroy($this->thumb);
+        unset($this->thumb);
         $this->thumb = imagecreatetruecolor($squaresize, $squaresize);
         imagecopy($this->thumb, $this->newimage, 0, 0, 0, 0, $squaresize, $squaresize);
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -1687,7 +1672,7 @@ class Thumbnail
                 }
             }
             imagecopy($this->im, $this->newimage, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-            $this->deprecatedImageDestroy($this->newimage);
+            unset($this->newimage);
         }
     }
 
@@ -1746,7 +1731,7 @@ class Thumbnail
             }
         }
         imagecopy($this->im, $this->newimage, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -1891,7 +1876,7 @@ class Thumbnail
             }
         }
         imagecopy($this->im, $this->newimage, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -1924,7 +1909,7 @@ class Thumbnail
             }
         }
         imagecopy($this->thumb, $this->newimage, 0, 0, 0, 0, $this->thumbx, $this->thumby);
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -1965,7 +1950,7 @@ class Thumbnail
                 imagecopymerge($this->im, $this->newimage, 0, $c, 0, 0, $this->size[0], 1, max(min($opacity, 100), 0));
             }
         }
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -1978,10 +1963,10 @@ class Thumbnail
         $this->newimage = imagecreatetruecolor($this->thumbx, $this->thumby + $bottom);
         imagefilledrectangle($this->newimage, 0, 0, $this->thumbx, $this->thumby + $bottom, imagecolorallocate($this->newimage, hexdec(substr($this->Backgroundcolor, 1, 2)), hexdec(substr($this->Backgroundcolor, 3, 2)), hexdec(substr($this->Backgroundcolor, 5, 2))));
         imagecopy($this->newimage, $this->thumb, 0, 0, 0, 0, $this->thumbx, $this->thumby);
-        $this->deprecatedImageDestroy($this->thumb);
+        unset($this->thumb);
         $this->thumb = imagecreatetruecolor($this->thumbx, $this->thumby + $bottom);
         imagecopy($this->thumb, $this->newimage, 0, 0, 0, 0, $this->thumbx, $this->thumby + $bottom);
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
         $this->thumbx = imagesx($this->thumb);
         $this->thumby = imagesy($this->thumb);
         for ($px = 0; $px < $this->thumbx; $px++) {
@@ -1996,7 +1981,7 @@ class Thumbnail
             $opacity = $this->Mirror[1] + floor(($bottom - ($this->thumby - $c)) * $shadingstrength);
             imagecopymerge($this->thumb, $this->newimage, 0, $c, 0, 0, $this->thumbx, 1, max(min($opacity, 100), 0));
         }
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -2067,7 +2052,7 @@ class Thumbnail
                 }
             }
             imagecopy($this->im, $this->newimage, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-            $this->deprecatedImageDestroy($this->newimage);
+            unset($this->newimage);
         }
     }
 
@@ -2242,7 +2227,7 @@ class Thumbnail
             }
         }
         imagecopy($this->im, $this->newimage, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -2263,7 +2248,7 @@ class Thumbnail
             }
         }
         imagecopy($this->im, $this->newimage, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -2285,7 +2270,7 @@ class Thumbnail
             }
         }
         imagecopy($this->im, $this->newimage, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -2314,7 +2299,7 @@ class Thumbnail
             }
         }
         imagecopy($this->im, $this->newimage, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-        $this->deprecatedImageDestroy($this->newimage);
+        unset($this->newimage);
     }
 
     /**
@@ -2595,10 +2580,10 @@ class Thumbnail
         if ($this->Displacementmap[2] == 0) {
             $maptmp = imagecreatetruecolor($this->size[0], $this->size[1]);
             imagecopyresampled($maptmp, $map, 0, 0, 0, 0, $this->size[0], $this->size[1], $mapxmax, $mapymax);
-            $this->deprecatedImageDestroy($map);
+            unset($map);
             $map = imagecreatetruecolor($this->size[0], $this->size[1]);
             imagecopy($map, $maptmp, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-            $this->deprecatedImageDestroy($maptmp);
+            unset($maptmp);
             $mapxmax = $this->size[0];
             $mapymax = $this->size[1];
         }
@@ -2622,8 +2607,8 @@ class Thumbnail
             }
         }
         imagecopy($this->im, $this->newimage, 0, 0, 0, 0, $this->size[0], $this->size[1]);
-        $this->deprecatedImageDestroy($this->newimage);
-        $this->deprecatedImageDestroy($map);
+        unset($this->newimage);
+        unset($map);
     }
 
     /**
@@ -2634,7 +2619,7 @@ class Thumbnail
     {
         if (is_resource($this->thumb)) {
             $temparray = $this->Displacementmap;
-            $this->deprecatedImageDestroy($this->im);
+            unset($this->im);
             $this->im = imagecreatetruecolor($this->thumbx, $this->thumby);
             imagecopy($this->im, $this->thumb, 0, 0, 0, 0, $this->thumbx, $this->thumby);
             $this->size[0] = $this->thumbx;
@@ -2750,18 +2735,6 @@ class Thumbnail
                     fclose($src_file);
                 }
             }
-        }
-    }
-
-    /**
-     * The call of this function (and this function) can be replaced by just unset() if we no longer need to support PHP 8.0 or older.
-     */
-    protected function deprecatedImageDestroy(&$resource)
-    {
-        if (PHP_VERSION_ID >= 80000) {
-            unset($resource);
-        } else {
-            imagedestroy($resource);
         }
     }
 }

--- a/application/modules/admin/config/config.php
+++ b/application/modules/admin/config/config.php
@@ -1308,6 +1308,10 @@ class Config extends \Ilch\Config\Install
                 // The file is no longer part of tarteaucitron.
                 unlink(ROOT_PATH . '/static/js/tarteaucitron/build/lang/tarteaucitron.kr.min.js');
                 break;
+            case "2.2.17":
+                // Update vendor folder to update various dependencies.
+                replaceVendorDirectory();
+                break;
         }
 
         return 'Update function executed.';

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ezyang/htmlpurifier": "^4.19"
     },
     "require-dev": {
-        "maximebf/debugbar": "^2.2.6",
+        "php-debugbar/php-debugbar": "^2.2.6",
         "phpunit/phpunit": "^10.5.63",
         "symfony/yaml": "^6.4.41"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ifsnop/mysqldump-php": "^2.12",
         "kartik-v/bootstrap-star-rating": "^4.1.2",
         "twbs/bootstrap": "^5.3.8",
-        "fortawesome/font-awesome": "^7.2.0",
+        "fortawesome/font-awesome": "^7.3.0",
         "npm-asset/jquery": "^4.0.0",
         "npm-asset/jquery-ui": "^1.14.2",
         "phpmailer/phpmailer": "^7.1.1",

--- a/composer.json
+++ b/composer.json
@@ -6,24 +6,24 @@
     "minimum-stability": "stable",
     "config": {
         "platform": {
-            "php": "7.4"
+            "php": "8.1"
         }
     },
     "require": {
-        "php": ">=7.4",
-        "ifsnop/mysqldump-php": "^2.11",
+        "php": ">=8.1",
+        "ifsnop/mysqldump-php": "^2.12",
         "kartik-v/bootstrap-star-rating": "^4.1.2",
-        "twbs/bootstrap": "^5.3.3",
+        "twbs/bootstrap": "^5.3.8",
         "fortawesome/font-awesome": "^7.2.0",
         "npm-asset/jquery": "^4.0.0",
-        "npm-asset/jquery-ui": "^1.14.0",
-        "phpmailer/phpmailer": "^7.0.2",
-        "ezyang/htmlpurifier": "^4.17"
+        "npm-asset/jquery-ui": "^1.14.2",
+        "phpmailer/phpmailer": "^7.1.1",
+        "ezyang/htmlpurifier": "^4.19"
     },
     "require-dev": {
-        "maximebf/debugbar": "^1.22.3",
-        "phpunit/phpunit": "^9.6.19",
-        "symfony/yaml": "^5.4.39"
+        "maximebf/debugbar": "^2.2.6",
+        "phpunit/phpunit": "^10.5.63",
+        "symfony/yaml": "^6.4.41"
     },
     "autoload": {
         "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e9cd4a7af27bef3b67aa36069bd8754",
+    "content-hash": "d02d404aeca665d2f65ef32795f9f0f9",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",
@@ -387,99 +387,30 @@
     ],
     "packages-dev": [
         {
-            "name": "doctrine/instantiator",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:15:36+00:00"
-        },
-        {
             "name": "maximebf/debugbar",
-            "version": "v1.23.6",
+            "version": "v2.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-debugbar/php-debugbar.git",
-                "reference": "4b3d5f1afe09a7db5a9d3282890f49f6176d6542"
+                "reference": "abb9fa3c5c8dbe7efe03ddba56782917481de3e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/4b3d5f1afe09a7db5a9d3282890f49f6176d6542",
-                "reference": "4b3d5f1afe09a7db5a9d3282890f49f6176d6542",
+                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/abb9fa3c5c8dbe7efe03ddba56782917481de3e8",
+                "reference": "abb9fa3c5c8dbe7efe03ddba56782917481de3e8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8",
+                "php": "^8.1",
                 "psr/log": "^1|^2|^3",
-                "symfony/var-dumper": "^4|^5|^6|^7"
+                "symfony/var-dumper": "^5.4|^6.4|^7.3|^8.0"
             },
             "require-dev": {
                 "dbrekelmans/bdi": "^1",
-                "phpunit/phpunit": "^8|^9",
+                "phpunit/phpunit": "^10",
+                "symfony/browser-kit": "^6.0|7.0",
                 "symfony/panther": "^1|^2.1",
-                "twig/twig": "^1.38|^2.7|^3.0"
+                "twig/twig": "^3.11.2"
             },
             "suggest": {
                 "kriswallsmith/assetic": "The best way to manage assets",
@@ -489,7 +420,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.23-dev"
+                    "dev-master": "2.2-dev"
                 }
             },
             "autoload": {
@@ -513,17 +444,19 @@
                 }
             ],
             "description": "Debug bar in the browser for php application",
-            "homepage": "https://github.com/maximebf/php-debugbar",
+            "homepage": "https://github.com/php-debugbar/php-debugbar",
             "keywords": [
                 "debug",
-                "debugbar"
+                "debug bar",
+                "debugbar",
+                "dev"
             ],
             "support": {
                 "issues": "https://github.com/php-debugbar/php-debugbar/issues",
-                "source": "https://github.com/php-debugbar/php-debugbar/tree/v1.23.6"
+                "source": "https://github.com/php-debugbar/php-debugbar/tree/v2.2.6"
             },
             "abandoned": "php-debugbar/php-debugbar",
-            "time": "2025-02-13T12:22:36+00:00"
+            "time": "2025-12-22T13:21:32+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -763,16 +696,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
@@ -780,18 +713,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -800,7 +733,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -829,7 +762,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
             },
             "funding": [
                 {
@@ -837,32 +770,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -889,7 +822,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -897,28 +831,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -926,7 +860,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -952,7 +886,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -960,32 +894,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1011,7 +945,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -1019,32 +954,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1070,7 +1005,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1078,24 +1013,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.34",
+            "version": "10.5.63",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
-                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -1105,27 +1039,26 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.10",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.8",
-                "sebastian/global-state": "^5.0.8",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.5",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -1133,7 +1066,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -1165,7 +1098,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
             },
             "funding": [
                 {
@@ -1189,34 +1122,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T05:45:00+00:00"
+            "time": "2026-01-27T05:48:37+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1237,34 +1170,34 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1287,7 +1220,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -1295,32 +1229,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:27:43+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1343,7 +1277,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -1351,32 +1285,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1398,7 +1332,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -1406,34 +1340,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.10",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
-                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1472,7 +1408,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
             },
             "funding": [
                 {
@@ -1492,33 +1429,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:22:56+00:00"
+            "time": "2026-01-24T09:25:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1541,7 +1478,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -1549,33 +1487,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1607,7 +1545,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -1615,27 +1554,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1643,7 +1582,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1662,7 +1601,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -1670,7 +1609,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
             },
             "funding": [
                 {
@@ -1678,34 +1618,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.8",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1747,7 +1687,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
             },
             "funding": [
                 {
@@ -1767,38 +1708,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:03:27+00:00"
+            "time": "2025-09-24T06:09:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.8",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1817,59 +1755,48 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:10:35+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1892,7 +1819,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -1900,34 +1828,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1949,7 +1877,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -1957,32 +1885,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2004,7 +1932,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2012,32 +1940,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.6",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2067,7 +1995,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
             },
             "funding": [
                 {
@@ -2087,86 +2016,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:57:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2025-08-10T07:50:56+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2189,7 +2064,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -2197,29 +2072,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2242,7 +2117,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -2250,24 +2125,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.4",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
-                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
@@ -2276,7 +2151,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -2301,7 +2176,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -2313,11 +2188,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2404,20 +2283,19 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
                 "shasum": ""
             },
             "require": {
-                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -2465,7 +2343,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2477,134 +2355,41 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.4.48",
+            "version": "v6.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "42f18f170aa86d612c3559cfb3bd11a375df32c8"
+                "reference": "7c8ad9ce4faf6c8a99948e70ce02b601a0439782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/42f18f170aa86d612c3559cfb3bd11a375df32c8",
-                "reference": "42f18f170aa86d612c3559cfb3bd11a375df32c8",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/7c8ad9ce4faf6c8a99948e70ce02b601a0439782",
+                "reference": "7c8ad9ce4faf6c8a99948e70ce02b601a0439782",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/console": "<4.4"
+                "symfony/console": "<5.4"
             },
             "require-dev": {
-                "ext-iconv": "*",
-                "symfony/console": "^4.4|^5.0|^6.0",
-                "symfony/http-kernel": "^4.4|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/uid": "^5.1|^6.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^6.3|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/uid": "^5.4|^6.0|^7.0",
                 "twig/twig": "^2.13|^3.0.4"
-            },
-            "suggest": {
-                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
-                "ext-intl": "To show region name in time zone dump",
-                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
             },
             "bin": [
                 "Resources/bin/var-dump-server"
@@ -2642,7 +2427,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.48"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.36"
             },
             "funding": [
                 {
@@ -2654,39 +2439,40 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T15:21:10+00:00"
+            "time": "2026-03-30T15:36:00+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.52",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "b0b27055f055f0d314c5c68ed0c10f0bbd90aee0"
+                "reference": "e8fdf3408c85806198d5826e604ffc6830d33152"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b0b27055f055f0d314c5c68ed0c10f0bbd90aee0",
-                "reference": "b0b27055f055f0d314c5c68ed0c10f0bbd90aee0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e8fdf3408c85806198d5826e604ffc6830d33152",
+                "reference": "e8fdf3408c85806198d5826e604ffc6830d33152",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<5.3"
+                "symfony/console": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.3|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "symfony/console": "^5.4|^6.0|^7.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -2717,7 +2503,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.52"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -2737,7 +2523,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-15T06:40:16+00:00"
+            "time": "2026-05-25T06:03:23+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2796,11 +2582,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=8.1"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.4"
+        "php": "8.1"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -69,16 +69,16 @@
         },
         {
             "name": "fortawesome/font-awesome",
-            "version": "7.2.0",
+            "version": "7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FortAwesome/Font-Awesome.git",
-                "reference": "337dd2045d5621ce0f8567c33c256f3dedeed55d"
+                "reference": "70fb2dd154b617f62fc4ae5b0b7e2943bfd2aa96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/337dd2045d5621ce0f8567c33c256f3dedeed55d",
-                "reference": "337dd2045d5621ce0f8567c33c256f3dedeed55d",
+                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/70fb2dd154b617f62fc4ae5b0b7e2943bfd2aa96",
+                "reference": "70fb2dd154b617f62fc4ae5b0b7e2943bfd2aa96",
                 "shasum": ""
             },
             "type": "library",
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/FortAwesome/Font-Awesome/issues",
                 "source": "https://github.com/FortAwesome/Font-Awesome"
             },
-            "time": "2026-02-10T18:17:20+00:00"
+            "time": "2026-06-25T22:03:17+00:00"
         },
         {
             "name": "ifsnop/mysqldump-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d02d404aeca665d2f65ef32795f9f0f9",
+    "content-hash": "0e03cd826c92c854ed3caea9b9074734",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",
@@ -387,78 +387,6 @@
     ],
     "packages-dev": [
         {
-            "name": "maximebf/debugbar",
-            "version": "v2.2.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-debugbar/php-debugbar.git",
-                "reference": "abb9fa3c5c8dbe7efe03ddba56782917481de3e8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/abb9fa3c5c8dbe7efe03ddba56782917481de3e8",
-                "reference": "abb9fa3c5c8dbe7efe03ddba56782917481de3e8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1",
-                "psr/log": "^1|^2|^3",
-                "symfony/var-dumper": "^5.4|^6.4|^7.3|^8.0"
-            },
-            "require-dev": {
-                "dbrekelmans/bdi": "^1",
-                "phpunit/phpunit": "^10",
-                "symfony/browser-kit": "^6.0|7.0",
-                "symfony/panther": "^1|^2.1",
-                "twig/twig": "^3.11.2"
-            },
-            "suggest": {
-                "kriswallsmith/assetic": "The best way to manage assets",
-                "monolog/monolog": "Log using Monolog",
-                "predis/predis": "Redis storage"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "DebugBar\\": "src/DebugBar/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Maxime Bouroumeau-Fuseau",
-                    "email": "maxime.bouroumeau@gmail.com",
-                    "homepage": "http://maximebf.com"
-                },
-                {
-                    "name": "Barry vd. Heuvel",
-                    "email": "barryvdh@gmail.com"
-                }
-            ],
-            "description": "Debug bar in the browser for php application",
-            "homepage": "https://github.com/php-debugbar/php-debugbar",
-            "keywords": [
-                "debug",
-                "debug bar",
-                "debugbar",
-                "dev"
-            ],
-            "support": {
-                "issues": "https://github.com/php-debugbar/php-debugbar/issues",
-                "source": "https://github.com/php-debugbar/php-debugbar/tree/v2.2.6"
-            },
-            "abandoned": "php-debugbar/php-debugbar",
-            "time": "2025-12-22T13:21:32+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -693,6 +621,80 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-debugbar/php-debugbar",
+            "version": "v2.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-debugbar/php-debugbar.git",
+                "reference": "abb9fa3c5c8dbe7efe03ddba56782917481de3e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/abb9fa3c5c8dbe7efe03ddba56782917481de3e8",
+                "reference": "abb9fa3c5c8dbe7efe03ddba56782917481de3e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^5.4|^6.4|^7.3|^8.0"
+            },
+            "replace": {
+                "maximebf/debugbar": "self.version"
+            },
+            "require-dev": {
+                "dbrekelmans/bdi": "^1",
+                "phpunit/phpunit": "^10",
+                "symfony/browser-kit": "^6.0|7.0",
+                "symfony/panther": "^1|^2.1",
+                "twig/twig": "^3.11.2"
+            },
+            "suggest": {
+                "kriswallsmith/assetic": "The best way to manage assets",
+                "monolog/monolog": "Log using Monolog",
+                "predis/predis": "Redis storage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/DebugBar/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/php-debugbar/php-debugbar",
+            "keywords": [
+                "debug",
+                "debug bar",
+                "debugbar",
+                "dev"
+            ],
+            "support": {
+                "issues": "https://github.com/php-debugbar/php-debugbar/issues",
+                "source": "https://github.com/php-debugbar/php-debugbar/tree/v2.2.6"
+            },
+            "time": "2025-12-22T13:21:32+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/development/composer.json
+++ b/development/composer.json
@@ -5,7 +5,7 @@
     "config": {
         "bin-dir": "bin",
         "platform": {
-            "php": "7.4"
+            "php": "8.1"
         },
         "bin-compat": "full",
         "allow-plugins": {
@@ -14,7 +14,8 @@
     },
     "require": {
         "squizlabs/php_codesniffer": "^4.0.1",
-        "friendsofphp/php-cs-fixer": "^3.57.1",
-        "phpcompatibility/php-compatibility": "^10.0.0@dev"
+        "friendsofphp/php-cs-fixer": "^3.95.10",
+        "phpcompatibility/php-compatibility": "^10.0.0@dev",
+        "symfony/polyfill-iconv": "^1.37.0"
     }
 }

--- a/development/composer.lock
+++ b/development/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67a7ee4c8132343dad0b031b98f606dc",
+    "content-hash": "117c16ab5f08a0da49e18cfddfc392e5",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -72,28 +72,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -131,7 +132,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -141,13 +142,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
@@ -567,23 +564,23 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.2",
+            "version": "v3.95.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "a28d88a5e172b27e78d0816992b15a9df3da20f1"
+                "reference": "93e1ab3e1f153024bd3ab23c8a349556063c6f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a28d88a5e172b27e78d0816992b15a9df3da20f1",
-                "reference": "a28d88a5e172b27e78d0816992b15a9df3da20f1",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/93e1ab3e1f153024bd3ab23c8a349556063c6f17",
+                "reference": "93e1ab3e1f153024bd3ab23c8a349556063c6f17",
                 "shasum": ""
             },
             "require": {
                 "clue/ndjson-react": "^1.3",
                 "composer/semver": "^3.4",
                 "composer/xdebug-handler": "^3.0.5",
-                "ergebnis/agent-detector": "^1.1.1",
+                "ergebnis/agent-detector": "^1.2",
                 "ext-filter": "*",
                 "ext-hash": "*",
                 "ext-json": "*",
@@ -594,32 +591,32 @@
                 "react/event-loop": "^1.5",
                 "react/socket": "^1.16",
                 "react/stream": "^1.4",
-                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0",
+                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0 || ^9.0",
                 "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/options-resolver": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
-                "symfony/polyfill-mbstring": "^1.33",
-                "symfony/polyfill-php80": "^1.33",
-                "symfony/polyfill-php81": "^1.33",
-                "symfony/polyfill-php84": "^1.33",
+                "symfony/polyfill-mbstring": "^1.37",
+                "symfony/polyfill-php80": "^1.37",
+                "symfony/polyfill-php81": "^1.37",
+                "symfony/polyfill-php84": "^1.37",
                 "symfony/process": "^5.4.47 || ^6.4.24 || ^7.2 || ^8.0",
                 "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "facile-it/paraunit": "^1.3.1 || ^2.11.0",
                 "infection/infection": "^0.32.7",
-                "justinrainbow/json-schema": "^6.8.0",
+                "justinrainbow/json-schema": "^6.9.0",
                 "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.9.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
                 "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
-                "symfony/polyfill-php85": "^1.33",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
-                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.8"
+                "symfony/polyfill-php85": "^1.38",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.36 || ^7.4.8 || ^8.1.0",
+                "symfony/yaml": "^5.4.53 || ^6.4.41 || ^7.4.13 || ^8.1.0"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -660,7 +657,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.2"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.10"
             },
             "funding": [
                 {
@@ -668,7 +665,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-15T09:20:44+00:00"
+            "time": "2026-06-19T14:45:22+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -856,22 +853,27 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -898,9 +900,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -954,30 +956,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -998,9 +1000,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "react/cache",
@@ -1530,29 +1532,29 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1584,7 +1586,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -1592,7 +1595,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1675,52 +1678,47 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.47",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed"
+                "reference": "d21b17ed158e79180fac3895ff751707970eeb57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
-                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d21b17ed158e79180fac3895ff751707970eeb57",
+                "reference": "d21b17ed158e79180fac3895ff751707970eeb57",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.9",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.1|^6.0"
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^5.4|^6.0|^7.0"
             },
             "conflict": {
-                "psr/log": ">=3",
-                "symfony/dependency-injection": "<4.4",
-                "symfony/dotenv": "<5.1",
-                "symfony/event-dispatcher": "<4.4",
-                "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
+                "symfony/dependency-injection": "<5.4",
+                "symfony/dotenv": "<5.4",
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/lock": "<5.4",
+                "symfony/process": "<5.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0|2.0"
+                "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
-                "psr/log": "^1|^2",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
-                "symfony/lock": "^4.4|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/var-dumper": "^4.4|^5.0|^6.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -1754,7 +1752,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.47"
+                "source": "https://github.com/symfony/console/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -1766,28 +1764,32 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T11:30:55+00:00"
+            "time": "2026-05-24T08:48:41+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.4",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
-                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
@@ -1796,7 +1798,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1821,7 +1823,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1833,52 +1835,51 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.45",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "72982eb416f61003e9bb6e91f8b3213600dcf9e9"
+                "reference": "2e3bf817ba9347341ab15926700fb6320367c0e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/72982eb416f61003e9bb6e91f8b3213600dcf9e9",
-                "reference": "72982eb416f61003e9bb6e91f8b3213600dcf9e9",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/2e3bf817ba9347341ab15926700fb6320367c0e1",
+                "reference": "2e3bf817ba9347341ab15926700fb6320367c0e1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/event-dispatcher-contracts": "^2|^3",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<4.4"
+                "symfony/dependency-injection": "<5.4",
+                "symfony/service-contracts": "<2.5"
             },
             "provide": {
                 "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0"
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/http-foundation": "^4.4|^5.0|^6.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/stopwatch": "^4.4|^5.0|^6.0"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -1906,7 +1907,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.45"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -1918,32 +1919,33 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2026-04-13T14:11:12+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.5.4",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "e0fe3d79b516eb75126ac6fa4cbf19b79b08c99f"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/e0fe3d79b516eb75126ac6fa4cbf19b79b08c99f",
-                "reference": "e0fe3d79b516eb75126ac6fa4cbf19b79b08c99f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.1",
                 "psr/event-dispatcher": "^1"
-            },
-            "suggest": {
-                "symfony/event-dispatcher-implementation": ""
             },
             "type": "library",
             "extra": {
@@ -1952,7 +1954,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1985,7 +1987,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.4"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1997,34 +1999,37 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.45",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54"
+                "reference": "c507b077756b4e3e09adbbe7975fac81cd3722ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/57c8294ed37d4a055b77057827c67f9558c95c54",
-                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c507b077756b4e3e09adbbe7975fac81cd3722ca",
+                "reference": "c507b077756b4e3e09adbbe7975fac81cd3722ca",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8",
-                "symfony/polyfill-php80": "^1.16"
+                "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^5.4|^6.4"
+                "symfony/process": "^5.4|^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -2052,7 +2057,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.45"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -2064,30 +2069,35 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-22T13:05:35+00:00"
+            "time": "2026-05-07T13:11:42+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.45",
+            "version": "v6.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "63741784cd7b9967975eec610b256eed3ede022b"
+                "reference": "9590e86be1d1c57bfbb16d0dd040345378c20896"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/63741784cd7b9967975eec610b256eed3ede022b",
-                "reference": "63741784cd7b9967975eec610b256eed3ede022b",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/9590e86be1d1c57bfbb16d0dd040345378c20896",
+                "reference": "9590e86be1d1c57bfbb16d0dd040345378c20896",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -2115,7 +2125,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.45"
+                "source": "https://github.com/symfony/finder/tree/v6.4.34"
             },
             "funding": [
                 {
@@ -2127,31 +2137,33 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-28T13:32:08+00:00"
+            "time": "2026-01-28T15:16:37+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.4.45",
+            "version": "v6.4.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "74e5b6f0db3e8589e6cfd5efb317a1fc2bb52fb6"
+                "reference": "eeaa8cabe54c7b3516938c72a4a161c0cc80a34f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/74e5b6f0db3e8589e6cfd5efb317a1fc2bb52fb6",
-                "reference": "74e5b6f0db3e8589e6cfd5efb317a1fc2bb52fb6",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/eeaa8cabe54c7b3516938c72a4a161c0cc80a34f",
+                "reference": "eeaa8cabe54c7b3516938c72a4a161c0cc80a34f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php73": "~1.0",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "type": "library",
             "autoload": {
@@ -2184,7 +2196,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.4.45"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.4.30"
             },
             "funding": [
                 {
@@ -2196,11 +2208,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2025-11-12T13:06:53+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2286,17 +2302,101 @@
             "time": "2026-04-10T16:19:22+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-grapheme",
+            "name": "symfony/polyfill-iconv",
             "version": "v1.37.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "2c5729fd241b4b22f6e4b436bc3354a4f262df57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/2c5729fd241b4b22f6e4b436bc3354a4f262df57",
+                "reference": "2c5729fd241b4b22f6e4b436bc3354a4f262df57",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-iconv": "*"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -2345,7 +2445,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -2365,20 +2465,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -2430,7 +2530,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -2450,20 +2550,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -2515,7 +2615,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -2535,87 +2635,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
-                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -2703,16 +2723,16 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
                 "shasum": ""
             },
             "require": {
@@ -2759,7 +2779,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -2779,20 +2799,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -2839,7 +2859,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -2859,25 +2879,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T18:47:49+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.51",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "467bfc56f18f5ef6d5ccb09324d7e988c1c0a98f"
+                "reference": "c8fc09bdfe9fde9aaa89b415a4477feaccec16a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/467bfc56f18f5ef6d5ccb09324d7e988c1c0a98f",
-                "reference": "467bfc56f18f5ef6d5ccb09324d7e988c1c0a98f",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c8fc09bdfe9fde9aaa89b415a4477feaccec16a7",
+                "reference": "c8fc09bdfe9fde9aaa89b415a4477feaccec16a7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1"
             },
             "type": "library",
             "autoload": {
@@ -2905,7 +2924,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.51"
+                "source": "https://github.com/symfony/process/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -2925,32 +2944,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:53:37+00:00"
+            "time": "2026-05-23T13:47:21+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.4",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f37b419f7aea2e9abf10abd261832cace12e3300",
-                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1|^3"
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
-            },
-            "suggest": {
-                "symfony/service-implementation": ""
             },
             "type": "library",
             "extra": {
@@ -2959,13 +2975,16 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Service\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2992,7 +3011,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.4"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3004,29 +3023,33 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.4.45",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "fb2c199cf302eb207f8c23e7ee174c1c31a5c004"
+                "reference": "b67e94e06a05d9572c2fa354483b3e13e3cb1898"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/fb2c199cf302eb207f8c23e7ee174c1c31a5c004",
-                "reference": "fb2c199cf302eb207f8c23e7ee174c1c31a5c004",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/b67e94e06a05d9572c2fa354483b3e13e3cb1898",
+                "reference": "b67e94e06a05d9572c2fa354483b3e13e3cb1898",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/service-contracts": "^1|^2|^3"
+                "php": ">=8.1",
+                "symfony/service-contracts": "^2.5|^3"
             },
             "type": "library",
             "autoload": {
@@ -3054,7 +3077,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.4.45"
+                "source": "https://github.com/symfony/stopwatch/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -3066,42 +3089,45 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2025-07-10T08:14:14+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.47",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799"
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/136ca7d72f72b599f2631aca474a4f8e26719799",
-                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799",
+                "url": "https://api.github.com/repos/symfony/string/zipball/62e3c927de664edadb5bef260987eb047a17a113",
+                "reference": "62e3c927de664edadb5bef260987eb047a17a113",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "~1.15"
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": ">=3.0"
+                "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/http-client": "^4.4|^5.0|^6.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0|^6.0"
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^6.2|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -3140,7 +3166,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.47"
+                "source": "https://github.com/symfony/string/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -3152,11 +3178,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-10T20:33:58+00:00"
+            "time": "2026-05-12T11:44:19+00:00"
         }
     ],
     "packages-dev": [],
@@ -3170,7 +3200,7 @@
     "platform": {},
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.4"
+        "php": "8.1"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
  * @package ilch
  */
 
-define('PHPVERSION', '7.4');
+define('PHPVERSION', '8.1');
 if (!version_compare(PHP_VERSION, PHPVERSION, '>=')) {
     die('Ilch CMS 2 needs at least php version ' . PHPVERSION);
 }

--- a/tests/PHPUnit/Ilch/PhpunitDataset.php
+++ b/tests/PHPUnit/Ilch/PhpunitDataset.php
@@ -12,7 +12,7 @@ class PhpunitDataset extends DatabaseTestCase
 {
     public function __construct($db)
     {
-        parent::__construct();
+        parent::__construct("");
         $this->db = $db;
     }
 

--- a/tests/PHPUnit/Ilch/PhpunitDataset.php
+++ b/tests/PHPUnit/Ilch/PhpunitDataset.php
@@ -12,7 +12,7 @@ class PhpunitDataset extends DatabaseTestCase
 {
     public function __construct($db)
     {
-        parent::__construct("");
+        parent::__construct("test");
         $this->db = $db;
     }
 

--- a/tests/libraries/ilch/Database/Mysql/ResultTest.php
+++ b/tests/libraries/ilch/Database/Mysql/ResultTest.php
@@ -36,13 +36,13 @@ class ResultTest extends DatabaseTestCase
     /**
      * @dataProvider dpForFetchCell
      *
-     * @param integer|string $cellParam
+     * @param integer|string $param
      * @param string $expected
      */
-    public function testFetchCell($cellParam, string $expected)
+    public function testFetchCell($param, string $expected)
     {
         $result = $this->db->select('*', 'groups')->execute();
-        self::assertEquals($expected, $result->fetchCell($cellParam));
+        self::assertEquals($expected, $result->fetchCell($param));
     }
 
     /**

--- a/tests/libraries/ilch/Database/Mysql/ResultTest.php
+++ b/tests/libraries/ilch/Database/Mysql/ResultTest.php
@@ -48,7 +48,7 @@ class ResultTest extends DatabaseTestCase
     /**
      * @return array
      */
-    public function dpForFetchCell(): array
+    public static function dpForFetchCell(): array
     {
         return [
             'null' => [
@@ -89,7 +89,7 @@ class ResultTest extends DatabaseTestCase
     /**
      * @return array
      */
-    public function dpForFetchArray(): array
+    public static function dpForFetchArray(): array
     {
         return [
             'both' => [
@@ -160,7 +160,7 @@ class ResultTest extends DatabaseTestCase
     /**
      * @return array
      */
-    public function dpForFetchRows(): array
+    public static function dpForFetchRows(): array
     {
         return [
             'simple assoc' => [
@@ -226,7 +226,7 @@ class ResultTest extends DatabaseTestCase
     /**
      * @return array
      */
-    public function dpForFetchList(): array
+    public static function dpForFetchList(): array
     {
         return [
             'without args' => [
@@ -273,7 +273,7 @@ class ResultTest extends DatabaseTestCase
     /**
      * @return array
      */
-    public function dpForTestGetNumRows(): array
+    public static function dpForTestGetNumRows(): array
     {
         return [[1], [4]];
     }
@@ -296,7 +296,7 @@ class ResultTest extends DatabaseTestCase
     /**
      * @return array
      */
-    public function dpForGetFieldCount(): array
+    public static function dpForGetFieldCount(): array
     {
         return [
             [

--- a/tests/libraries/ilch/Database/Mysql/SelectTest.php
+++ b/tests/libraries/ilch/Database/Mysql/SelectTest.php
@@ -380,7 +380,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
                 'expectedSqlPart' => '5'
             ],
             'with array'    => [
-                'where'           => [5, 10],
+                'limit'           => [5, 10],
                 'expectedSqlPart' => '5, 10'
             ]
         ];

--- a/tests/libraries/ilch/Database/Mysql/SelectTest.php
+++ b/tests/libraries/ilch/Database/Mysql/SelectTest.php
@@ -62,7 +62,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForTable(): array
+    public static function dpForTable(): array
     {
         return [
             'simple tablename' => [
@@ -99,7 +99,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForFields(): array
+    public static function dpForFields(): array
     {
         return [
             'string all' => [
@@ -170,7 +170,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * Data provider for testGenerateSqlForWhere
      * @return array
      */
-    public function dpForWhere(): array
+    public static function dpForWhere(): array
     {
         return [
             'simple condition'  => [
@@ -259,7 +259,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * Operator data provider
      * @return array
      */
-    public function dpOperators(): array
+    public static function dpOperators(): array
     {
         return [['='], ['<='], ['>='], ['<'], ['>'], ['!='], ['<>'], ['LIKE'], ['NOT LIKE']];
     }
@@ -289,7 +289,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForOrWhere(): array
+    public static function dpForOrWhere(): array
     {
         return [
             'with empty where and single condition' => [
@@ -338,7 +338,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForTestGenerateSqlForOrderBy(): array
+    public static function dpForTestGenerateSqlForOrderBy(): array
     {
         return [
             'field without table' => [
@@ -372,7 +372,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForLimit(): array
+    public static function dpForLimit(): array
     {
         return [
             'with integer'  => [
@@ -420,7 +420,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
      * Data provider for testGenerateSqlForLimitWithPage
      * @return array
      */
-    public function dpForLimitWithPage(): array
+    public static function dpForLimitWithPage(): array
     {
         //expected offset for limit 10
         return [
@@ -453,7 +453,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForTestGenerateSqlWithGroup(): array
+    public static function dpForTestGenerateSqlWithGroup(): array
     {
         return [
             'one field' => [
@@ -503,7 +503,7 @@ class SelectTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function dpForJoinConditions(): array
+    public static function dpForJoinConditions(): array
     {
         return [
             'single field comparison' => [

--- a/tests/libraries/ilch/FunctionsTest.php
+++ b/tests/libraries/ilch/FunctionsTest.php
@@ -60,7 +60,7 @@ class FunctionsTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestArrayDot(): array
+    public static function dpForTestArrayDot(): array
     {
         return [
             'no key provided' => ['params' => ['data' => ['1', '2'], 'key' => null, 'default' => null], ['1', '2']],
@@ -85,7 +85,7 @@ class FunctionsTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestArrayDotSet(): array
+    public static function dpForTestArrayDotSet(): array
     {
         return [
             'test 1' => ['params' => ['array' => [], 'key' => 'test.value', 'value' => 'admin'], ['value' => 'admin']],
@@ -106,7 +106,7 @@ class FunctionsTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestIsInArray(): array
+    public static function dpForTestIsInArray(): array
     {
         return [
             'is in array' => ['params' => ['needle' => ['test'], 'haystack' => ['test']], true],
@@ -128,7 +128,7 @@ class FunctionsTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestUrlGetContents(): array
+    public static function dpForTestUrlGetContents(): array
     {
         return [
             'valid url' => ['params' => ['url' => 'https://raw.githubusercontent.com/IlchCMS/Ilch-2.0/master/development/.gitignore'], '/vendor' . "\n" . '/bin/*' . "\n"],
@@ -150,7 +150,7 @@ class FunctionsTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestVarExportShortSyntax(): array
+    public static function dpForTestVarExportShortSyntax(): array
     {
         return [
             'string' => ['params' => ['var' => 'test', 'indent' => ''], '"test"'],
@@ -217,7 +217,7 @@ class FunctionsTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestFormatBytes(): array
+    public static function dpForTestFormatBytes(): array
     {
         return [
             'invalid empty string' => ['params' => ['bytes' => '', 'decimals' => 0], false],
@@ -254,7 +254,7 @@ class FunctionsTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidateDate(): array
+    public static function dpForTestValidateDate(): array
     {
         return [
             'invalid empty string' => ['params' => ['date' => '', 'format' => 'Y-m-d H:i:s'], false],

--- a/tests/libraries/ilch/Layout/Helper/GetMenuTest.php
+++ b/tests/libraries/ilch/Layout/Helper/GetMenuTest.php
@@ -51,7 +51,7 @@ class GetMenuTest extends DatabaseTestCase
         self::assertSame($expected, $out->getMenu(1, '<h2>%s</h2>%c', $options));
     }
 
-    public function dpForTestGetMenu(): array
+    public static function dpForTestGetMenu(): array
     {
         $menuTitle = '<h2>Menue</h2>';
         $testBox = '<h2>Testbox</h2><p>Inhalt der Testbox</p>';

--- a/tests/libraries/ilch/RouterTest.php
+++ b/tests/libraries/ilch/RouterTest.php
@@ -140,7 +140,7 @@ class RouterTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestUpdateRequestByQuery(): array
+    public static function dpForTestUpdateRequestByQuery(): array
     {
         return [
             'route without params' => [

--- a/tests/libraries/ilch/TranslatorTest.php
+++ b/tests/libraries/ilch/TranslatorTest.php
@@ -108,14 +108,14 @@ class TranslatorTest extends TestCase
     /**
      * Tests if the Translator replaces the placeholders withing the translated texts
      * with one replacement.
-     * @dataProvider placeholderDataProvider
+     * @dataProvider dpForTransPlaceholders
      */
     public function testTransPlaceholders(string $key, array $placeholders, string $expected)
     {
         self::assertSame($expected, $this->translator->trans($key, ...$placeholders));
     }
 
-    public function placeholderDataProvider(): array
+    public static function dpForTransPlaceholders(): array
     {
         return [
             ['welcomeUser', ['Hans'], 'Welcome, Hans'],

--- a/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
+++ b/tests/libraries/ilch/Validation/Validators/CaptchaTest.php
@@ -38,21 +38,21 @@ class CaptchaTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             'valid' => [
-                'data'                    => $this->createData('test'),
+                'data'                    => CaptchaTest::createData('test'),
                 'expectedIsValid'         => true
             ],
             'invalid captcha' => [
-                'data'                    => $this->createData('abc'),
+                'data'                    => CaptchaTest::createData('abc'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.captcha.wrongCaptcha',
                 'expectedErrorParameters' => []
             ],
             'invalid empty' => [
-                'data'                    => $this->createData(''),
+                'data'                    => CaptchaTest::createData(''),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.captcha.wrongCaptcha',
                 'expectedErrorParameters' => []
@@ -66,7 +66,7 @@ class CaptchaTest extends TestCase
      * @param string $value
      * @return stdClass
      */
-    private function createData(string $value): stdClass
+    private static function createData(string $value): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/DateTest.php
+++ b/tests/libraries/ilch/Validation/Validators/DateTest.php
@@ -37,63 +37,63 @@ class DateTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             // date validations
             'date correct' => [
-                'data'                    => $this->createData('2020-08-01'),
+                'data'                    => DateTest::createData('2020-08-01'),
                 'expectedIsValid'         => true
             ],
             'date wrong' => [
-                'data'                    => $this->createData('2020-08-01 12:00:00'),
+                'data'                    => DateTest::createData('2020-08-01 12:00:00'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.date.mustBeDate',
                 'expectedErrorParameters' => ['Y-m-d']
             ],
             // datetime validations
             'datetime correct' => [
-                'data'                    => $this->createData('2020-08-01 12:00:00', 'Y-m-d H\\:i\\:s'),
+                'data'                    => DateTest::createData('2020-08-01 12:00:00', 'Y-m-d H\\:i\\:s'),
                 'expectedIsValid'         => true
             ],
             'datetime wrong' => [
-                'data'                    => $this->createData('2020-08-01 24:00:00', 'Y-m-d H\\:i\\:s'),
+                'data'                    => DateTest::createData('2020-08-01 24:00:00', 'Y-m-d H\\:i\\:s'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.date.mustBeDate',
                 'expectedErrorParameters' => ['Y-m-d H\\:i\\:s']
             ],
             // time validations
             'time correct' => [
-                'data'                    => $this->createData('12:00:00', 'H\\:i\\:s'),
+                'data'                    => DateTest::createData('12:00:00', 'H\\:i\\:s'),
                 'expectedIsValid'         => true
             ],
             'time wrong' => [
-                'data'                    => $this->createData('24:00:00', 'H\\:i\\:s'),
+                'data'                    => DateTest::createData('24:00:00', 'H\\:i\\:s'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.date.mustBeDate',
                 'expectedErrorParameters' => ['H\\:i\\:s']
             ],
             // other
             'string too short' => [
-                'data'                    => $this->createData('abcd'),
+                'data'                    => DateTest::createData('abcd'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.date.mustBeDate',
                 'expectedErrorParameters' => ['Y-m-d']
             ],
             'Null byte' => [
-                'data'                    => $this->createData("\0"),
+                'data'                    => DateTest::createData("\0"),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.date.mustBeDate',
                 'expectedErrorParameters' => ['Y-m-d']
             ],
             'Null' => [
-                'data'                    => $this->createData(null),
+                'data'                    => DateTest::createData(null),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.date.mustBeDate',
                 'expectedErrorParameters' => ['Y-m-d']
             ],
             'empty string' => [
-                'data'                    => $this->createData(""),
+                'data'                    => DateTest::createData(""),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.date.mustBeDate',
                 'expectedErrorParameters' => ['Y-m-d']
@@ -108,7 +108,7 @@ class DateTest extends TestCase
      * @param string $parameter
      * @return stdClass
      */
-    private function createData(?string $value, string $parameter = 'Y-m-d'): stdClass
+    private static function createData(?string $value, string $parameter = 'Y-m-d'): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/DomainTest.php
+++ b/tests/libraries/ilch/Validation/Validators/DomainTest.php
@@ -40,135 +40,135 @@ class DomainTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             'valid domain with subdomain, hostname' => [
-                'data'                    => $this->createData('www.ilch.de', true),
+                'data'                    => DomainTest::createData('www.ilch.de', true),
                 'expectedIsValid'         => true
             ],
             'valid domain, hostname' => [
-                'data'                    => $this->createData('ilch.de', true),
+                'data'                    => DomainTest::createData('ilch.de', true),
                 'expectedIsValid'         => true
             ],
             'valid domain, ip address, hostname' => [
-                'data'                    => $this->createData('127.0.0.1', true),
+                'data'                    => DomainTest::createData('127.0.0.1', true),
                 'expectedIsValid'         => true
             ],
             'valid domain (longest domain), hostname' => [
-                'data'                    => $this->createData('www.thelongestdomainnameintheworldandthensomeandthensomemoreandmore.com', true),
+                'data'                    => DomainTest::createData('www.thelongestdomainnameintheworldandthensomeandthensomemoreandmore.com', true),
                 'expectedIsValid'         => true
             ],
             'invalid too long domain (toolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolong.com), hostname' => [
-                'data'                    => $this->createData('toolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolong.com', true),
+                'data'                    => DomainTest::createData('toolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolongtoolong.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'invalid too long domain (random), hostname' => [
-                'data'                    => $this->createData('eauBcFReEmjLcoZwI0RuONNnwU4H9r151juCaqTI5VeIP5jcYIqhx1lh5vV00l2rTs6y7hOp7rYw42QZiq6VIzjcYrRm8gFRMk9U9Wi1grL8Mr5kLVloYLthHgyA94QK3SaXCATklxgo6XvcbXIqAGG7U0KxTr8hJJU1p2ZQ2mXHmp4DhYP8N9SRuEKzaCPcSIcW7uj21jZqBigsLsNAXEzU8SPXZjmVQVtwQATPWeWyGW4GuJhjP4Q8o0.com', true),
+                'data'                    => DomainTest::createData('eauBcFReEmjLcoZwI0RuONNnwU4H9r151juCaqTI5VeIP5jcYIqhx1lh5vV00l2rTs6y7hOp7rYw42QZiq6VIzjcYrRm8gFRMk9U9Wi1grL8Mr5kLVloYLthHgyA94QK3SaXCATklxgo6XvcbXIqAGG7U0KxTr8hJJU1p2ZQ2mXHmp4DhYP8N9SRuEKzaCPcSIcW7uj21jZqBigsLsNAXEzU8SPXZjmVQVtwQATPWeWyGW4GuJhjP4Q8o0.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'valid domain (random, trailing dot), hostname' => [
-                'data'                    => $this->createData('kDTvHt1PPDgX5EiP2MwiXjcoWNOhhTuOVAUWJ3TmpBYCC9QoJV114LMYrV3Zl58.kDTvHt1PPDgX5EiP2MwiXjcoWNOhhTuOVAUWJ3TmpBYCC9QoJV114LMYrV3Zl58.kDTvHt1PPDgX5EiP2MwiXjcoWNOhhTuOVAUWJ3TmpBYCC9QoJV114LMYrV3Zl58.CQ1oT5Uq3jJt6Uhy3VH9u3Gi5YhfZCvZVKgLlaXNFhVKB1zJxvunR7SJa.com.', true),
+                'data'                    => DomainTest::createData('kDTvHt1PPDgX5EiP2MwiXjcoWNOhhTuOVAUWJ3TmpBYCC9QoJV114LMYrV3Zl58.kDTvHt1PPDgX5EiP2MwiXjcoWNOhhTuOVAUWJ3TmpBYCC9QoJV114LMYrV3Zl58.kDTvHt1PPDgX5EiP2MwiXjcoWNOhhTuOVAUWJ3TmpBYCC9QoJV114LMYrV3Zl58.CQ1oT5Uq3jJt6Uhy3VH9u3Gi5YhfZCvZVKgLlaXNFhVKB1zJxvunR7SJa.com.', true),
                 'expectedIsValid'         => true
             ],
             'valid domain (cont-ains.h-yph-en-s.com), hostname' => [
-                'data'                    => $this->createData('cont-ains.h-yph-en-s.com', true),
+                'data'                    => DomainTest::createData('cont-ains.h-yph-en-s.com', true),
                 'expectedIsValid'         => true
             ],
             'invalid domain (..com), hostname' => [
-                'data'                    => $this->createData('..com', true),
+                'data'                    => DomainTest::createData('..com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'invalid domain (ab..cc.dd), hostname' => [
-                'data'                    => $this->createData('ab..cc.dd', true),
+                'data'                    => DomainTest::createData('ab..cc.dd', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'invalid domain (a.-bc.com), hostname' => [
-                'data'                    => $this->createData('a.-bc.com', true),
+                'data'                    => DomainTest::createData('a.-bc.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'invalid domain (ab.cd-.com), hostname' => [
-                'data'                    => $this->createData('ab.cd-.com', true),
+                'data'                    => DomainTest::createData('ab.cd-.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'invalid domain (-.abc.com), hostname' => [
-                'data'                    => $this->createData('-.abc.com', true),
+                'data'                    => DomainTest::createData('-.abc.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'invalid domain (abc.-.abc.com), hostname' => [
-                'data'                    => $this->createData('abc.-.abc.com', true),
+                'data'                    => DomainTest::createData('abc.-.abc.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'invalid domain (underscore_.example.com), hostname' => [
-                'data'                    => $this->createData('underscore_.example.com', true),
+                'data'                    => DomainTest::createData('underscore_.example.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'invalid domain (-1), hostname' => [
-                'data'                    => $this->createData('-1', true),
+                'data'                    => DomainTest::createData('-1', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'valid domain (_example.com)' => [
-                'data'                    => $this->createData('_example.com'),
+                'data'                    => DomainTest::createData('_example.com'),
                 'expectedIsValid'         => true
             ],
             'invalid domain (_example.com), hostname' => [
-                'data'                    => $this->createData('_example.com', true),
+                'data'                    => DomainTest::createData('_example.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'valid domain (test_.example.com)' => [
-                'data'                    => $this->createData('test_.example.com'),
+                'data'                    => DomainTest::createData('test_.example.com'),
                 'expectedIsValid'         => true
             ],
             'invalid domain (test_.example.com), hostname' => [
-                'data'                    => $this->createData('test_.example.com', true),
+                'data'                    => DomainTest::createData('test_.example.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'valid domain (te_st.example.com)' => [
-                'data'                    => $this->createData('te_st.example.com'),
+                'data'                    => DomainTest::createData('te_st.example.com'),
                 'expectedIsValid'         => true
             ],
             'invalid domain (te_st.example.com), hostname' => [
-                'data'                    => $this->createData('te_st.example.com', true),
+                'data'                    => DomainTest::createData('te_st.example.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'valid domain (test._example.com)' => [
-                'data'                    => $this->createData('test._example.com'),
+                'data'                    => DomainTest::createData('test._example.com'),
                 'expectedIsValid'         => true
             ],
             'invalid domain (test._example.com), hostname' => [
-                'data'                    => $this->createData('test._example.com', true),
+                'data'                    => DomainTest::createData('test._example.com', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.domain.noValidDomain',
                 'expectedErrorParameters' => []
             ],
             'empty string, hostname' => [
-                'data'                    => $this->createData('', true),
+                'data'                    => DomainTest::createData('', true),
                 'expectedIsValid'         => true
             ],
         ];
@@ -181,7 +181,7 @@ class DomainTest extends TestCase
      * @param bool $validateAsHostname
      * @return stdClass
      */
-    private function createData(string $value, bool $validateAsHostname = false): stdClass
+    private static function createData(string $value, bool $validateAsHostname = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/EmailTest.php
+++ b/tests/libraries/ilch/Validation/Validators/EmailTest.php
@@ -37,44 +37,44 @@ class EmailTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             // email validations
             'email valid' => [
-                'data'                    => $this->createData('test@test.de'),
+                'data'                    => EmailTest::createData('test@test.de'),
                 'expectedIsValid'         => true
             ],
             'empty email valid' => [
-                'data'                    => $this->createData(''),
+                'data'                    => EmailTest::createData(''),
                 'expectedIsValid'         => true
             ],
             'email invalid' => [
-                'data'                    => $this->createData('test'),
+                'data'                    => EmailTest::createData('test'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
                 'expectedErrorParameters' => []
             ],
             'email invalid missing domain' => [
-                'data'                    => $this->createData('test@'),
+                'data'                    => EmailTest::createData('test@'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
                 'expectedErrorParameters' => []
             ],
             'email invalid missing name' => [
-                'data'                    => $this->createData('@test.de'),
+                'data'                    => EmailTest::createData('@test.de'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
                 'expectedErrorParameters' => []
             ],
             'email invalid space as name and domain' => [
-                'data'                    => $this->createData(' @ '),
+                'data'                    => EmailTest::createData(' @ '),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
                 'expectedErrorParameters' => []
             ],
             'email invalid domain invalid' => [
-                'data'                    => $this->createData(' @.de'),
+                'data'                    => EmailTest::createData(' @.de'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.email.noValidEmail',
                 'expectedErrorParameters' => []
@@ -88,7 +88,7 @@ class EmailTest extends TestCase
      * @param string $value
      * @return stdClass
      */
-    private function createData(string $value): stdClass
+    private static function createData(string $value): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/ExistsTest.php
+++ b/tests/libraries/ilch/Validation/Validators/ExistsTest.php
@@ -63,60 +63,60 @@ class ExistsTest extends DatabaseTestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             'existing table, column and value' => [
-                'data'                    => $this->createData(['groups', 'id'], '1'),
+                'data'                    => ExistsTest::createData(['groups', 'id'], '1'),
                 'expectedIsValid'         => true
             ],
             'existing table and column' => [
-                'data'                    => $this->createData(['groups', 'id']),
+                'data'                    => ExistsTest::createData(['groups', 'id']),
                 'expectedIsValid'         => true
             ],
             'existing table, other column' => [
-                'data'                    => $this->createData(['groups', 'name']),
+                'data'                    => ExistsTest::createData(['groups', 'name']),
                 'expectedIsValid'         => true
             ],
             'existing table, other column and value' => [
-                'data'                    => $this->createData(['groups', 'name'], 'admin'),
+                'data'                    => ExistsTest::createData(['groups', 'name'], 'admin'),
                 'expectedIsValid'         => true
             ],
             'existing table, two columns' => [
-                'data'                    => $this->createData(['groups', 'name', 'id']),
+                'data'                    => ExistsTest::createData(['groups', 'name', 'id']),
                 'expectedIsValid'         => true
             ],
             'existing table, other column and wrong value' => [
-                'data'                    => $this->createData(['groups', 'name'], 'star'),
+                'data'                    => ExistsTest::createData(['groups', 'name'], 'star'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.exists.resourceNotFound',
                 'expectedErrorParameters' => []
             ],
             'existing table, column wrong value' => [
-                'data'                    => $this->createData(['groups', 'id'], '3'),
+                'data'                    => ExistsTest::createData(['groups', 'id'], '3'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.exists.resourceNotFound',
                 'expectedErrorParameters' => []
             ],
             // Returns true for a not existing column?
             'existing table wrong column' => [
-                'data'                    => $this->createData(['groups', 'abc']),
+                'data'                    => ExistsTest::createData(['groups', 'abc']),
                 'expectedIsValid'         => true
             ],
             //  MySQL Error: Unknown column 'abc' in 'field list'
 //            'existing table wrong column with value' => [
-//                'data'                    => $this->createData(['groups', 'abc'], '1'),
+//                'data'                    => ExistsTest::createData(['groups', 'abc'], '1'),
 //                'expectedIsValid'         => false,
 //                'expectedErrorKey'        => 'validation.errors.exists.resourceNotFound',
 //                'expectedErrorParameters' => []
 //            ],
             // Returns true for a not existing table?
             'wrong table' => [
-                'data'                    => $this->createData(['abc']),
+                'data'                    => ExistsTest::createData(['abc']),
                 'expectedIsValid'         => true
             ],
             'wrong table inverted' => [
-                'data'                    => $this->createData(['abc'], null, true),
+                'data'                    => ExistsTest::createData(['abc'], null, true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.exists.resourceNotFound',
                 'expectedErrorParameters' => []
@@ -132,7 +132,7 @@ class ExistsTest extends DatabaseTestCase
      * @param bool $invertResult
      * @return stdClass
      */
-    private function createData(array $parameter = [], ?string $value = null, bool $invertResult = false): stdClass
+    private static function createData(array $parameter = [], ?string $value = null, bool $invertResult = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/IntegerTest.php
+++ b/tests/libraries/ilch/Validation/Validators/IntegerTest.php
@@ -37,35 +37,35 @@ class IntegerTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             'valid integer' => [
-                'data'                    => $this->createData(1),
+                'data'                    => IntegerTest::createData(1),
                 'expectedIsValid'         => true
             ],
             'valid integer string' => [
-                'data'                    => $this->createData('1'),
+                'data'                    => IntegerTest::createData('1'),
                 'expectedIsValid'         => true
             ],
             'valid integer empty' => [
-                'data'                    => $this->createData(''),
+                'data'                    => IntegerTest::createData(''),
                 'expectedIsValid'         => true
             ],
             'invalid integer' => [
-                'data'                    => $this->createData(1.5),
+                'data'                    => IntegerTest::createData(1.5),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.integer.mustBeInteger',
                 'expectedErrorParameters' => []
             ],
             'invalid integer string' => [
-                'data'                    => $this->createData('1.5'),
+                'data'                    => IntegerTest::createData('1.5'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.integer.mustBeInteger',
                 'expectedErrorParameters' => []
             ],
             'invalid integer invert' => [
-                'data'                    => $this->createData(1.5, true),
+                'data'                    => IntegerTest::createData(1.5, true),
                 'expectedIsValid'         => true
             ],
         ];
@@ -78,7 +78,7 @@ class IntegerTest extends TestCase
      * @param bool $invertResult
      * @return stdClass
      */
-    private function createData($value, bool $invertResult = false): stdClass
+    private static function createData($value, bool $invertResult = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/MaxTest.php
+++ b/tests/libraries/ilch/Validation/Validators/MaxTest.php
@@ -37,52 +37,52 @@ class MaxTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             // string validations
             'string correct'                    => [
-                'data'                    => $this->createData('abcde', 5),
+                'data'                    => MaxTest::createData('abcde', 5),
                 'expectedIsValid'         => true
             ],
             'string too short'                  => [
-                'data'                    => $this->createData('abcdef', 5),
+                'data'                    => MaxTest::createData('abcdef', 5),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.max.string',
                 'expectedErrorParameters' => [5]
             ],
             'number string as string correct'   => [
-                'data'                    => $this->createData('12345', 5, true),
+                'data'                    => MaxTest::createData('12345', 5, true),
                 'expectedIsValid'         => true
             ],
             'number string as string too short' => [
-                'data'                    => $this->createData('123456', 5, true),
+                'data'                    => MaxTest::createData('123456', 5, true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.max.string',
                 'expectedErrorParameters' => [5]
             ],
             // numeric
             'number (int) correct'              => [
-                'data'                    => $this->createData(5, 5),
+                'data'                    => MaxTest::createData(5, 5),
                 'expectedIsValid'         => true
             ],
             'number string correct'             => [
-                'data'                    => $this->createData('5', 5),
+                'data'                    => MaxTest::createData('5', 5),
                 'expectedIsValid'         => true
             ],
             'number too low'                    => [
-                'data'                    => $this->createData('6', 5),
+                'data'                    => MaxTest::createData('6', 5),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.max.numeric',
                 'expectedErrorParameters' => [5]
             ],
             //array
             'array correct'                     => [
-                'data'                    => $this->createData([1, 2, 3], 3),
+                'data'                    => MaxTest::createData([1, 2, 3], 3),
                 'expectedIsValid'         => true
             ],
             'array too small'                   => [
-                'data'                    => $this->createData([1, 2, 3], 4),
+                'data'                    => MaxTest::createData([1, 2, 3], 4),
                 'expectedIsValid'         => true,
                 'expectedErrorKey'        => 'validation.errors.max.array',
                 'expectedErrorParameters' => [4]
@@ -98,7 +98,7 @@ class MaxTest extends TestCase
      * @param bool $forceString
      * @return stdClass
      */
-    private function createData($value, int $max, bool $forceString = false): stdClass
+    private static function createData($value, int $max, bool $forceString = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/MinTest.php
+++ b/tests/libraries/ilch/Validation/Validators/MinTest.php
@@ -37,56 +37,56 @@ class MinTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             // string validations
             'string correct'              => [
-                'data'                    => $this->createData('abcdef', 5),
+                'data'                    => MinTest::createData('abcdef', 5),
                 'expectedIsValid'         => true
             ],
             'string too short'            => [
-                'data'                    => $this->createData('abcd', 5),
+                'data'                    => MinTest::createData('abcd', 5),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.min.string',
                 'expectedErrorParameters' => [5]
             ],
             'number string as string correct' => [
-                'data'                    => $this->createData('12345', 5, true),
+                'data'                    => MinTest::createData('12345', 5, true),
                 'expectedIsValid'         => true
             ],
             'number string as string too short' => [
-                'data'                    => $this->createData('1234', 5, true),
+                'data'                    => MinTest::createData('1234', 5, true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.min.string',
                 'expectedErrorParameters' => [5]
             ],
             // numeric
             'number (int) correct'        => [
-                'data'                    => $this->createData(5, 5),
+                'data'                    => MinTest::createData(5, 5),
                 'expectedIsValid'         => true
             ],
             'number string correct'       => [
-                'data'                    => $this->createData('5', 5),
+                'data'                    => MinTest::createData('5', 5),
                 'expectedIsValid'         => true
             ],
             'number too low'              => [
-                'data'                    => $this->createData('4', 5),
+                'data'                    => MinTest::createData('4', 5),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.min.numeric',
                 'expectedErrorParameters' => [5]
             ],
             //array
             'array correct'               => [
-                'data'                    => $this->createData([1, 2, 3], 3),
+                'data'                    => MinTest::createData([1, 2, 3], 3),
                 'expectedIsValid'         => true
             ],
             'array bigger than needed'    => [
-                'data'                    => $this->createData([1, 2, 3], 2),
+                'data'                    => MinTest::createData([1, 2, 3], 2),
                 'expectedIsValid'         => true
             ],
             'array too small'             => [
-                'data'                    => $this->createData([1, 2], 3),
+                'data'                    => MinTest::createData([1, 2], 3),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.min.array',
                 'expectedErrorParameters' => [3]
@@ -102,7 +102,7 @@ class MinTest extends TestCase
      * @param bool $forceString
      * @return stdClass
      */
-    private function createData($value, int $min, bool $forceString = false): stdClass
+    private static function createData($value, int $min, bool $forceString = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/NumericTest.php
+++ b/tests/libraries/ilch/Validation/Validators/NumericTest.php
@@ -37,43 +37,43 @@ class NumericTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             'valid numeric' => [
-                'data'                    => $this->createData(1),
+                'data'                    => NumericTest::createData(1),
                 'expectedIsValid'         => true
             ],
             'valid numeric string' => [
-                'data'                    => $this->createData('1'),
+                'data'                    => NumericTest::createData('1'),
                 'expectedIsValid'         => true
             ],
             'valid numeric empty' => [
-                'data'                    => $this->createData(''),
+                'data'                    => NumericTest::createData(''),
                 'expectedIsValid'         => true
             ],
             'valid numeric float' => [
-                'data'                    => $this->createData(1.5),
+                'data'                    => NumericTest::createData(1.5),
                 'expectedIsValid'         => true
             ],
             'valid numeric float string' => [
-                'data'                    => $this->createData('1.5'),
+                'data'                    => NumericTest::createData('1.5'),
                 'expectedIsValid'         => true
             ],
             'invalid numeric string' => [
-                'data'                    => $this->createData('a'),
+                'data'                    => NumericTest::createData('a'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.numeric.mustBeNumeric',
                 'expectedErrorParameters' => []
             ],
             'valid numeric invert' => [
-                'data'                    => $this->createData(1.5, true),
+                'data'                    => NumericTest::createData(1.5, true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.numeric.mustBeNumeric',
                 'expectedErrorParameters' => []
             ],
             'invalid numeric invert' => [
-                'data'                    => $this->createData('a', true),
+                'data'                    => NumericTest::createData('a', true),
                 'expectedIsValid'         => true
             ],
         ];
@@ -86,7 +86,7 @@ class NumericTest extends TestCase
      * @param bool $invertResult
      * @return stdClass
      */
-    private function createData($value, bool $invertResult = false): stdClass
+    private static function createData($value, bool $invertResult = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/RequiredTest.php
+++ b/tests/libraries/ilch/Validation/Validators/RequiredTest.php
@@ -37,21 +37,21 @@ class RequiredTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             'valid' => [
-                'data'                    => $this->createData('test'),
+                'data'                    => RequiredTest::createData('test'),
                 'expectedIsValid'         => true
             ],
             'invalid' => [
-                'data'                    => $this->createData(''),
+                'data'                    => RequiredTest::createData(''),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.required.fieldIsRequired',
                 'expectedErrorParameters' => []
             ],
             'invalid inverted' => [
-                'data'                    => $this->createData('', true),
+                'data'                    => RequiredTest::createData('', true),
                 'expectedIsValid'         => true
             ]
         ];
@@ -64,7 +64,7 @@ class RequiredTest extends TestCase
      * @param bool $invertResult
      * @return stdClass
      */
-    private function createData($value, bool $invertResult = false): stdClass
+    private static function createData($value, bool $invertResult = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/SameTest.php
+++ b/tests/libraries/ilch/Validation/Validators/SameTest.php
@@ -37,27 +37,27 @@ class SameTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             'passwords are the same' => [
-                'data'                    => $this->createData('password', 'god', 'password_confirm', 'god'),
+                'data'                    => SameTest::createData('password', 'god', 'password_confirm', 'god'),
                 'expectedIsValid'         => true
             ],
             'password are not the same' => [
-                'data'                    => $this->createData('password', '123', 'password_confirm', 'god'),
+                'data'                    => SameTest::createData('password', '123', 'password_confirm', 'god'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.same.fieldsDontMatch',
                 'expectedErrorParameters' => ['password_confirm']
             ],
             'strict comparison' => [
-                'data'                    => $this->createData('password', '123', 'password_confirm', 123, true),
+                'data'                    => SameTest::createData('password', '123', 'password_confirm', 123, true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.same.fieldsDontMatch',
                 'expectedErrorParameters' => ['password_confirm']
             ],
             'passwords are the same inverted' => [
-                'data'                    => $this->createData('password', 'god', 'password_confirm', 'god', null, true),
+                'data'                    => SameTest::createData('password', 'god', 'password_confirm', 'god', null, true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.same.fieldsDontMatch',
                 'expectedErrorParameters' => ['password_confirm']
@@ -76,7 +76,7 @@ class SameTest extends TestCase
      * @param bool $invertResult
      * @return stdClass
      */
-    private function createData(string $firstField, $valueFirstField, string $secondField, $valueSecondField, ?bool $strict = null, bool $invertResult = false): stdClass
+    private static function createData(string $firstField, $valueFirstField, string $secondField, $valueSecondField, ?bool $strict = null, bool $invertResult = false): stdClass
     {
         $data = new stdClass();
         $data->field = $firstField;

--- a/tests/libraries/ilch/Validation/Validators/SizeTest.php
+++ b/tests/libraries/ilch/Validation/Validators/SizeTest.php
@@ -37,64 +37,64 @@ class SizeTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             // numeric
             'valid' => [
-                'data'                    => $this->createData(3, 3),
+                'data'                    => SizeTest::createData(3, 3),
                 'expectedIsValid'         => true
             ],
             'invalid' => [
-                'data'                    => $this->createData(3, 2),
+                'data'                    => SizeTest::createData(3, 2),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.size.numeric',
                 'expectedErrorParameters' => [2]
             ],
             // array
             'array valid' => [
-                'data'                    => $this->createData(['a', 'b', 'c'], 3),
+                'data'                    => SizeTest::createData(['a', 'b', 'c'], 3),
                 'expectedIsValid'         => true
             ],
             'array invalid' => [
-                'data'                    => $this->createData(['a', 'b', 'c'], 2),
+                'data'                    => SizeTest::createData(['a', 'b', 'c'], 2),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.size.array',
                 'expectedErrorParameters' => [2]
             ],
             'array empty invalid' => [
-                'data'                    => $this->createData([], 2),
+                'data'                    => SizeTest::createData([], 2),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.size.array',
                 'expectedErrorParameters' => [2]
             ],
             // string
             'string valid' => [
-                'data'                    => $this->createData('abc', 3),
+                'data'                    => SizeTest::createData('abc', 3),
                 'expectedIsValid'         => true
             ],
             'numeric string valid' => [
-                'data'                    => $this->createData('123', 3, true),
+                'data'                    => SizeTest::createData('123', 3, true),
                 'expectedIsValid'         => true
             ],
             'numeric string invalid force string false' => [
-                'data'                    => $this->createData('123', 3),
+                'data'                    => SizeTest::createData('123', 3),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.size.numeric',
                 'expectedErrorParameters' => [3]
             ],
             'numeric string valid force string false' => [
-                'data'                    => $this->createData('123', 123),
+                'data'                    => SizeTest::createData('123', 123),
                 'expectedIsValid'         => true
             ],
             'string invalid' => [
-                'data'                    => $this->createData('abc', 2),
+                'data'                    => SizeTest::createData('abc', 2),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.size.string',
                 'expectedErrorParameters' => [2]
             ],
 //            'string empty invalid' => [
-//                'data'                    => $this->createData('', 2),
+//                'data'                    => SizeTest::createData('', 2),
 //                'expectedIsValid'         => false,
 //                'expectedErrorKey'        => 'validation.errors.size.string',
 //                'expectedErrorParameters' => [2]
@@ -110,7 +110,7 @@ class SizeTest extends TestCase
      * @param bool $forceString
      * @return stdClass
      */
-    private function createData($value, int $size, bool $forceString = false): stdClass
+    private static function createData($value, int $size, bool $forceString = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/TimezoneTest.php
+++ b/tests/libraries/ilch/Validation/Validators/TimezoneTest.php
@@ -37,36 +37,36 @@ class TimezoneTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             // timezone validations
             'timezone valid' => [
-                'data'                    => $this->createData('Europe/Berlin'),
+                'data'                    => TimezoneTest::createData('Europe/Berlin'),
                 'expectedIsValid'         => true
             ],
             'timezone valid including outdated' => [
-                'data'                    => $this->createData('America/Shiprock', true),
+                'data'                    => TimezoneTest::createData('America/Shiprock', true),
                 'expectedIsValid'         => true
             ],
             'empty timezone valid' => [
-                'data'                    => $this->createData(''),
+                'data'                    => TimezoneTest::createData(''),
                 'expectedIsValid'         => true
             ],
             'timezone invalid' => [
-                'data'                    => $this->createData('test'),
+                'data'                    => TimezoneTest::createData('test'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.timezone.notAValidTimezone',
                 'expectedErrorParameters' => []
             ],
             'timezone invalid completely removed' => [
-                'data'                    => $this->createData('Canada/East-Saskatchewan'),
+                'data'                    => TimezoneTest::createData('Canada/East-Saskatchewan'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.timezone.notAValidTimezone',
                 'expectedErrorParameters' => []
             ],
             'timezone invalid outdated' => [
-                'data'                    => $this->createData('America/Shiprock'),
+                'data'                    => TimezoneTest::createData('America/Shiprock'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.timezone.notAValidTimezone',
                 'expectedErrorParameters' => []
@@ -80,7 +80,7 @@ class TimezoneTest extends TestCase
      * @param string $value
      * @return stdClass
      */
-    private function createData(string $value, bool $includeOutdated = false): stdClass
+    private static function createData(string $value, bool $includeOutdated = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/Validation/Validators/UniqueTest.php
+++ b/tests/libraries/ilch/Validation/Validators/UniqueTest.php
@@ -63,31 +63,31 @@ class UniqueTest extends DatabaseTestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             'unique value for name' => [
-                'data'                    => $this->createData(['groups'], 'moderator'),
+                'data'                    => UniqueTest::createData(['groups'], 'moderator'),
                 'expectedIsValid'         => true
             ],
             'existing value for name ignored' => [
-                'data'                    => $this->createData(['groups', 'name', 1], 'admin'),
+                'data'                    => UniqueTest::createData(['groups', 'name', 1], 'admin'),
                 'expectedIsValid'         => true
             ],
             'existing value for name ignore different id' => [
-                'data'                    => $this->createData(['groups', 'name', 2], 'admin'),
+                'data'                    => UniqueTest::createData(['groups', 'name', 2], 'admin'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.unique.valueExists',
                 'expectedErrorParameters' => ['admin']
             ],
             'existing value for name' => [
-                'data'                    => $this->createData(['groups'], 'admin'),
+                'data'                    => UniqueTest::createData(['groups'], 'admin'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.unique.valueExists',
                 'expectedErrorParameters' => ['admin']
             ],
             'unique value for name inverted' => [
-                'data'                    => $this->createData(['groups'], 'moderator', true),
+                'data'                    => UniqueTest::createData(['groups'], 'moderator', true),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.unique.valueExists',
                 'expectedErrorParameters' => ['moderator']
@@ -103,7 +103,7 @@ class UniqueTest extends DatabaseTestCase
      * @param bool $invertResult
      * @return stdClass
      */
-    private function createData(array $parameter = [], ?string $value = null, bool $invertResult = false): stdClass
+    private static function createData(array $parameter = [], ?string $value = null, bool $invertResult = false): stdClass
     {
         $data = new stdClass();
         $data->field = 'name';

--- a/tests/libraries/ilch/Validation/Validators/UrlTest.php
+++ b/tests/libraries/ilch/Validation/Validators/UrlTest.php
@@ -37,43 +37,43 @@ class UrlTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidator(): array
+    public static function dpForTestValidator(): array
     {
         return [
             'valid url domain with subdomain and protocol' => [
-                'data'                    => $this->createData('https://www.ilch.de'),
+                'data'                    => UrlTest::createData('https://www.ilch.de'),
                 'expectedIsValid'         => true
             ],
             'valid url domain with subdomain and ftp protocol' => [
-                'data'                    => $this->createData('ftp://www.ilch.de'),
+                'data'                    => UrlTest::createData('ftp://www.ilch.de'),
                 'expectedIsValid'         => true
             ],
             'invalid url domain with subdomain and invalid protocol' => [
-                'data'                    => $this->createData('invalid://www.ilch.de'),
+                'data'                    => UrlTest::createData('invalid://www.ilch.de'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.url.noValidUrl',
                 'expectedErrorParameters' => []
             ],
             'invalid url no protocol' => [
-                'data'                    => $this->createData('ilch.de'),
+                'data'                    => UrlTest::createData('ilch.de'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.url.noValidUrl',
                 'expectedErrorParameters' => []
             ],
             'invalid url domain with subdomain no protocol' => [
-                'data'                    => $this->createData('www.ilch.de'),
+                'data'                    => UrlTest::createData('www.ilch.de'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.url.noValidUrl',
                 'expectedErrorParameters' => []
             ],
             'invalid url no domain' => [
-                'data'                    => $this->createData('ilch'),
+                'data'                    => UrlTest::createData('ilch'),
                 'expectedIsValid'         => false,
                 'expectedErrorKey'        => 'validation.errors.url.noValidUrl',
                 'expectedErrorParameters' => []
             ],
             'empty string' => [
-                'data'                    => $this->createData(''),
+                'data'                    => UrlTest::createData(''),
                 'expectedIsValid'         => true
             ],
         ];
@@ -85,7 +85,7 @@ class UrlTest extends TestCase
      * @param string $value
      * @return stdClass
      */
-    private function createData(string $value): stdClass
+    private static function createData(string $value): stdClass
     {
         $data = new stdClass();
         $data->field = 'fieldName';

--- a/tests/libraries/ilch/ValidationTest.php
+++ b/tests/libraries/ilch/ValidationTest.php
@@ -52,7 +52,7 @@ class ValidationTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidationWithSingleValidator(): array
+    public static function dpForTestValidationWithSingleValidator(): array
     {
         return [
             'int'                            => ['params' => ['testField' => 5], 'expected' => true, 'inverted' => false],
@@ -90,7 +90,7 @@ class ValidationTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidationWithValidatorChainBreakingChain(): array
+    public static function dpForTestValidationWithValidatorChainBreakingChain(): array
     {
         return [
             '2 validators chained - correct'       => [
@@ -162,7 +162,7 @@ class ValidationTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidationWithValidatorChainWithoutBreakingChain(): array
+    public static function dpForTestValidationWithValidatorChainWithoutBreakingChain(): array
     {
         return [
             '2 validators chained - correct'       => [
@@ -230,7 +230,7 @@ class ValidationTest extends TestCase
     /**
      * @return array
      */
-    public function dpForTestValidationWithVariousValidators(): array
+    public static function dpForTestValidationWithVariousValidators(): array
     {
         // Excluding the validators Grecaptcha, Integer (not inverted; already covered above), Exists and Unique.
         return [


### PR DESCRIPTION
# Description
- Remove code no longer needed with PHP 8.1 and newer.
- Update CI workflow to no longer run PHP 7.4, but PHP 8.1 instead.
- Update PHP quality workflow to check based on PHP 8.1 and newer.
- Update composer platform to PHP 8.1.
- Update FontAwesome to version 7.3.0.
- Update PHPUnit to version 10.5.63.
- Update the debugbar to version 2.2.6 and switch to new official repository.
- PHPUnit 10: Fix "Data Provider is not static"
- PHPUnit 10: Fix "using $this when not in object context"
- PHPUnit 10: Fix "Providing invalid named argument"

PHPUnit is clearly not the latest version of it, but 10.5.63 is the newest one we can use while still supporting PHP 8.1.
Debugbar 2.2.6 is the newest version we can use while still supporting PHP 8.1.

The unit tests still trigger some PHP deprecations.

I plan to merge this after the release of Ilch 2.2.17 or after June 30th.

Fixes #972
#1334

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
