### PR TITLE
Shoutbox: Fehlende Einstellungen reparieren und Defaults anzeigen (Fix #1446)

### DIFF
--- a/application/modules/shoutbox/config/config.php
+++ b/application/modules/shoutbox/config/config.php
@@ -9,9 +9,35 @@ namespace Modules\Shoutbox\Config;
 
 class Config extends \Ilch\Config\Install
 {
+    /**
+     * Default values for all settings of the module. Used on install and to
+     * repair missing settings on update. The admincenter settings page falls
+     * back to these defaults for missing config values.
+     */
+    public const SETTINGS_DEFAULTS = [
+        'shoutbox_limit' => '5',
+        'shoutbox_messagesPerPageAdmincenter' => '20',
+        'shoutbox_messagesPerPage' => '20',
+        'shoutbox_maxtextlength' => '50',
+        'shoutbox_floodInterval' => '30',
+        'shoutbox_autoRefreshInterval' => '30',
+        'shoutbox_writeaccess' => '1,2',
+        'shoutbox_designBackgroundColor' => '',
+        'shoutbox_designTextColor' => '',
+        'shoutbox_designNameColor' => '',
+        'shoutbox_designBoxBackgroundColor' => '',
+        'shoutbox_designButtonColor' => '',
+        'shoutbox_designButtonTextColor' => '',
+        'shoutbox_designInputBackgroundColor' => '',
+        'shoutbox_designInputTextColor' => '',
+        'shoutbox_designFontSize' => '0',
+        'shoutbox_showAvatars' => '1',
+        'shoutbox_customCss' => '',
+    ];
+
     public $config = [
         'key' => 'shoutbox',
-        'version' => '1.8.0',
+        'version' => '1.8.1',
         'icon_small' => 'fa-solid fa-bullhorn',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -44,24 +70,9 @@ class Config extends \Ilch\Config\Install
         $this->db()->queryMulti($this->getInstallSql());
 
         $databaseConfig = new \Ilch\Config\Database($this->db());
-        $databaseConfig->set('shoutbox_limit', '5')
-            ->set('shoutbox_messagesPerPageAdmincenter', '20')
-            ->set('shoutbox_messagesPerPage', '20')
-            ->set('shoutbox_maxtextlength', '50')
-            ->set('shoutbox_floodInterval', '30')
-            ->set('shoutbox_autoRefreshInterval', '30')
-            ->set('shoutbox_writeaccess', '1,2')
-            ->set('shoutbox_designBackgroundColor', '')
-            ->set('shoutbox_designTextColor', '')
-            ->set('shoutbox_designNameColor', '')
-            ->set('shoutbox_designBoxBackgroundColor', '')
-            ->set('shoutbox_designButtonColor', '')
-            ->set('shoutbox_designButtonTextColor', '')
-            ->set('shoutbox_designInputBackgroundColor', '')
-            ->set('shoutbox_designInputTextColor', '')
-            ->set('shoutbox_designFontSize', '0')
-            ->set('shoutbox_showAvatars', '1')
-            ->set('shoutbox_customCss', '');
+        foreach (self::SETTINGS_DEFAULTS as $key => $value) {
+            $databaseConfig->set($key, $value);
+        }
     }
 
     public function uninstall()
@@ -69,24 +80,9 @@ class Config extends \Ilch\Config\Install
         $this->db()->drop('shoutbox', true);
 
         $databaseConfig = new \Ilch\Config\Database($this->db());
-        $databaseConfig->delete('shoutbox_limit')
-            ->delete('shoutbox_messagesPerPageAdmincenter')
-            ->delete('shoutbox_messagesPerPage')
-            ->delete('shoutbox_maxtextlength')
-            ->delete('shoutbox_floodInterval')
-            ->delete('shoutbox_autoRefreshInterval')
-            ->delete('shoutbox_writeaccess')
-            ->delete('shoutbox_designBackgroundColor')
-            ->delete('shoutbox_designTextColor')
-            ->delete('shoutbox_designNameColor')
-            ->delete('shoutbox_designBoxBackgroundColor')
-            ->delete('shoutbox_designButtonColor')
-            ->delete('shoutbox_designButtonTextColor')
-            ->delete('shoutbox_designInputBackgroundColor')
-            ->delete('shoutbox_designInputTextColor')
-            ->delete('shoutbox_designFontSize')
-            ->delete('shoutbox_showAvatars')
-            ->delete('shoutbox_customCss');
+        foreach (array_keys(self::SETTINGS_DEFAULTS) as $key) {
+            $databaseConfig->delete($key);
+        }
     }
 
     public function getInstallSql(): string
@@ -130,28 +126,18 @@ class Config extends \Ilch\Config\Install
             case "1.6.1":
             case "1.6.2":
             case "1.6.3":
-                // Add default values for new settings.
-                $databaseConfig = new \Ilch\Config\Database($this->db());
-                $databaseConfig->set('shoutbox_messagesPerPageAdmincenter', '20')
-                    ->set('shoutbox_messagesPerPage', '20');
-                // no break
             case "1.7.0":
             case "1.7.1":
-                // Add default values for the flood protection, auto refresh and design settings.
+            case "1.7.2":
+            case "1.8.0":
+                // Add default values for settings added in later versions.
+                // Only adds missing settings without overwriting existing values.
                 $databaseConfig = new \Ilch\Config\Database($this->db());
-                $databaseConfig->set('shoutbox_floodInterval', '30')
-                    ->set('shoutbox_autoRefreshInterval', '30')
-                    ->set('shoutbox_designBackgroundColor', '')
-                    ->set('shoutbox_designTextColor', '')
-                    ->set('shoutbox_designNameColor', '')
-                    ->set('shoutbox_designBoxBackgroundColor', '')
-                    ->set('shoutbox_designButtonColor', '')
-                    ->set('shoutbox_designButtonTextColor', '')
-                    ->set('shoutbox_designInputBackgroundColor', '')
-                    ->set('shoutbox_designInputTextColor', '')
-                    ->set('shoutbox_designFontSize', '0')
-                    ->set('shoutbox_showAvatars', '1')
-                    ->set('shoutbox_customCss', '');
+                foreach (self::SETTINGS_DEFAULTS as $key => $value) {
+                    if ($databaseConfig->get($key) === null) {
+                        $databaseConfig->set($key, $value);
+                    }
+                }
                 // no break
         }
 

--- a/application/modules/shoutbox/controllers/admin/Settings.php
+++ b/application/modules/shoutbox/controllers/admin/Settings.php
@@ -7,6 +7,7 @@
 
 namespace Modules\Shoutbox\Controllers\Admin;
 
+use Modules\Shoutbox\Config\Config as ShoutboxConfig;
 use Modules\Shoutbox\Libs\DesignCss;
 use Modules\User\Mappers\Group as UserGroupMapper;
 use Ilch\Validation;
@@ -101,25 +102,37 @@ class Settings extends \Ilch\Controller\Admin
                 ->to(['action' => 'index']);
         }
 
-        $this->getView()->set('limit', $this->getConfig()->get('shoutbox_limit'))
-            ->set('messagesPerPage', $this->getConfig()->get('shoutbox_messagesPerPage'))
-            ->set('messagesPerPageAdmincenter', $this->getConfig()->get('shoutbox_messagesPerPageAdmincenter'))
-            ->set('maxtextlength', $this->getConfig()->get('shoutbox_maxtextlength'))
-            ->set('floodInterval', $this->getConfig()->get('shoutbox_floodInterval'))
-            ->set('autoRefreshInterval', $this->getConfig()->get('shoutbox_autoRefreshInterval'))
+        $this->getView()->set('limit', $this->getConfigOrDefault('shoutbox_limit'))
+            ->set('messagesPerPage', $this->getConfigOrDefault('shoutbox_messagesPerPage'))
+            ->set('messagesPerPageAdmincenter', $this->getConfigOrDefault('shoutbox_messagesPerPageAdmincenter'))
+            ->set('maxtextlength', $this->getConfigOrDefault('shoutbox_maxtextlength'))
+            ->set('floodInterval', $this->getConfigOrDefault('shoutbox_floodInterval'))
+            ->set('autoRefreshInterval', $this->getConfigOrDefault('shoutbox_autoRefreshInterval'))
             ->set('userGroupList', $userGroupMapper->getGroupList())
-            ->set('writeAccess', $this->getConfig()->get('shoutbox_writeaccess'))
-            ->set('designBackgroundColor', (string)$this->getConfig()->get('shoutbox_designBackgroundColor'))
-            ->set('designTextColor', (string)$this->getConfig()->get('shoutbox_designTextColor'))
-            ->set('designNameColor', (string)$this->getConfig()->get('shoutbox_designNameColor'))
-            ->set('designBoxBackgroundColor', (string)$this->getConfig()->get('shoutbox_designBoxBackgroundColor'))
-            ->set('designButtonColor', (string)$this->getConfig()->get('shoutbox_designButtonColor'))
-            ->set('designButtonTextColor', (string)$this->getConfig()->get('shoutbox_designButtonTextColor'))
-            ->set('designInputBackgroundColor', (string)$this->getConfig()->get('shoutbox_designInputBackgroundColor'))
-            ->set('designInputTextColor', (string)$this->getConfig()->get('shoutbox_designInputTextColor'))
-            ->set('designFontSize', (int)$this->getConfig()->get('shoutbox_designFontSize'))
-            ->set('showAvatars', $this->getConfig()->get('shoutbox_showAvatars') !== '0')
-            ->set('customCss', (string)$this->getConfig()->get('shoutbox_customCss'));
+            ->set('writeAccess', $this->getConfigOrDefault('shoutbox_writeaccess'))
+            ->set('designBackgroundColor', $this->getConfigOrDefault('shoutbox_designBackgroundColor'))
+            ->set('designTextColor', $this->getConfigOrDefault('shoutbox_designTextColor'))
+            ->set('designNameColor', $this->getConfigOrDefault('shoutbox_designNameColor'))
+            ->set('designBoxBackgroundColor', $this->getConfigOrDefault('shoutbox_designBoxBackgroundColor'))
+            ->set('designButtonColor', $this->getConfigOrDefault('shoutbox_designButtonColor'))
+            ->set('designButtonTextColor', $this->getConfigOrDefault('shoutbox_designButtonTextColor'))
+            ->set('designInputBackgroundColor', $this->getConfigOrDefault('shoutbox_designInputBackgroundColor'))
+            ->set('designInputTextColor', $this->getConfigOrDefault('shoutbox_designInputTextColor'))
+            ->set('designFontSize', (int)$this->getConfigOrDefault('shoutbox_designFontSize'))
+            ->set('showAvatars', $this->getConfigOrDefault('shoutbox_showAvatars') !== '0')
+            ->set('customCss', $this->getConfigOrDefault('shoutbox_customCss'));
+    }
+
+    /**
+     * Gets a config value, falling back to the module default if the value
+     * is missing in the database (e.g. after an incomplete update).
+     *
+     * @param string $key
+     * @return string
+     */
+    private function getConfigOrDefault(string $key): string
+    {
+        return (string)($this->getConfig()->get($key) ?? ShoutboxConfig::SETTINGS_DEFAULTS[$key]);
     }
 
     /**


### PR DESCRIPTION
# Description

Behebt die Fehlermeldungen beim Speichern der Shoutbox-Einstellungen ohne Änderungen (Modulversion 1.8.0 → 1.8.1).

Fixes #1446

**Ursache:** Installationen, die Zwischenstände des Branches aus #1443 getestet haben, stehen in der Datenbank auf einer Modulversion (z. B. 1.7.2 oder ein früher 1.8.0-Stand), die der beim Review konsolidierte Update-Switch nicht mehr abdeckt. Dadurch wurden die Default-Werte für `shoutbox_floodInterval` und `shoutbox_autoRefreshInterval` nie angelegt: Die Einstellungsseite rendert leere Pflichtfelder, und das Speichern scheitert an der `required`-Validierung. Die übrigen Felder waren nicht betroffen, weil der Controller sie castet. Reguläre Updates von ≤ 1.7.1 waren nicht betroffen.

