### PR TITLE
DefaultCaptcha: fix session key cleanup and compare case-insensitively

### DIFF
--- a/application/libraries/Captcha/DefaultCaptcha.php
+++ b/application/libraries/Captcha/DefaultCaptcha.php
@@ -98,8 +98,9 @@ class DefaultCaptcha
     {
         $result = false;
         if (isset($_SESSION[$sessionKey])) {
-            $result = ($token === $_SESSION[$sessionKey]);
-            unset($_SESSION['captcha']);
+            // The generated captcha text is always lowercase, so compare case-insensitively.
+            $result = (strcasecmp(trim($token), $_SESSION[$sessionKey]) === 0);
+            unset($_SESSION[$sessionKey]);
         }
         return $result;
     }


### PR DESCRIPTION
# Description
`DefaultCaptcha::checkCaptcha()` had two issues:

1. It unset the hardcoded session key `'captcha'` instead of the passed `$sessionKey`. When a captcha was stored under a custom session key, it was never invalidated after a successful check, so the same solution stayed valid for further submissions.
2. The comparison was case-sensitive. The generated captcha text is always lowercase, so users who typed the (correctly read) characters with uppercase letters were rejected. The entered token is now trimmed and compared with `strcasecmp()`.

Discovered while working with multiple captcha instances (each with its own session key) on one page.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [x] AI-assisted

If AI-assisted, briefly state:
- Tools used (e.g., GitHub Copilot, ChatGPT, Claude): Claude Code (Anthropic)
- What was generated by the tool (code, tests, docs, commit message, etc.): the code change, the commit message and this PR description were drafted by the tool
- Extent of AI use (single snippet, file, entire feature — approximate %): single small snippet, 3 changed lines in one file (~100% tool-drafted, human-reviewed)
- Verification steps performed (tests, manual review, security checks): manual browser testing (correct/incorrect input, mixed-case input accepted, re-submission after a successful check is rejected because the session key is now cleaned up), manual code review
- License/IP check performed for AI outputs (yes/no + short note): yes — trivial fix to existing GPL-3.0 code, no external code included

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
