### PR TITLE
PHP Quality Checks workflow: don't fail when all changed files are excluded by phpcs.xml

### DIFF
--- a/.github/workflows/php-quality.yaml
+++ b/.github/workflows/php-quality.yaml
@@ -64,7 +64,18 @@ jobs:
         if: steps.changed.outputs.files != ''
         run: |
           echo "Running phpcs on: ${{ steps.changed.outputs.files }}"
-          phpcs -p --extensions=php ${{ steps.changed.outputs.files }}
+          # phpcs applies the exclude-patterns from phpcs.xml. If every changed
+          # file is excluded (e.g. bundled libraries like Captcha/Thumb or module
+          # views), it reports "No files were checked" and exits with code 16.
+          # Treat that case as success instead of failing the check.
+          phpcs -p --extensions=php ${{ steps.changed.outputs.files }} || {
+            ec=$?
+            if [ "$ec" -eq 16 ]; then
+              echo "All changed files are excluded by phpcs.xml - nothing to check."
+              exit 0
+            fi
+            exit $ec
+          }
 
       - name: Run PHPCompatibility (phpcs standard) on changed files
         if: steps.changed.outputs.files != ''


### PR DESCRIPTION
# Description
The "PHP Quality Checks (changed files)" workflow fails with a false negative when a PR only touches files that are excluded in `phpcs.xml` (e.g. the bundled `Captcha`/`Thumb` libraries, module views, fpdf).

phpcs applies the exclude-patterns from `phpcs.xml` even when files are passed explicitly on the command line. If every changed file of a PR is excluded, the effective file list is empty and phpcs aborts with `ERROR: No files were checked` and exit code 16, turning the check red although there was nothing to lint. Recent example: the run for #1441, where the only changed file was `application/libraries/Captcha/DefaultCaptcha.php`.

This PR makes the PHPCS step treat exit code 16 ("no files were checked") as success with an explanatory log message; every other non-zero exit code still fails the step. The PHPLint and PHPCompatibility steps are unaffected: they don't use the project ruleset, so the excludes don't apply to them.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [ ] No AI assistance used
- [x] AI-assisted

If AI-assisted, briefly state:
- Tools used (e.g., GitHub Copilot, ChatGPT, Claude): Claude Code
- What was generated by the tool (code, tests, docs, commit message, etc.): analysis of the failing workflow run, the workflow change, commit message and PR description
- Extent of AI use (single snippet, file, entire feature — approximate %): single step in one workflow file, ~100%
- Verification steps performed (tests, manual review, security checks): manual review; behaviour reproduces the documented phpcs exit code 16 for "No files were checked" as seen in the failed run for #1441
- License/IP check performed for AI outputs (yes/no + short note): yes — trivial shell snippet, no third-party code involved

# This PR has been tested in the following browsers:
Not applicable — CI workflow change only, no frontend impact.
