### PR TITLE
PHPCS: Only exclude josecl/cool-php-captcha

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,7 +10,7 @@
     <exclude-pattern>./modules/**/views/*.php</exclude-pattern>
     <exclude-pattern>./modules/shop/static/class/fpdf</exclude-pattern>
 
-    <exclude-pattern>./application/libraries/Captcha</exclude-pattern>
+    <exclude-pattern>./application/libraries/Captcha/Captcha.php</exclude-pattern>
     <exclude-pattern>./application/libraries/Thumb</exclude-pattern>
 
     <arg name="extensions" value="php" />


### PR DESCRIPTION
# Description
- Only exclude josecl/cool-php-captcha

The other two files ("DefaultCaptcha.php and GoogleCaptcha.php") are created by us.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used
