### PR TITLE
HTMLPurifier: aspect-ratio von Video-Embeds wird zerstört (Videos nur als schmaler Streifen sichtbar)

### DIFF
--- a/application/libraries/Ilch/Design/Base.php
+++ b/application/libraries/Ilch/Design/Base.php
@@ -158,6 +158,9 @@ abstract class Base
         $this->purifierConfig->set('AutoFormat.Linkify', true);
         // Had to be enabled to allow the output of the media embed plugin of CKEditor 5.
         $this->purifierConfig->set('CSS.Trusted', true);
+        // Allow "tricky" CSS properties like "display". The media embed plugin of CKEditor 5
+        // uses "display: block;" for the iframe of embedded videos.
+        $this->purifierConfig->set('CSS.AllowTricky', true);
         $def = $this->purifierConfig->getHTMLDefinition(true);
         $def->addAttribute('iframe', 'allowfullscreen', 'Bool');
         // Settings to allow (most of) the output of the media embed plugin of CKEditor 5.
@@ -185,6 +188,17 @@ abstract class Base
             'src' => new EmbedUrlDef(),
             'type' => 'Text',
         ));
+
+        // Workaround for HTMLPurifier mangling "aspect-ratio: 16 / 9" to the invalid "aspect-ratio:16 9".
+        // Its CSS_Multiple wrapper splits the value at spaces and drops the "/". CSS_Ratio itself
+        // handles "16 / 9" correctly, so replace the definition with one without the wrapper.
+        // The media embed plugin of CKEditor 5 uses "aspect-ratio: 16 / 9;" for embedded videos.
+        $cssDef = $this->purifierConfig->getCSSDefinition();
+        $cssDef->info['aspect-ratio'] = new \HTMLPurifier_AttrDef_CSS_Composite([
+            new \HTMLPurifier_AttrDef_CSS_Ratio(),
+            new \HTMLPurifier_AttrDef_Enum(['auto']),
+        ]);
+
         $this->purifier = new \HTMLPurifier($this->purifierConfig);
     }
 

--- a/tests/libraries/ilch/Design/BasePurifyTest.php
+++ b/tests/libraries/ilch/Design/BasePurifyTest.php
@@ -452,6 +452,20 @@ class BasePurifyTest extends TestCase
     }
 
     /**
+     * Media embed (CKEditor 5): Newer versions of CKEditor 5 create different embed code.
+     * This embed code includes "aspect-ratio: 16 / 9", which HTMLPurifier 4.19 mangles.
+     * A workaround was implemented with Ilch 2.2.18.
+     *
+     * @see https://github.com/IlchCMS/Ilch-2.0/pull/1450
+     * @return void
+     */
+    public function testPurifyEmbedMediaCK5AspectRatio()
+    {
+        $output = $this->view->purify('<figure class="media"><div data-oembed-url="https://www.youtube.com/watch?v=H08tGjXNHO4"><div><iframe src="https://www.youtube.com/watch?v=H08tGjXNHO4" width="1280" height="720" style="width: 100%; height: auto; aspect-ratio: 16 / 9; border: 0; display: block;" frameborder="0" allow="autoplay; encrypted-media" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></div></div></figure>');
+        self::assertEquals('<figure class="media"><div data-oembed-url="https://www.youtube.com/watch?v=H08tGjXNHO4"><div><iframe src="https://www.youtube.com/watch?v=H08tGjXNHO4" width="1280" height="720" style="width:100%;height:auto;aspect-ratio:16/9;border:0;display:block;" frameborder="0" allowfullscreen=""></iframe></div></div></figure>', $output);
+    }
+
+    /**
      * Media embed, but with not allowed URL. Should get filtered out. (CKEditor 5)
      *
      * @return void


### PR DESCRIPTION
# Description
Videos, die mit dem Media-Embed-Plugin des CKEditor 5 eingefügt wurden, werden im
Forum (und überall sonst, wo Inhalte durch den HTMLPurifier laufen) nur noch als
schmaler, ca. 150px hoher Streifen angezeigt.
Gemeldet im Ilch-Forum: https://www.ilch.de/forum-showposts-58916.html

**Ursache:** Neuere CKEditor-5-Versionen speichern Video-Embeds mit
`style="width: 100%; height: auto; aspect-ratio: 16 / 9; display: block; …"`
(statt des früheren padding-bottom-Tricks). Der HTMLPurifier (4.19) validiert
`aspect-ratio` über `HTMLPurifier_AttrDef_CSS_Multiple` – dieser Wrapper zerlegt
den Wert an Leerzeichen, verwirft den Schrägstrich und liefert das ungültige
`aspect-ratio:16 9` aus. Der Browser ignoriert die Angabe, das iframe fällt mit
`height:auto` auf die Standardhöhe von 150px zurück. Zusätzlich entfernt der
Purifier `display: block`, weil diese Eigenschaft hinter `CSS.AllowTricky` steckt.

**Fix** in `Design/Base.php::initializeHtmlPurifier()`:
- `CSS.AllowTricky` aktivieren (erlaubt u. a. `display`).
- Die `aspect-ratio`-Definition ohne den fehlerhaften `Multiple`-Wrapper
  registrieren; `HTMLPurifier_AttrDef_CSS_Ratio` verarbeitet `16 / 9` selbst korrekt.

Ergänzend:
- Unit-Test für den neuen Embed-Code hinzugefügt.

Die betroffenen Beiträge sind in der Datenbank unbeschädigt gespeichert; mit
diesem Fix werden auch bestehende Beiträge ohne Nacharbeit wieder korrekt
angezeigt. Der zugrunde liegende Fehler liegt eigentlich in
`ezyang/htmlpurifier` (Splitting in `AttrDef/CSS/Multiple.php`); dieser PR
umgeht ihn auf Ilch-Seite, bis er dort behoben ist.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [ ] No AI assistance used
- [x] AI-assisted

If AI-assisted, briefly state:
- Tools used (e.g., GitHub Copilot, ChatGPT, Claude): Claude Code
- What was generated by the tool (code, tests, docs, commit message, etc.): Fehleranalyse und die 14 geänderten Zeilen in `Design/Base.php`
- Extent of AI use (single snippet, file, entire feature — approximate %): ein Snippet (~14 Zeilen, 1 Datei)
- Verification steps performed (tests, manual review, security checks): manueller Review; Reproduktion vor/nach dem Fix mit realem Beitragsinhalt; PHPUnit-Suite `libraries` (566 Tests) grün; Anzeige im Browser geprüft
- License/IP check performed for AI outputs (yes/no + short note): yes – nutzt ausschließlich vorhandene HTMLPurifier-Klassen, kein Fremdcode

# This PR has been tested in the following browsers:
- [x] Chrome
- [x] Firefox
- [ ] Opera
- [ ] Edge
