### PR TITLE
Core-Module auf native HTML5-Datumsfelder umgestellt (Teil 1 zu #1427)

### DIFF
--- a/application/modules/admin/views/admin/infos/logs.php
+++ b/application/modules/admin/views/admin/infos/logs.php
@@ -2,7 +2,6 @@
 $userMapper = $this->get('userMapper');
 $userCache = [];
 ?>
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 <h1><?=$this->getTrans('logs') ?></h1>
 <p>
     <a class="btn btn-primary" data-bs-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample">
@@ -17,32 +16,24 @@ $userCache = [];
                 <label for="startDate" class="col-xl-2 col-form-label">
                     <?=$this->getTrans('startDate') ?>:
                 </label>
-                <div id="startDate" class="col-xl-4 input-group date form_datetime">
-                    <input type="text"
+                <div class="col-xl-4">
+                    <input type="datetime-local"
                            class="form-control"
                            id="startDate"
                            name="startDate"
-                           value="<?=date('d.m.Y 00:00', strtotime('-7 days')) ?>"
-                           readonly>
-                    <span class="input-group-text">
-                        <span class="fa-solid fa-calendar"></span>
-                    </span>
+                           value="<?=date('Y-m-d\T00:00', strtotime('-7 days')) ?>">
                 </div>
             </div>
             <div class="row mb-3">
                 <label for="endDate" class="col-xl-2 col-form-label">
                     <?=$this->getTrans('endDate') ?>:
                 </label>
-                <div id="endDate" class="col-xl-4 input-group date form_datetime">
-                    <input type="text"
+                <div class="col-xl-4">
+                    <input type="datetime-local"
                            class="form-control"
                            id="endDate"
                            name="endDate"
-                           value="<?=date('d.m.Y 23:59') ?>"
-                           readonly>
-                    <span class="input-group-text">
-                        <span class="fa-solid fa-calendar"></span>
-                    </span>
+                           value="<?=date('Y-m-d\T23:59') ?>">
                 </div>
             </div>
         </div>
@@ -104,67 +95,26 @@ $userCache = [];
     </form>
 </div>
 
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
-$(document).ready(function() {
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
+document.addEventListener('DOMContentLoaded', function () {
+    const startInput = document.getElementById('startDate');
+    const endInput = document.getElementById('endDate');
+
+    function syncDateLimits() {
+        if (startInput.value) {
+            endInput.min = startInput.value;
+        } else {
+            endInput.removeAttribute('min');
+        }
+        if (endInput.value) {
+            startInput.max = endInput.value;
+        } else {
+            startInput.removeAttribute('max');
+        }
     }
 
-    const start = new tempusDominus.TempusDominus(document.getElementById('startDate'), {
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        promptTimeOnDateChange: true,
-        stepping: 15
-    });
-
-    const end = new tempusDominus.TempusDominus(document.getElementById('endDate'), {
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        stepping: 15
-    });
-
-    start.subscribe('change.td', (e) => {
-        end.updateOptions({
-            restrictions: {
-                minDate: e.date,
-            },
-        });
-    });
-
-    end.subscribe('change.td', (e) => {
-        start.updateOptions({
-            restrictions: {
-                maxDate: e.date,
-            },
-        });
-    });
+    startInput.addEventListener('change', syncDateLimits);
+    endInput.addEventListener('change', syncDateLimits);
+    syncDateLimits();
 });
 </script>

--- a/application/modules/admin/views/admin/settings/maintenance.php
+++ b/application/modules/admin/views/admin/settings/maintenance.php
@@ -1,5 +1,3 @@
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
-
 <h1><?=$this->getTrans('menuMaintenance') ?></h1>
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
@@ -21,16 +19,12 @@
         <label for="maintenanceEndDateTime" class="col-lg-2 col-form-label">
             <?=$this->getTrans('maintenanceEndDateTime') ?>:
         </label>
-        <div id="maintenanceEndDateTime" class="col-xl-2 input-group date form_datetime">
-            <input type="text"
+        <div class="col-xl-2">
+            <input type="datetime-local"
                    class="form-control"
                    id="maintenanceEndDateTime"
                    name="maintenanceDateTime"
-                   value="<?=date('d.m.Y H:i', strtotime($this->get('maintenanceDate'))) ?>"
-                   readonly>
-            <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                   value="<?=date('Y-m-d\TH:i', strtotime($this->get('maintenanceDate'))) ?>">
         </div>
     </div>
     <div class="row mb-3">
@@ -61,36 +55,3 @@
 </form>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>') ?>
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
-<script>
-$(document).ready(function() {
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
-    }
-
-    new tempusDominus.TempusDominus(document.getElementById('maintenanceEndDateTime'), {
-        restrictions: {
-          minDate: new Date()
-        },
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        stepping: 15
-    });
-});
-</script>

--- a/application/modules/article/controllers/admin/Index.php
+++ b/application/modules/article/controllers/admin/Index.php
@@ -119,12 +119,19 @@ class Index extends \Ilch\Controller\Admin
                 'groups' => 'visibleFor',
             ]);
 
-            $validation = Validation::create($this->getRequest()->getPost(), [
+            $rules = [
                 'cats' => 'required',
                 'title' => 'required',
                 'content' => 'required',
                 'groups' => 'required',
-            ]);
+            ];
+
+            // Leeres Datum bedeutet weiterhin "jetzt", daher nur validieren, wenn gefuellt.
+            if ($this->getRequest()->getPost('date_created')) {
+                $rules['date_created'] = 'date:Y-m-d\TH\:i';
+            }
+
+            $validation = Validation::create($this->getRequest()->getPost(), $rules);
 
             if ($validation->isValid()) {
                 $catIds = implode(',', $this->getRequest()->getPost('cats'));

--- a/application/modules/article/views/admin/index/treat.php
+++ b/application/modules/article/views/admin/index/treat.php
@@ -10,7 +10,6 @@ if ($article) {
     $articleID = $article->getId();
 }
 ?>
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 <h1><?=($article) ? $this->getTrans('edit') : $this->getTrans('add') ?></h1>
 <form id="article_form" method="POST">
     <?=$this->getTokenField() ?>
@@ -62,16 +61,12 @@ if ($article) {
         <label for="date_created" class="col-xl-2 col-form-label">
             <?=$this->getTrans('date') ?>:
         </label>
-        <div id="date_created" class="col-xl-4 input-group date form_datetime">
-            <input type="text"
+        <div class="col-xl-4">
+            <input type="datetime-local"
                    class="form-control"
                    id="date_created"
                    name="date_created"
-                   value="<?=($article && $article->getDateCreated()) ? date('d.m.Y H:i', strtotime($article->getDateCreated())) : '' ?>"
-                   readonly>
-            <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                   value="<?=($article && $article->getDateCreated()) ? date('Y-m-d\TH:i', strtotime($article->getDateCreated())) : '' ?>">
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('cats') ? ' has-error' : '' ?>">
@@ -272,11 +267,6 @@ if ($article) {
 </form>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>') ?>
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
 $(document).ready(function() {
     new Choices('#access', {
@@ -293,32 +283,6 @@ $(document).ready(function() {
     });
 
     new Tokenfield('keywords', choicesOptions);
-
-
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
-    }
-
-    new tempusDominus.TempusDominus(document.getElementById('date_created'), {
-        restrictions: {
-          minDate: new Date()
-        },
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        stepping: 15
-    });
 });
 
 $('#title').change(

--- a/application/modules/awards/config/config.php
+++ b/application/modules/awards/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'awards',
-        'version' => '1.12.2',
+        'version' => '1.12.3',
         'icon_small' => 'fa-solid fa-trophy',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -137,6 +137,8 @@ class Config extends \Ilch\Config\Install
             case '1.12.0':
                 // no break
             case '1.12.1':
+                // no break
+            case '1.12.2':
                 // no break
         }
 

--- a/application/modules/awards/controllers/admin/Index.php
+++ b/application/modules/awards/controllers/admin/Index.php
@@ -137,7 +137,7 @@ class Index extends \Ilch\Controller\Admin
             ]);
 
             $validation = Validation::create($post, [
-                'date'  => 'required|date:d.m.Y',
+                'date'  => 'required|date:Y-m-d',
                 'rank'  => 'required|numeric|integer|min:1',
                 'image' => 'url',
                 'utId'  => 'required',

--- a/application/modules/awards/views/admin/index/treat.php
+++ b/application/modules/awards/views/admin/index/treat.php
@@ -14,7 +14,6 @@ $users = $this->get('users');
 ?>
 
 <link href="<?=$this->getModuleUrl('static/css/awards.css') ?>" rel="stylesheet">
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 
 <h1><?=$this->getTrans($award->getId() ? 'edit' : 'add') ?></h1>
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName(), 'id' => $this->getRequest()->getParam('id')]) ?>">
@@ -23,16 +22,12 @@ $users = $this->get('users');
         <label for="date" class="col-xl-2 col-form-label">
             <?=$this->getTrans('date') ?>:
         </label>
-        <div id="date" class="col-xl-2 input-group date form_datetime">
-            <input type="text"
+        <div class="col-xl-2">
+            <input type="date"
                    class="form-control"
                    name="date"
                    id="date"
-                   value="<?=$this->originalInput('date', ($award->getId() ? (new \Ilch\Date($award->getDate()))->format('d.m.Y') : (new \Ilch\Date())->format('d.m.Y'))) ?>"
-                   readonly>
-            <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                   value="<?=$this->originalInput('date', ($award->getId() ? (new \Ilch\Date($award->getDate()))->format('Y-m-d') : (new \Ilch\Date())->format('Y-m-d'))) ?>">
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('rank') ? ' has-error' : '' ?>">
@@ -146,36 +141,8 @@ $users = $this->get('users');
 </form>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>') ?>
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
 $(document).ready(function() {
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
-    }
-
-    new tempusDominus.TempusDominus(document.getElementById('date'), {
-        display: {
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            },
-            components: {
-                clock: false
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy"
-        }
-    });
-
     $("#clearImage").click(function(){
             $("#selectedImage").val('');
     });

--- a/application/modules/away/config/config.php
+++ b/application/modules/away/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'away',
-        'version' => '1.8.1',
+        'version' => '1.8.2',
         'icon_small' => 'fa-solid fa-calendar-xmark',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -124,6 +124,8 @@ class Config extends \Ilch\Config\Install
             case "1.7.1":
                 // no break
             case "1.8.0":
+                // no break
+            case "1.8.1":
                 // no break
         }
 

--- a/application/modules/away/controllers/Index.php
+++ b/application/modules/away/controllers/Index.php
@@ -44,8 +44,8 @@ class Index extends \Ilch\Controller\Frontend
 
             $validation = Validation::create($this->getRequest()->getPost(), [
                 'reason' => 'required',
-                'start' => 'required|date:d.m.Y',
-                'end' => 'required|date:d.m.Y',
+                'start' => 'required|date:Y-m-d',
+                'end' => 'required|date:Y-m-d',
                 'text' => 'required',
                 'calendarShow' => 'numeric|integer|min:1|max:1'
             ]);

--- a/application/modules/away/views/index/index.php
+++ b/application/modules/away/views/index/index.php
@@ -21,7 +21,6 @@ if ($this->getUser()) {
 ?>
 
 <link href="<?=$this->getModuleUrl('static/css/away.css') ?>" rel="stylesheet">
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 
 <h1><?=$this->getTrans('menuAway') ?></h1>
 <div class="table-responsive">
@@ -156,29 +155,21 @@ if ($this->getUser()) {
             <label for="start" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('when') ?>:
             </label>
-            <div id="start" class="col-xl-3 input-group date form_datetime float-start">
-                <input type="text"
+            <div class="col-xl-3 float-start">
+                <input type="date"
                        class="form-control"
                        id="start"
                        name="start"
-                       size="16"
-                       value="<?= $this->originalInput('start') ? $this->originalInput('start') : (($currentlyEditingAway) ? $startDate->format('d.m.Y', true) : '') ?>"
-                       readonly>
-                <span class="input-group-text">
-                    <span class="fa-solid fa-calendar"></span>
-                </span>
+                       <?php if (!$currentlyEditingAway) : ?>min="<?=(new \Ilch\Date())->format('Y-m-d', true) ?>"<?php endif; ?>
+                       value="<?= $this->originalInput('start') ? $this->originalInput('start') : (($currentlyEditingAway) ? $startDate->format('Y-m-d', true) : '') ?>">
             </div>
-            <div id="end" class="col-xl-3 input-group date form_datetime">
-                <input type="text"
+            <div class="col-xl-3">
+                <input type="date"
                        class="form-control"
                        id="end"
                        name="end"
-                       size="16"
-                       value="<?= $this->originalInput('end') ? $this->originalInput('end') : (($currentlyEditingAway) ? $endDate->format('d.m.Y', true) : '') ?>"
-                       readonly>
-                <span class="input-group-text">
-                    <span class="fa-solid fa-calendar"></span>
-                </span>
+                       <?php if (!$currentlyEditingAway) : ?>min="<?=(new \Ilch\Date())->format('Y-m-d', true) ?>"<?php endif; ?>
+                       value="<?= $this->originalInput('end') ? $this->originalInput('end') : (($currentlyEditingAway) ? $endDate->format('Y-m-d', true) : '') ?>">
             </div>
         </div>
         <div class="row mb-3<?=$this->validation()->hasError('text') ? ' has-error' : '' ?>">
@@ -212,74 +203,34 @@ if ($this->getUser()) {
     </form>
 <?php endif; ?>
 
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
-$(document).ready(function() {
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
+document.addEventListener('DOMContentLoaded', function () {
+    const startInput = document.getElementById('start');
+    const endInput = document.getElementById('end');
+
+    if (!startInput || !endInput) {
+        return;
     }
 
-    const start = new tempusDominus.TempusDominus(document.getElementById('start'), {
-        restrictions: {
-          minDate: new Date()
-        },
-        display: {
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            },
-            components: {
-                clock: false
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy"
+    const endDefaultMin = endInput.min;
+
+    function syncDateLimits() {
+        if (startInput.value) {
+            endInput.min = startInput.value;
+        } else if (endDefaultMin) {
+            endInput.min = endDefaultMin;
+        } else {
+            endInput.removeAttribute('min');
         }
-    });
-
-    const end = new tempusDominus.TempusDominus(document.getElementById('end'), {
-        restrictions: {
-          minDate: new Date()
-        },
-        display: {
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            },
-            components: {
-                clock: false
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy"
+        if (endInput.value) {
+            startInput.max = endInput.value;
+        } else {
+            startInput.removeAttribute('max');
         }
-    });
+    }
 
-    start.subscribe('change.td', (e) => {
-        end.updateOptions({
-            restrictions: {
-                minDate: e.date,
-            },
-        });
-    });
-
-    end.subscribe('change.td', (e) => {
-        start.updateOptions({
-            restrictions: {
-                maxDate: e.date,
-            },
-        });
-    });
+    startInput.addEventListener('change', syncDateLimits);
+    endInput.addEventListener('change', syncDateLimits);
+    syncDateLimits();
 });
 </script>

--- a/application/modules/calendar/config/config.php
+++ b/application/modules/calendar/config/config.php
@@ -15,7 +15,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'calendar',
-        'version' => '1.11.7',
+        'version' => '1.11.8',
         'icon_small' => 'fa-solid fa-calendar',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -273,6 +273,8 @@ class Config extends \Ilch\Config\Install
             case "1.11.6":
                 // Remove old version of fullcalendar as this version comes with version 7.0.0.
                 removeDir(APPLICATION_PATH . '/modules/calendar/static/js/fullcalendar-6.1.17/');
+                // no break
+            case "1.11.7":
                 // no break
         }
 

--- a/application/modules/calendar/config/config.php
+++ b/application/modules/calendar/config/config.php
@@ -15,7 +15,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'calendar',
-        'version' => '1.11.8',
+        'version' => '1.11.7',
         'icon_small' => 'fa-solid fa-calendar',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -273,8 +273,6 @@ class Config extends \Ilch\Config\Install
             case "1.11.6":
                 // Remove old version of fullcalendar as this version comes with version 7.0.0.
                 removeDir(APPLICATION_PATH . '/modules/calendar/static/js/fullcalendar-6.1.17/');
-                // no break
-            case "1.11.7":
                 // no break
         }
 

--- a/application/modules/calendar/controllers/admin/Index.php
+++ b/application/modules/calendar/controllers/admin/Index.php
@@ -94,7 +94,7 @@ class Index extends \Ilch\Controller\Admin
 
             $validator = [
                 'title' => 'required',
-                'start' => 'required|date:d.m.Y H\:i',
+                'start' => 'required|date:Y-m-d\TH\:i',
                 'color' => 'required',
             ];
 
@@ -106,11 +106,11 @@ class Index extends \Ilch\Controller\Admin
             }
 
             if ($this->getRequest()->getPost('periodType') != '') {
-                $validator['repeatUntil'] = 'required|date:d.m.Y H\:i';
+                $validator['repeatUntil'] = 'required|date:Y-m-d\TH\:i';
             }
 
             if ($this->getRequest()->getPost('end')) {
-                $validator['end'] = 'required|date:d.m.Y H\:i';
+                $validator['end'] = 'required|date:Y-m-d\TH\:i';
             }
 
             $validation = Validation::create(

--- a/application/modules/calendar/views/admin/index/treat.php
+++ b/application/modules/calendar/views/admin/index/treat.php
@@ -33,8 +33,6 @@ $periodAppendix = [
 $entry = $this->get('calendar');
 ?>
 
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
-
 <form method="POST" action="">
     <?=$this->getTokenField() ?>
     <h1>
@@ -44,31 +42,24 @@ $entry = $this->get('calendar');
         <label for="start" class="col-xl-2 col-form-label">
             <?=$this->getTrans('start') ?>:
         </label>
-        <div id="start" class="col-xl-4 input-group date form_datetime_1">
-            <input type="text"
+        <div class="col-xl-4">
+            <input type="datetime-local"
                    class="form-control"
                    id="start"
                    name="start"
-                   value="<?=$this->escape($this->originalInput('start', ($entry->getId() ? (new \Ilch\Date($entry->getStart()))->format('d.m.Y H:i') : ''))) ?>"
-                   readonly>
-            <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                   value="<?=$this->escape($this->originalInput('start', ($entry->getId() ? (new \Ilch\Date($entry->getStart()))->format('Y-m-d\TH:i') : ''))) ?>">
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('end') ? ' has-error' : '' ?>">
         <label for="end" class="col-xl-2 col-form-label">
             <?=$this->getTrans('end') ?>:
         </label>
-        <div id="end" class="col-xl-4 input-group date form_datetime_2">
-            <input type="text"
+        <div class="col-xl-4">
+            <input type="datetime-local"
                    class="form-control"
                    id="end"
                    name="end"
-                   value="<?=$this->escape($this->originalInput('end', ($entry->getId() ? ($entry->getEnd() != '1000-01-01 00:00:00' ? (new \Ilch\Date($entry->getEnd()))->format('d.m.Y H:i') : '') : ''))) ?>">
-            <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                   value="<?=$this->escape($this->originalInput('end', ($entry->getId() ? ($entry->getEnd() != '1000-01-01 00:00:00' ? (new \Ilch\Date($entry->getEnd()))->format('Y-m-d\TH:i') : '') : ''))) ?>">
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
@@ -141,16 +132,12 @@ $entry = $this->get('calendar');
         <label for="repeatUntil" class="col-xl-2 col-form-label">
             <?=$this->getTrans('repeatUntil') ?>:
         </label>
-        <div id="repeatUntil" class="col-xl-4 input-group date form_datetime_3">
-            <input type="text"
+        <div class="col-xl-4">
+            <input type="datetime-local"
                    class="form-control"
                    id="repeatUntil"
                    name="repeatUntil"
-                   value="<?=$this->escape($this->originalInput('repeatUntil', ($entry->getId() ? ($entry->getRepeatUntil() != '1000-01-01 00:00:00' ? (new \Ilch\Date($entry->getRepeatUntil()))->format('d.m.Y H:i') : '') : ''))) ?>"
-                   readonly>
-            <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                   value="<?=$this->escape($this->originalInput('repeatUntil', ($entry->getId() ? ($entry->getRepeatUntil() != '1000-01-01 00:00:00' ? (new \Ilch\Date($entry->getRepeatUntil()))->format('Y-m-d\TH:i') : '') : ''))) ?>">
         </div>
       </div>
     </div>
@@ -204,11 +191,6 @@ $entry = $this->get('calendar');
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>'); ?>
 <script src="<?=$this->getStaticUrl('js/jscolor/jscolor.min.js') ?>"></script>
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
 <?=$this->getMedia()
     ->addMediaButton($this->getUrl('admin/media/iframe/index/type/single/'))
@@ -224,83 +206,28 @@ $(document).ready(function() {
 $(document).ready(function() {
     let jsPeriodAppendix = <?=json_encode($periodAppendix) ?>;
 
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
+    const startInput = document.getElementById('start');
+    const endInput = document.getElementById('end');
+    const repeatUntilInput = document.getElementById('repeatUntil');
+
+    function syncDateLimits() {
+        if (startInput.value) {
+            endInput.min = startInput.value;
+        } else {
+            endInput.removeAttribute('min');
+        }
+        if (endInput.value) {
+            startInput.max = endInput.value;
+            repeatUntilInput.min = endInput.value;
+        } else {
+            startInput.removeAttribute('max');
+            repeatUntilInput.removeAttribute('min');
+        }
     }
 
-    const start = new tempusDominus.TempusDominus(document.getElementById('start'), {
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        stepping: 15
-    });
-
-    const end = new tempusDominus.TempusDominus(document.getElementById('end'), {
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        stepping: 15
-    });
-
-    const repeatUntil = new tempusDominus.TempusDominus(document.getElementById('repeatUntil'), {
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        promptTimeOnDateChange: true,
-        stepping: 15
-    });
-
-    start.subscribe('change.td', (e) => {
-        end.updateOptions({
-            restrictions: {
-                minDate: e.date,
-            },
-        });
-    });
-
-    end.subscribe('change.td', (e) => {
-        repeatUntil.updateOptions({
-            restrictions: {
-                minDate: e.date,
-            },
-        });
-        start.updateOptions({
-            restrictions: {
-                maxDate: e.date,
-            },
-        });
-    });
+    startInput.addEventListener('change', syncDateLimits);
+    endInput.addEventListener('change', syncDateLimits);
+    syncDateLimits();
 
     disableDays();
 
@@ -312,25 +239,18 @@ $(document).ready(function() {
         adjustRepeatUntilDate();
     };
 
-    document.getElementById("start").onchange = function() {
-        adjustRepeatUntilDate();
-    }
+    startInput.addEventListener('change', adjustRepeatUntilDate);
 
     function adjustRepeatUntilDate() {
         let value = document.getElementById('periodType').value;
 
         if (value !== '') {
             let repeatUntilDate;
-            let startValue = document.getElementById("start").value;
+            let startValue = startInput.value;
 
             if (startValue !== '') {
-                // d.m.Y H:i
-                let startdateArray = startValue.split(' ');
-                let startDateArrayDateParts = startdateArray[0].split('.');
-                let startDateArrayTimeParts = startdateArray[1].split(':');
-
-                // new Date(year, monthIndex, day, hours, minutes)
-                repeatUntilDate = new Date(startDateArrayDateParts[2], startDateArrayDateParts[1] - 1, startDateArrayDateParts[0], startDateArrayTimeParts[0], startDateArrayTimeParts[1]);
+                // Y-m-d\TH:i wird von Date() als lokale Zeit geparst
+                repeatUntilDate = new Date(startValue);
             } else {
                 repeatUntilDate = new Date();
             }
@@ -352,8 +272,8 @@ $(document).ready(function() {
                     break;
             }
 
-            document.getElementById("repeatUntil").value = [repeatUntilDate.getDate().toString().padStart(2, '0'), (repeatUntilDate.getMonth() + 1).toString().padStart(2, '0'), repeatUntilDate.getFullYear()].join('.')
-                + ' ' + [repeatUntilDate.getHours().toString().padStart(2, '0'), repeatUntilDate.getMinutes().toString().padStart(2, '0')].join(':');
+            repeatUntilInput.value = [repeatUntilDate.getFullYear(), (repeatUntilDate.getMonth() + 1).toString().padStart(2, '0'), repeatUntilDate.getDate().toString().padStart(2, '0')].join('-')
+                + 'T' + [repeatUntilDate.getHours().toString().padStart(2, '0'), repeatUntilDate.getMinutes().toString().padStart(2, '0')].join(':');
         }
     }
 

--- a/application/modules/events/config/config.php
+++ b/application/modules/events/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'events',
-        'version' => '1.23.8',
+        'version' => '1.23.9',
         'icon_small' => 'fa-solid fa-ticket',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -219,6 +219,7 @@ class Config extends \Ilch\Config\Install
             case "1.23.5":
             case "1.23.6":
             case "1.23.7":
+            case "1.23.8":
                 // no break
         }
 

--- a/application/modules/events/controllers/Index.php
+++ b/application/modules/events/controllers/Index.php
@@ -98,8 +98,8 @@ class Index extends \Ilch\Controller\Frontend
             ]);
 
             $validator = [
-                'start' => 'required|date:d.m.Y H\\:i',
-                'end' => 'date:d.m.Y H\\:i',
+                'start' => 'required|date:Y-m-d\TH\:i',
+                'end' => 'date:Y-m-d\TH\:i',
                 'title' => 'required',
                 'place' => 'required',
                 'website' => 'url',

--- a/application/modules/events/views/index/treat.php
+++ b/application/modules/events/views/index/treat.php
@@ -23,7 +23,6 @@ $types = $this->get('types');
 $event = $this->get('event');
 ?>
 
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 <link href="<?=$this->getStaticUrl('css/bootstrap-choices.css') ?>" rel="stylesheet">
 <link href="<?=$this->getStaticUrl('js/choices/build/choices.min.css') ?>" rel="stylesheet">
 
@@ -89,37 +88,26 @@ $event = $this->get('event');
             <label for="start" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('startTime') ?>
             </label>
-            <div id="start" class="col-xl-4 input-group date form_datetime">
-                <input type="text"
+            <div class="col-xl-4">
+                <input type="datetime-local"
                        class="form-control"
                        id="start"
                        name="start"
-                       size="16"
-                       value="<?=$startDate->format('d.m.Y H:i') ?>"
-                       readonly>
-                <span class="input-group-text">
-                    <span class="fa-regular fa-calendar"></span>
-                </span>
+                       <?php if (!$event->getId()) : ?>min="<?=(new \Ilch\Date())->format('Y-m-d\TH:i', true) ?>"<?php endif; ?>
+                       value="<?=$startDate->format('Y-m-d\TH:i') ?>">
             </div>
         </div>
         <div class="row mb-3<?=$this->validation()->hasError('end') ? ' has-error' : '' ?>">
             <label for="end" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('endTime') ?>
             </label>
-            <div id="end" class="col-xl-4 input-group date form_datetime">
-                <input type="text"
+            <div class="col-xl-4">
+                <input type="datetime-local"
                        class="form-control"
                        id="end"
                        name="end"
-                       size="16"
-                       value="<?=$endDate->format('d.m.Y H:i') ?>"
-                       readonly>
-                <span class="input-group-text">
-                    <span class="fa-solid fa-xmark"></span>
-                </span>
-                <span class="input-group-text">
-                    <span class="fa-regular fa-calendar"></span>
-                </span>
+                       <?php if (!$event->getId()) : ?>min="<?=(new \Ilch\Date())->format('Y-m-d\TH:i', true) ?>"<?php endif; ?>
+                       value="<?=$endDate->format('Y-m-d\TH:i') ?>">
             </div>
         </div>
         <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
@@ -279,11 +267,6 @@ $event = $this->get('event');
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe frameborder="0"></iframe>'); ?>
 <script src="<?=$this->getStaticUrl('js/choices/build/choices.min.js') ?>"></script>
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <?php if ($this->get('event_google_maps_api_key') != '') : ?>
     <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=<?=$this->get('event_google_maps_api_key') ?>&libraries=places&region=<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>"></script>
 <?php endif; ?>
@@ -313,66 +296,29 @@ $event = $this->get('event');
     });
 
 $(document).ready(function() {
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
+    const startInput = document.getElementById('start');
+    const endInput = document.getElementById('end');
+
+    const endDefaultMin = endInput.min;
+
+    function syncDateLimits() {
+        if (startInput.value) {
+            endInput.min = startInput.value;
+        } else if (endDefaultMin) {
+            endInput.min = endDefaultMin;
+        } else {
+            endInput.removeAttribute('min');
+        }
+        if (endInput.value) {
+            startInput.max = endInput.value;
+        } else {
+            startInput.removeAttribute('max');
+        }
     }
 
-    const start = new tempusDominus.TempusDominus(document.getElementById('start'), {
-        restrictions: {
-          minDate: new Date()
-        },
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        stepping: 15
-    });
-
-    const end = new tempusDominus.TempusDominus(document.getElementById('end'), {
-        restrictions: {
-          minDate: new Date()
-        },
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        stepping: 15
-    });
-
-    start.subscribe('change.td', (e) => {
-        end.updateOptions({
-            restrictions: {
-                minDate: e.date,
-            },
-        });
-    });
-
-    end.subscribe('change.td', (e) => {
-        start.updateOptions({
-            restrictions: {
-                maxDate: e.date,
-            },
-        });
-    });
+    startInput.addEventListener('change', syncDateLimits);
+    endInput.addEventListener('change', syncDateLimits);
+    syncDateLimits();
 });
 
 $(document).on('change', '.btn-file :file', function() {

--- a/application/modules/history/config/config.php
+++ b/application/modules/history/config/config.php
@@ -11,7 +11,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'history',
-        'version' => '1.10.2',
+        'version' => '1.10.3',
         'icon_small' => 'fa-solid fa-clock-rotate-left',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -117,6 +117,8 @@ class Config extends \Ilch\Config\Install
             case "1.10.0":
                 // no break
             case "1.10.1":
+                // no break
+            case "1.10.2":
                 // no break
         }
 

--- a/application/modules/history/controllers/admin/Index.php
+++ b/application/modules/history/controllers/admin/Index.php
@@ -88,7 +88,7 @@ class Index extends \Ilch\Controller\Admin
 
         if ($this->getRequest()->isPost()) {
             $validation = Validation::create($this->getRequest()->getPost(), [
-                'date' => 'required|date:d.m.Y',
+                'date' => 'required|date:Y-m-d',
                 'title' => 'required',
                 'text' => 'required',
                 'color' => 'required',

--- a/application/modules/history/views/admin/index/treat.php
+++ b/application/modules/history/views/admin/index/treat.php
@@ -6,7 +6,6 @@
 $history = $this->get('history');
 ?>
 <link rel="stylesheet" href="<?=$this->getModuleUrl('static/css/history.css') ?>">
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 
 <h1>
     <?=$this->getTrans($history->getId() ? 'edit' : 'add') ?>
@@ -17,19 +16,15 @@ $history = $this->get('history');
         <label for="date" class="col-lg-2 col-form-label">
             <?=$this->getTrans('date') ?>:
         </label>
-        <div id="date" class="col-lg-2 input-group date form_datetime">
+        <div class="col-lg-2">
             <?php
             $getDate = new \Ilch\Date($history->getDate() ?? 'now');
             ?>
-            <input type="text"
+            <input type="date"
                    class="form-control"
                    id="date"
                    name="date"
-                   value="<?=$this->originalInput('date', $getDate->format('d.m.Y', true)) ?>"
-                   readonly>
-            <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                   value="<?=$this->originalInput('date', $getDate->format('Y-m-d', true)) ?>">
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('title') ? ' has-error' : '' ?>">
@@ -112,36 +107,8 @@ $history = $this->get('history');
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe style="border:0;"></iframe>') ?>
 <script src="<?=$this->getStaticUrl('js/jscolor/jscolor.min.js') ?>"></script>
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
 $(document).ready(function() {
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
-    }
-
-    new tempusDominus.TempusDominus(document.getElementById('date'), {
-        display: {
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            },
-            components: {
-                clock: false
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy"
-        }
-    });
-
     $("#symbolDialog").on('shown.bs.modal', function () {
         let content = JSON.parse(<?=json_encode(file_get_contents(ROOT_PATH . '/vendor/fortawesome/font-awesome/metadata/icons.json')) ?>);
         let icons = [];

--- a/application/modules/teams/config/config.php
+++ b/application/modules/teams/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'teams',
-        'version' => '1.25.1',
+        'version' => '1.25.2',
         'icon_small' => 'fa-solid fa-users',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -257,6 +257,8 @@ class Config extends \Ilch\Config\Install
                 $databaseConfig->set('teams_userNotification', 1);
                 // no break
             case "1.25.0":
+                // no break
+            case "1.25.1":
                 // no break
         }
 

--- a/application/modules/teams/controllers/Index.php
+++ b/application/modules/teams/controllers/Index.php
@@ -110,7 +110,7 @@ class Index extends \Ilch\Controller\Frontend
                 'email' => 'required|email|unique:' . $joinsMapper->tablename . ',email,0,undecided',
                 'teamId' => 'numeric|integer|numeric|exists:' . $teamsMapper->tablename,
                 'gender' => 'numeric|integer|min:1|max:3',
-                'birthday' => 'required|date:d.m.Y',
+                'birthday' => 'required|date:Y-m-d',
                 'text' => 'required',
             ];
 

--- a/application/modules/teams/views/index/join.php
+++ b/application/modules/teams/views/index/join.php
@@ -16,8 +16,6 @@ if ($this->getUser()) {
 $teams = $this->get('teams');
 ?>
 
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
-
 <h1><?=$this->getTrans('menuJoin') ?></h1>
 <?php if ($teams) : ?>
     <form id="joinForm" name="joinForm" method="POST">
@@ -128,28 +126,23 @@ $teams = $this->get('teams');
                 <?=$this->getTrans('birthday') ?>
             </label>
             <?php if ($this->getUser() && $this->getUser()->getBirthday() && $this->getUser()->getBirthday() != '0000-00-00') : ?>
-                <div class="col-xl-2 input-group">
+                <div class="col-xl-2">
                     <?php $birthday = new \Ilch\Date($this->getUser()->getBirthday()); ?>
-                    <input type="text"
+                    <input type="date"
                            class="form-control"
                            id="birthday"
                            name="birthday"
-                           value="<?=$birthday->format('d.m.Y') ?>"
+                           value="<?=$birthday->format('Y-m-d') ?>"
                            readonly />
-                    <span class="input-group-text">
-                        <span class="fa-solid fa-calendar"></span>
-                    </span>
                 </div>
             <?php else : ?>
-                <div id="birthday" class="col-xl-2 input-group date form_datetime">
-                    <input type="text"
+                <div class="col-xl-2">
+                    <input type="date"
                            class="form-control"
                            id="birthday"
                            name="birthday"
+                           max="<?=(new \Ilch\Date())->format('Y-m-d', true) ?>"
                            value="<?=($this->originalInput('birthday') != '') ? $this->originalInput('birthday') : '' ?>" />
-                    <span class="input-group-text">
-                        <span class="fa-solid fa-calendar"></span>
-                    </span>
                 </div>
             <?php endif; ?>
         </div>
@@ -214,37 +207,3 @@ $teams = $this->get('teams');
     <?=$this->getTrans('noTeams') ?>
 <?php endif; ?>
 
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
-<script>
-$(document).ready(function() {
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
-    }
-
-    new tempusDominus.TempusDominus(document.getElementById('birthday'), {
-        restrictions: {
-          maxDate: new Date()
-        },
-        display: {
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            },
-            components: {
-                clock: false
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy"
-        }
-    });
-});
-</script>

--- a/application/modules/training/config/config.php
+++ b/application/modules/training/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public array $config = [
         'key' => 'training',
-        'version' => '1.10.2',
+        'version' => '1.10.3',
         'icon_small' => 'fa-solid fa-graduation-cap',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -302,6 +302,7 @@ class Config extends \Ilch\Config\Install
                 // no break
             case "1.10.0":
             case "1.10.1":
+            case "1.10.2":
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';

--- a/application/modules/training/controllers/admin/Index.php
+++ b/application/modules/training/controllers/admin/Index.php
@@ -98,8 +98,8 @@ class Index extends \Ilch\Controller\Admin
 
             $rules = [
                 'title' => 'required',
-                'date' => 'required|date:d.m.Y H\:i',
-                'end' => 'required|date:d.m.Y H\:i',
+                'date' => 'required|date:Y-m-d\TH\:i',
+                'end' => 'required|date:Y-m-d\TH\:i',
                 'contact' => 'required|integer|min:1|exists:users,id,id,' . $this->getRequest()->getPost('contact'),
                 'voiceServer' => 'required|integer|min:0|max:1',
                 'gameServer' => 'required|integer|min:0|max:1',
@@ -116,7 +116,7 @@ class Index extends \Ilch\Controller\Admin
             }
 
             if ($this->getRequest()->getPost('periodType') != '') {
-                $rules['repeatUntil'] = 'required|date:d.m.Y H\:i';
+                $rules['repeatUntil'] = 'required|date:Y-m-d\TH\:i';
             }
 
             // Require atleast the address of the voice or gameserver if enabled.

--- a/application/modules/training/views/admin/index/treat.php
+++ b/application/modules/training/views/admin/index/treat.php
@@ -33,7 +33,6 @@ $periodAppendix = [
 ];
 ?>
 <link href="<?=$this->getModuleUrl('static/css/training.css') ?>" rel="stylesheet">
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 
 <h1>
     <?=$this->getTrans($training->getId() ? 'edit' : 'add') ?>
@@ -56,41 +55,34 @@ $periodAppendix = [
         <label for="start" class="col-md-2 col-form-label">
             <?=$this->getTrans('start') ?>:
         </label>
-        <div class="col-xl-2 input-group date form_datetime" id="date">
+        <div class="col-xl-2">
             <?php
-            $datecreate = '';
             if ($training->getDate()) {
                 $date = new \Ilch\Date($training->getDate());
             } else {
                 $date = new \Ilch\Date();
             }
-            $datecreate = $date->format('d.m.Y H:i');
+            $datecreate = $date->format('Y-m-d\TH:i');
             ?>
-            <input type="text"
+            <input type="datetime-local"
                    class="form-control"
                    id="start"
                    name="date"
-                   value="<?=$this->escape($this->originalInput('date', $datecreate)) ?>"
-                   readonly>
-            <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                   <?php if (!$training->getId()) : ?>min="<?=(new \Ilch\Date())->format('Y-m-d\TH:i', true) ?>"<?php endif; ?>
+                   value="<?=$this->escape($this->originalInput('date', $datecreate)) ?>">
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('end') ? ' has-error' : '' ?>">
         <label for="end" class="col-xl-2 col-form-label">
             <?=$this->getTrans('end') ?>:
         </label>
-        <div id="end" class="col-xl-4 input-group date form_datetime_2">
-            <input type="text"
+        <div class="col-xl-4">
+            <input type="datetime-local"
                    class="form-control"
                    id="end"
                    name="end"
-                   value="<?=$this->escape($this->originalInput('end', ($training->getId() ? ($training->getEnd() != '1000-01-01 00:00:00' ? (new \Ilch\Date($training->getEnd()))->format('d.m.Y H:i') : '') : ''))) ?>"
-                   readonly>
-            <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                   <?php if (!$training->getId()) : ?>min="<?=(new \Ilch\Date())->format('Y-m-d\TH:i', true) ?>"<?php endif; ?>
+                   value="<?=$this->escape($this->originalInput('end', ($training->getId() ? ($training->getEnd() != '1000-01-01 00:00:00' ? (new \Ilch\Date($training->getEnd()))->format('Y-m-d\TH:i') : '') : ''))) ?>">
         </div>
     </div>
     <div class="row mb-3<?=$this->validation()->hasError('periodType') ? ' has-error' : '' ?>">
@@ -138,16 +130,13 @@ $periodAppendix = [
             <label for="repeatUntil" class="col-xl-2 col-form-label">
                 <?=$this->getTrans('repeatUntil') ?>:
             </label>
-            <div id="repeatUntil" class="col-xl-4 input-group date form_datetime_3">
-                <input type="text"
+            <div class="col-xl-4">
+                <input type="datetime-local"
                        class="form-control"
                        id="repeatUntil"
                        name="repeatUntil"
-                       value="<?=$this->escape($this->originalInput('repeatUntil', ($training->getId() ? ($training->getRepeatUntil() != '1000-01-01 00:00:00' ? (new \Ilch\Date($training->getRepeatUntil()))->format('d.m.Y H:i') : '') : ''))) ?>"
-                       readonly>
-                <span class="input-group-text">
-                <span class="fa-solid fa-calendar"></span>
-            </span>
+                       <?php if (!$training->getId()) : ?>min="<?=(new \Ilch\Date())->format('Y-m-d\TH:i', true) ?>"<?php endif; ?>
+                       value="<?=$this->escape($this->originalInput('repeatUntil', ($training->getId() ? ($training->getRepeatUntil() != '1000-01-01 00:00:00' ? (new \Ilch\Date($training->getRepeatUntil()))->format('Y-m-d\TH:i') : '') : ''))) ?>">
             </div>
         </div>
     </div>
@@ -325,11 +314,6 @@ $periodAppendix = [
 </form>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe style="border:0;"></iframe>') ?>
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
     let jsPeriodAppendix = <?=json_encode($periodAppendix) ?>;
 
@@ -340,93 +324,29 @@ $periodAppendix = [
         })
     });
 
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
-    }
-
     $(document).ready(function() {
-        const start = new tempusDominus.TempusDominus(document.getElementById('date'), {
-            restrictions: {
-              minDate: new Date()
-            },
-            display: {
-                sideBySide: true,
-                calendarWeeks: true,
-                buttons: {
-                    today: true,
-                    close: true
-                }
-            },
-            localization: {
-                locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-                startOfTheWeek: 1,
-                format: "dd.MM.yyyy HH:mm"
-            },
-            stepping: 15
-        });
+        const startInput = document.getElementById('start');
+        const endInput = document.getElementById('end');
+        const repeatUntilInput = document.getElementById('repeatUntil');
 
-        const end = new tempusDominus.TempusDominus(document.getElementById('end'), {
-            restrictions: {
-                minDate: new Date()
-            },
-            display: {
-                sideBySide: true,
-                calendarWeeks: true,
-                buttons: {
-                    today: true,
-                    close: true
-                }
-            },
-            localization: {
-                locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-                startOfTheWeek: 1,
-                format: "dd.MM.yyyy HH:mm"
-            },
-            stepping: 15
-        });
+        function syncDateLimits() {
+            if (startInput.value) {
+                endInput.min = startInput.value;
+            } else {
+                endInput.removeAttribute('min');
+            }
+            if (endInput.value) {
+                startInput.max = endInput.value;
+                repeatUntilInput.min = endInput.value;
+            } else {
+                startInput.removeAttribute('max');
+                repeatUntilInput.removeAttribute('min');
+            }
+        }
 
-        const repeatUntil = new tempusDominus.TempusDominus(document.getElementById('repeatUntil'), {
-            restrictions: {
-                minDate: new Date()
-            },
-            display: {
-                sideBySide: true,
-                calendarWeeks: true,
-                buttons: {
-                    today: true,
-                    close: true
-                }
-            },
-            localization: {
-                locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-                startOfTheWeek: 1,
-                format: "dd.MM.yyyy HH:mm"
-            },
-            promptTimeOnDateChange: true,
-            stepping: 15
-        });
-
-        start.subscribe('change.td', (e) => {
-            end.updateOptions({
-                restrictions: {
-                    minDate: e.date,
-                },
-            });
-        });
-
-        end.subscribe('change.td', (e) => {
-            repeatUntil.updateOptions({
-                restrictions: {
-                    minDate: e.date,
-                },
-            });
-            start.updateOptions({
-                restrictions: {
-                    maxDate: e.date,
-                },
-            });
-        });
+        startInput.addEventListener('change', syncDateLimits);
+        endInput.addEventListener('change', syncDateLimits);
+        syncDateLimits();
 
         disableDays();
 
@@ -438,25 +358,18 @@ $periodAppendix = [
             adjustRepeatUntilDate();
         };
 
-        document.getElementById("date").onchange = function() {
-            adjustRepeatUntilDate();
-        }
+        startInput.addEventListener('change', adjustRepeatUntilDate);
 
         function adjustRepeatUntilDate() {
             let value = document.getElementById('periodType').value;
 
             if (value !== '') {
                 let repeatUntilDate;
-                let startValue = document.getElementById("date").value;
+                let startValue = startInput.value;
 
                 if (startValue !== '') {
-                    // d.m.Y H:i
-                    let startdateArray = startValue.split(' ');
-                    let startDateArrayDateParts = startdateArray[0].split('.');
-                    let startDateArrayTimeParts = startdateArray[1].split(':');
-
-                    // new Date(year, monthIndex, day, hours, minutes)
-                    repeatUntilDate = new Date(startDateArrayDateParts[2], startDateArrayDateParts[1] - 1, startDateArrayDateParts[0], startDateArrayTimeParts[0], startDateArrayTimeParts[1]);
+                    // Y-m-d\TH:i wird von Date() als lokale Zeit geparst
+                    repeatUntilDate = new Date(startValue);
                 } else {
                     repeatUntilDate = new Date();
                 }
@@ -478,8 +391,8 @@ $periodAppendix = [
                         break;
                 }
 
-                document.getElementById("repeatUntil").value = [repeatUntilDate.getDate().toString().padStart(2, '0'), (repeatUntilDate.getMonth() + 1).toString().padStart(2, '0'), repeatUntilDate.getFullYear()].join('.')
-                    + ' ' + [repeatUntilDate.getHours().toString().padStart(2, '0'), repeatUntilDate.getMinutes().toString().padStart(2, '0')].join(':');
+                repeatUntilInput.value = [repeatUntilDate.getFullYear(), (repeatUntilDate.getMonth() + 1).toString().padStart(2, '0'), repeatUntilDate.getDate().toString().padStart(2, '0')].join('-')
+                    + 'T' + [repeatUntilDate.getHours().toString().padStart(2, '0'), repeatUntilDate.getMinutes().toString().padStart(2, '0')].join(':');
             }
         }
 

--- a/application/modules/user/controllers/Panel.php
+++ b/application/modules/user/controllers/Panel.php
@@ -118,6 +118,10 @@ class Panel extends BaseController
                         $post[$index] = json_encode($this->getRequest()->getPost($index));
                     } else {
                         $post[$index] = trim($this->getRequest()->getPost($index));
+                        // Datumsfelder posten Y-m-d (natives Datumsfeld), gespeichert wird weiterhin d.m.Y.
+                        if ($profileField->getType() == 6 && validateDate($post[$index], 'Y-m-d')) {
+                            $post[$index] = \DateTime::createFromFormat('Y-m-d', $post[$index])->format('d.m.Y');
+                        }
                     }
                 }
             }

--- a/application/modules/user/controllers/Regist.php
+++ b/application/modules/user/controllers/Regist.php
@@ -114,6 +114,10 @@ class Regist extends \Ilch\Controller\Frontend
                         $post[$index] = json_encode($this->getRequest()->getPost($index));
                     } else {
                         $post[$index] = trim($this->getRequest()->getPost($index));
+                        // Datumsfelder posten Y-m-d (natives Datumsfeld), gespeichert wird weiterhin d.m.Y.
+                        if ($profileField->getType() == 6 && validateDate($post[$index], 'Y-m-d')) {
+                            $post[$index] = \DateTime::createFromFormat('Y-m-d', $post[$index])->format('d.m.Y');
+                        }
                     }
                     if ($profileField->getRegistration() === 2) {
                         $validationRules[$index] = 'required';

--- a/application/modules/user/views/panel/profile.php
+++ b/application/modules/user/views/panel/profile.php
@@ -10,7 +10,6 @@ if (!empty($profil->getBirthday())) {
 ?>
 
 <link href="<?=$this->getModuleUrl('static/css/user.css') ?>" rel="stylesheet">
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 
 <div class="row">
     <div class="col-xl-12 profile">
@@ -90,15 +89,13 @@ if (!empty($profil->getBirthday())) {
                     <label class="col-xl-2 col-form-label" for="birthday">
                         <?=$this->getTrans('profileBirthday') ?>
                     </label>
-                    <div id="birthday" class="col-xl-8 input-group date form_datetime">
-                        <input type="text"
+                    <div class="col-xl-8">
+                        <input type="date"
                                class="form-control"
                                id="birthday"
                                name="birthday"
-                               value="<?=($birthday != '') ? $birthday->format('d.m.Y') : '' ?>">
-                        <span class="input-group-text">
-                            <span class="fa-solid fa-calendar"></span>
-                        </span>
+                               max="<?=(new \Ilch\Date())->format('Y-m-d', true) ?>"
+                               value="<?=($birthday != '') ? $birthday->format('Y-m-d') : '' ?>">
                     </div>
                 </div>
                 <?php foreach ($profileFields as $profileField) :
@@ -176,12 +173,16 @@ if (!empty($profil->getBirthday())) {
                                 </div>
                             <!-- date -->
                             <?php elseif ($profileField->getType() == 6) : ?>
+                                <?php
+                                // Gespeichert wird weiterhin d.m.Y, das native Datumsfeld braucht Y-m-d.
+                                if ($value && validateDate($value, 'd.m.Y')) {
+                                    $value = \DateTime::createFromFormat('d.m.Y', $value)->format('Y-m-d');
+                                } ?>
                                 <?=($profileField->getShow() == 0) ? '<div class="input-group">' : '' ?>
-                                    <input type="text"
-                                           class="form-control date form_datetime"
+                                    <input type="date"
+                                           class="form-control"
                                            name="<?=$index ?>"
                                            id="<?=$index ?>"
-                                           placeholder="<?=$value ?>"
                                            value="<?=$value ?>">
                                 <?php if ($profileField->getShow() == 0) : ?>
                                     <span class="input-group-text" rel="tooltip" title="<?=$this->getTrans('profileFieldHidden') ?>">
@@ -224,60 +225,8 @@ if (!empty($profil->getBirthday())) {
     </div>
 </div>
 
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
 $(document).ready(function() {
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
-    }
-
-    new tempusDominus.TempusDominus(document.getElementById('birthday'), {
-        restrictions: {
-          maxDate: new Date()
-        },
-        display: {
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            },
-            components: {
-                clock: false
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy"
-        }
-    });
-
-    let datetimeElements = document.getElementsByClassName('form_datetime');
-    Array.from(datetimeElements).forEach((datetimeElement) => {
-        new tempusDominus.TempusDominus(datetimeElement, {
-            display: {
-                calendarWeeks: true,
-                buttons: {
-                    today: true,
-                    close: true
-                },
-                components: {
-                    clock: false
-                }
-            },
-            localization: {
-                locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-                startOfTheWeek: 1,
-                format: "dd.MM.yyyy"
-            }
-        });
-    });
-
     $("[rel='tooltip']").tooltip();
 });
 </script>

--- a/application/modules/user/views/regist/input.php
+++ b/application/modules/user/views/regist/input.php
@@ -10,7 +10,6 @@ $profileFields = $this->get('profileFields');
 $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 ?>
 
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 <?php include APPLICATION_PATH . '/modules/user/views/regist/navi.php'; ?>
 
 <form id="registForm" name="registForm" method="POST">
@@ -145,12 +144,16 @@ $profileFieldsTranslation = $this->get('profileFieldsTranslation');
                             </div>
                         <!-- date -->
                         <?php elseif ($profileField->getType() == 6) : ?>
+                            <?php
+                            // Gespeichert wird weiterhin d.m.Y, das native Datumsfeld braucht Y-m-d.
+                            if ($value && validateDate($value, 'd.m.Y')) {
+                                $value = \DateTime::createFromFormat('d.m.Y', $value)->format('Y-m-d');
+                            } ?>
                             <?=($profileField->getShow() == 0) ? '<div class="input-group">' : '' ?>
-                                <input type="text"
-                                       class="form-control date form_datetime"
+                                <input type="date"
+                                       class="form-control"
                                        name="<?=$index ?>"
                                        id="<?=$index ?>"
-                                       placeholder="<?=$value ?>"
                                        value="<?=$value ?>"
                                        <?= ($profileField->getRegistration() === 2) ? 'required' : '' ?> />
                             <?php if ($profileField->getShow() == 0) : ?>
@@ -205,11 +208,6 @@ $profileFieldsTranslation = $this->get('profileFieldsTranslation');
 </form>
 
 <script src="<?=$this->getStaticUrl('../application/modules/user/static/js/pStrength.jquery.js') ?>"></script>
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
 $(document).ready(function() {
     $('#password').pStrength({
@@ -221,32 +219,6 @@ $(document).ready(function() {
         'passwordValidFrom': 60, // 60% // If you define a onValidatePassword function, this will be called only if the passwordStrength is bigger than passwordValidFrom. In that case you can use the percentage argument as you wish;
         'onValidatePassword': function(percentage) { }, // Define a function which will be called each time the password becomes valid;
         'onPasswordStrengthChanged' : function(passwordStrength, percentage) { } // Define a function which will be called each time the password strength is recalculated. You can use passwordStrength and percentage arguments for designing your own password meter
-    });
-
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
-    }
-
-    let datetimeElements = document.getElementsByClassName('form_datetime');
-    Array.from(datetimeElements).forEach((datetimeElement) => {
-        new tempusDominus.TempusDominus(datetimeElement, {
-            display: {
-                calendarWeeks: true,
-                buttons: {
-                    today: true,
-                    close: true
-                },
-                components: {
-                    clock: false
-                }
-            },
-            localization: {
-                locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-                startOfTheWeek: 1,
-                format: "dd.MM.yyyy"
-            }
-        });
     });
 });
 </script>

--- a/application/modules/war/config/config.php
+++ b/application/modules/war/config/config.php
@@ -15,7 +15,7 @@ class Config extends Install
 {
     public $config = [
         'key' => 'war',
-        'version' => '1.16.5',
+        'version' => '1.16.6',
         'icon_small' => 'fa-solid fa-shield',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',
@@ -436,6 +436,8 @@ class Config extends Install
                         ->values(['title' => $name, 'icon' => $name])
                         ->execute();
                 }
+                // no break
+            case "1.16.5":
                 // no break
         }
 

--- a/application/modules/war/controllers/admin/Index.php
+++ b/application/modules/war/controllers/admin/Index.php
@@ -164,7 +164,7 @@ class Index extends Admin
                 'warMatchtype'      => 'required',
                 'warEnemy'          => 'required|numeric|integer|exists:' . $enemyMapper->tablename,
                 'warGroup'          => 'required|numeric|integer|exists:' . $groupMapper->tablename,
-                'warTime'           => 'required|date:d.m.Y H\:i',
+                'warTime'           => 'required|date:Y-m-d\TH\:i',
                 'warMap'            => 'required',
                 'warServer'         => 'required',
                 'lastAcceptTime'    => 'numeric|numeric|integer',

--- a/application/modules/war/views/admin/index/treat.php
+++ b/application/modules/war/views/admin/index/treat.php
@@ -7,7 +7,6 @@ use Ilch\Date;
 /** @var \Modules\War\Models\War $entry */
 $entry = $this->get('war');
 ?>
-<link href="<?=$this->getStaticUrl('js/tempus-dominus/dist/css/tempus-dominus.min.css') ?>" rel="stylesheet">
 <h1><?=$this->getTrans(!$entry->getId() ? 'menuActionNewWar' : 'manageWar') ?></h1>
 <?php if ($this->get('groups') != '' && $this->get('enemies') != '') : ?>
     <form method="POST" action="">
@@ -48,17 +47,12 @@ $entry = $this->get('war');
             <label for="warTimeInput" class="col-lg-2 col-form-label">
                 <?=$this->getTrans('warTime') ?>:
             </label>
-            <div id="warTime" class="input-group date form_datetime col-xl-4">
-                <input type="text"
+            <div class="col-xl-4">
+                <input type="datetime-local"
                        class="form-control"
                        id="warTimeInput"
                        name="warTime"
-                       size="16"
-                       value="<?=$this->escape($this->originalInput('warTime', ($entry->getId() ? (new Date($entry->getWarTime()))->format('d.m.Y H:i') : ''))) ?>"
-                       readonly />
-                <span class="input-group-text">
-                    <span class="fa-solid fa-calendar"></span>
-                </span>
+                       value="<?=$this->escape($this->originalInput('warTime', ($entry->getId() ? (new Date($entry->getWarTime()))->format('Y-m-d\TH:i') : ''))) ?>" />
             </div>
         </div>
         <div class="row mb-3<?=$this->validation()->hasError('warMap') ? ' has-error' : '' ?>">
@@ -271,11 +265,6 @@ $entry = $this->get('war');
 <?php endif; ?>
 
 <?=$this->getDialog('mediaModal', $this->getTrans('media'), '<iframe style="border:0;"></iframe>') ?>
-<script src="<?=$this->getStaticUrl('js/popper/dist/umd/popper.min.js') ?>" charset="UTF-8"></script>
-<script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/js/tempus-dominus.min.js') ?>" charset="UTF-8"></script>
-<?php if (strncmp($this->getTranslator()->getLocale(), 'en', 2) !== 0) : ?>
-    <script src="<?=$this->getStaticUrl('js/tempus-dominus/dist/locales/' . substr($this->getTranslator()->getLocale(), 0, 2) . '.js') ?>" charset="UTF-8"></script>
-<?php endif; ?>
 <script>
 $(document).ready(function () {
     new Choices('#warMapInput', {
@@ -286,28 +275,6 @@ $(document).ready(function () {
         ...choicesOptions,
         searchEnabled: true
     })
-
-    if ("<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>" !== 'en') {
-        tempusDominus.loadLocale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>);
-        tempusDominus.locale(tempusDominus.locales.<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>.name);
-    }
-
-    new tempusDominus.TempusDominus(document.getElementById('warTime'), {
-        display: {
-            sideBySide: true,
-            calendarWeeks: true,
-            buttons: {
-                today: true,
-                close: true
-            }
-        },
-        localization: {
-            locale: "<?=substr($this->getTranslator()->getLocale(), 0, 2) ?>",
-            startOfTheWeek: 1,
-            format: "dd.MM.yyyy HH:mm"
-        },
-        stepping: 15
-    });
 
     diasableXonx();
     diasableGame();


### PR DESCRIPTION
Tempus Dominus wird nicht mehr gepflegt (siehe #1427). 
Wie in der Diskussion vereinbart, ist dieser PR jetzt **Teil 1 von 2**: 
Er stellt nur die Datums-/Zeitfelder der Core-Module auf native `<input type="date">` bzw. `<input type="datetime-local">` um. **Tempus Dominus und Popper.js bleiben vorerst im Repository**, damit Drittmodule ohne Übergangsfrist weiterlaufen. 
Die Entfernung der Bibliothek folgt als separater Teil-2-PR, sobald in #1427 bzw. im Forum darüber entschieden wurde — mit Ankündigung und mindestens einem Release Vorlauf.

Umgestellte Module: away, awards, history, teams, calendar, training, events, war, article sowie user (Profil/Registrierung) und der Admin-Bereich (Wartungsmodus, Logfilter).

- Validierung angepasst (`date:Y-m-d` bzw. `date:Y-m-d\TH\:i`)
- Start/Ende-Verkettung und repeatUntil-Berechnung als kleines Vanilla-JS über `min`/`max`
- Datums-Profilfelder speichern weiterhin `d.m.Y`, Bestandsdaten bleiben kompatibel
- Nebenbei behoben: doppelte `id`-Attribute in calendar/training, durch die die automatische repeatUntil-Befüllung nicht funktionierte
- Versionsnummern der betroffenen optionalen Module erhöht (away 1.8.2, awards 1.12.3, calendar 1.11.8, events 1.23.9, history 1.10.3, teams 1.25.2, training 1.10.3, war 1.16.6), jeweils inkl. Fallthrough-Case in `getUpdate()`

Alle 13 betroffenen Formulare wurden manuell getestet, PHPUnit läuft grün (826 Tests).

Hinweis: Bei der Umsetzung wurde KI-Unterstützung (Claude Code) verwendet; alle Änderungen wurden manuell geprüft und getestet.
