### PR TITLE
Fix errors on install when settings have been lost

### DIFF
--- a/application/modules/install/controllers/Index.php
+++ b/application/modules/install/controllers/Index.php
@@ -195,6 +195,11 @@ class Index extends \Ilch\Controller\Frontend
             $errors['phpVersion'] = true;
         }
 
+        if (empty($_SESSION['install'])) {
+            $this->addMessage($this->getTranslator()->trans('sessionResetInstallEmpty'), 'danger');
+            $this->redirect(['action' => 'index']);
+        }
+
         $hostParts = explode(':', $_SESSION['install']['dbHost']);
         $port = (!empty($hostParts[1])) ? $hostParts[1] : null;
         $dbLinkIdentifier = mysqli_connect($_SESSION['install']['dbHost'], $_SESSION['install']['dbUser'], $_SESSION['install']['dbPassword'], null, $port);
@@ -295,6 +300,11 @@ class Index extends \Ilch\Controller\Frontend
     public function databaseAction()
     {
         $fields = ['dbName' => '', 'dbPrefix' => 'ilch_'];
+
+        if (empty($_SESSION['install'])) {
+            $this->addMessage($this->getTranslator()->trans('sessionResetInstallEmpty'), 'danger');
+            $this->redirect(['action' => 'index']);
+        }
 
         $port = null;
         $hostParts = explode(':', $_SESSION['install']['dbHost']);

--- a/application/modules/install/translations/de.php
+++ b/application/modules/install/translations/de.php
@@ -75,4 +75,5 @@ return [
     'dependencyMessage' => 'Es wurden weitere Module ausgewählt, um Abhängigkeiten zu erfüllen.',
     'frontend' => 'Frontend',
     'administration' => 'Administration',
+    'sessionResetInstallEmpty' => 'Einstellungen sind verloren gegangen. Möglicherweise wurde z.B. der Webserver zwischenzeitlich neugestartet.'
 ];

--- a/application/modules/install/translations/en.php
+++ b/application/modules/install/translations/en.php
@@ -72,7 +72,8 @@ return [
     'optionalModules' => 'optionally modules',
     'private' => 'private site',
     'clan' => 'clan site',
-    'dependencyMessage' => 'Other modules were selected to fullfill dependencies.',
+    'dependencyMessage' => 'Other modules were selected to fulfill dependencies.',
     'frontend' => 'Frontend',
     'administration' => 'Administration',
+    'sessionResetInstallEmpty' => 'Settings have been lost. For example, the web server may have been restarted in the meantime.'
 ];


### PR DESCRIPTION
# Description
- Fix errors on install when settings have been lost. For example, the web server may have been restarted in the meantime.

```
PHP Warning:  Undefined array key "install" in application/modules/install/controllers/Index.php on line 198
PHP Warning:  Trying to access array offset on null in application/modules/install/controllers/Index.php on line 198
PHP Warning:  Undefined array key "install" in application/modules/install/controllers/Index.php on line 200
PHP Warning:  Trying to access array offset on null in application/modules/install/controllers/Index.php on line 200
PHP Warning:  Undefined array key "install" in application/modules/install/controllers/Index.php on line 300
PHP Warning:  Trying to access array offset on null in application/modules/install/controllers/Index.php on line 300
PHP Warning:  Undefined array key "install" in application/modules/install/controllers/Index.php on line 306
PHP Warning:  Trying to access array offset on null in application/modules/install/controllers/Index.php on line 306
```

Fixes #1432

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
