### PR TITLE
QueryBuilder: fix call to non-existent addPart() in addWhere()

### DIFF
--- a/application/libraries/Ilch/Database/Mysql/QueryBuilder.php
+++ b/application/libraries/Ilch/Database/Mysql/QueryBuilder.php
@@ -180,7 +180,7 @@ abstract class QueryBuilder
             if (\is_array($where)) {
                 $this->where->addParts($this->createCompositePartArray($where));
             } elseif ($where instanceof Expression\CompositePart) {
-                $this->where->addPart($where);
+                $this->where->add($where);
             } else {
                 throw new \InvalidArgumentException('array or Expression\CompositePart expected');
             }


### PR DESCRIPTION
# Description
`QueryBuilder::addWhere()` calls `$this->where->addPart($where)` when an `Expression\CompositePart` is appended to an existing where condition of the same composite type. `Composite` has no method `addPart()` — it is named `add()` — so this code path always failed with a fatal error:

```
Uncaught Error: Call to undefined method Ilch\Database\Mysql\Expression\AndX::addPart()
```

How to reproduce:

```php
$select = $db->select('*')
    ->from('table')
    ->where(['foo' => 1]); // creates an AndX where condition

// appending a composite expression of the same type -> fatal error
$select->andWhere($select->orX(['a LIKE' => '%x%', 'b LIKE' => '%x%']));
```

`addPart()` has no other call site in the code base, so this is a one-line rename to the existing `Composite::add()`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [x] AI-assisted

If AI-assisted, briefly state:
- Tools used (e.g., GitHub Copilot, ChatGPT, Claude): Claude Code (Anthropic)
- What was generated by the tool (code, tests, docs, commit message, etc.): the tool found the bug while generating code that exercised this code path; the one-line fix, the commit message and this PR description were drafted by the tool
- Extent of AI use (single snippet, file, entire feature — approximate %): one changed line (~100% tool-drafted, human-reviewed)
- Verification steps performed (tests, manual review, security checks): executed the previously failing `andWhere(orX(...))` call against a live MySQL database — no fatal error anymore, generated SQL contains the expected parenthesized `WHERE (... OR ...)` group and the query returns correct results; verified `addPart()` has no other call sites
- License/IP check performed for AI outputs (yes/no + short note): yes — one-line fix to existing GPL-3.0 code, no external code included

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
