### PR TITLE
Kalender-Box: FullCalendar-7-kompatiblen Titel-Link und +N-Zaehler

### DIFF
--- a/application/modules/calendar/boxes/views/calendar.php
+++ b/application/modules/calendar/boxes/views/calendar.php
@@ -8,6 +8,8 @@
 <link href="<?=$this->getBoxUrl('static/js/fullcalendar-7.0.0/dist/themes/classic/palette.css') ?>" rel="stylesheet">
 
 <div class="calendar">
+    <div class="calendarbox-title" id='calendarboxTitle<?=$this->get('uniqid') ?>'></div>
+
     <div id='calendarbox<?=$this->get('uniqid') ?>'></div>
 </div>
 
@@ -35,16 +37,37 @@
 
     document.addEventListener('DOMContentLoaded', function() {
         let calendarEl = document.getElementById('calendarbox<?=$this->get('uniqid') ?>');
+        let titleEl = document.getElementById('calendarboxTitle<?=$this->get('uniqid') ?>');
+        let calendarUrl = '<?=$this->getUrl(['module' => 'calendar']) ?>';
+
+        if (!calendarEl) {
+            return;
+        }
+
         let calendar = new FullCalendar.Calendar(calendarEl, {
             initialView: "dayGridMonth",
+            // Der Titel wird ueber datesSet selbst gerendert, damit er verlinkt werden kann.
             headerToolbar: {
               left: '',
-              center: 'title',
+              center: '',
               right: ''
             },
             locale: languagecalendar,
             nowIndicator: true,
             height: 450,
+            // In der Box ist kein Platz fuer Termintitel: alle Termine eines Tages
+            // werden zu einem "+N"-Zaehler zusammengefasst.
+            dayMaxEvents: 0,
+            moreLinkClass: 'calendarbox-event-count',
+            moreLinkContent: function (arg) {
+                return '+' + arg.num;
+            },
+            moreLinkClick: function () {
+                window.location = calendarUrl;
+
+                // Ein truthy Rueckgabewert unterdrueckt das Popover von FullCalendar.
+                return true;
+            },
             eventSources: [
                 <?php foreach ($this->get('events') ?? [] as $url) : ?>
                 {
@@ -52,25 +75,17 @@
                 },
                 <?php endforeach; ?>
             ],
-            eventDidMount: function (info) {
-                $('#calendarbox<?=$this->get('uniqid') ?> .fc-daygrid-day.fc-day').each(function() {
-                    let eventframe = $(this).find('.fc-daygrid-day-frame .fc-daygrid-day-events');
-                    
-                    let count = eventframe[0].childElementCount;
-                    count--;
-                    if (count > 0) {
-                        $(this).find('.fc-daygrid-day-frame .fc-daygrid-day-events').html('<div class="fc-event-count">+' + count + '<div>');
-                    }
-                });
-                info.event.remove();
-            },
-            loading: function( isLoading ) {
-                if(isLoading) {// isLoading gives bool value
-                    //show your loader here 
-                } else {
-                    let titleframe = $('#calendarbox<?=$this->get('uniqid') ?> .fc-toolbar-title');
-                    titleframe[0].innerHTML = '<a href="<?=$this->getUrl(['module' => 'calendar']) ?>">' + titleframe[0].innerHTML + '</a>';
+            datesSet: function (info) {
+                if (!titleEl) {
+                    return;
                 }
+
+                let link = document.createElement('a');
+                link.href = calendarUrl;
+                link.textContent = info.view.title;
+
+                titleEl.textContent = '';
+                titleEl.appendChild(link);
             }
         });
         calendar.render();

--- a/application/modules/calendar/boxes/views/calendar.php
+++ b/application/modules/calendar/boxes/views/calendar.php
@@ -46,7 +46,7 @@
 
         let calendar = new FullCalendar.Calendar(calendarEl, {
             initialView: "dayGridMonth",
-            // Der Titel wird ueber datesSet selbst gerendert, damit er verlinkt werden kann.
+            // Title is rendered via datesSet so that it can be linked.
             headerToolbar: {
               left: '',
               center: '',
@@ -55,8 +55,8 @@
             locale: languagecalendar,
             nowIndicator: true,
             height: 450,
-            // In der Box ist kein Platz fuer Termintitel: alle Termine eines Tages
-            // werden zu einem "+N"-Zaehler zusammengefasst.
+            // In the box there is no space for event titles: all events of a day
+            // are summarized as a "+N" counter.
             dayMaxEvents: 0,
             moreLinkClass: 'calendarbox-event-count',
             moreLinkContent: function (arg) {
@@ -65,7 +65,7 @@
             moreLinkClick: function () {
                 window.location = calendarUrl;
 
-                // Ein truthy Rueckgabewert unterdrueckt das Popover von FullCalendar.
+                // A truthy return value suppresses FullCalendar's popover.
                 return true;
             },
             eventSources: [

--- a/application/modules/calendar/config/config.php
+++ b/application/modules/calendar/config/config.php
@@ -15,7 +15,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'calendar',
-        'version' => '1.11.8',
+        'version' => '1.11.7',
         'icon_small' => 'fa-solid fa-calendar',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/calendar/config/config.php
+++ b/application/modules/calendar/config/config.php
@@ -15,7 +15,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'calendar',
-        'version' => '1.11.7',
+        'version' => '1.11.8',
         'icon_small' => 'fa-solid fa-calendar',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/calendar/static/css/calendar.css
+++ b/application/modules/calendar/static/css/calendar.css
@@ -19,10 +19,10 @@
 }
 
 /*
- * Kalender-Box.
- * FullCalendar 7 vergibt seine CSS-Klassen ueber CSS-Module (z. B. .fc-oH) und
- * damit bei jedem Build neu. Die Box gestaltet deshalb nur eigene Klassen, die
- * ueber die Optionen moreLinkClass bzw. ueber eigenes Markup gesetzt werden.
+ * Calendar box.
+ * FullCalendar 7 assigns its CSS classes via CSS modules (e.g. .fc-oH) and
+ * therefore generates them new with each build. The box therefore only styles
+ * its own classes, which are set via the moreLinkClass option or via custom markup.
  */
 .calendar .calendarbox-title {
     padding: 10px 0;

--- a/application/modules/calendar/static/css/calendar.css
+++ b/application/modules/calendar/static/css/calendar.css
@@ -17,141 +17,40 @@
     width: 100%;
     margin: 0 auto;
 }
-.calendar #calendar .fc-basic-view .fc-body .fc-row {
-    min-height: 45px;
-}
-@media (min-width: 768px) {
-    .calendar #calendar .fc-basic-view .fc-body .fc-row {
-        height: 100px;
-    }
-}
-@media (min-width: 992px) {
-    .calendar #calendar .fc-basic-view .fc-body .fc-row {
-        height: 112px;
-    }
-}
-@media (min-width: 1200px) {
-    .calendar #calendar .fc-basic-view .fc-body .fc-row {
-        height: 130px;
-    }
-}
-.calendar #calendar .fc-today {
-    background-color:#4295C9 !important;
-}
-.calendar #calendar .fc-sat {
-    color: gray;
-}
-.calendar #calendar .fc-sun {
-    color: red;
-}
-.calendar #calendar .fc-day-grid-event .fc-content {
-    text-overflow: ellipsis;
-}
-.calendar #calendar .fc-agendaWeek-button,
-.calendar #calendar .fc-listWeek-button-desk {
-    display: none;
-}
-@media (min-width: 768px) {
-    .calendar #calendar .fc-agendaWeek-button,
-    .calendar #calendar .fc-listWeek-button-desk  {
-        display: block !important;
-    }
-    .calendar #calendar .fc-listWeek-button {
-        display: none;
-    }
-}
-.calendar #calendar .fc-today-button.fc-state-disabled {
-    cursor: not-allowed;
-}
-.calendar #calendar .fc-today-button {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-}
-@media (min-width: 768px) {
-    .calendar #calendar .fc-today-button {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-    }
-}
-.calendar #calendar .fc-toolbar .fc-center {
-    padding-top: 10px;
-}
-.calendar #calendar .fc-toolbar .fc-center h2 {
+
+/*
+ * Kalender-Box.
+ * FullCalendar 7 vergibt seine CSS-Klassen ueber CSS-Module (z. B. .fc-oH) und
+ * damit bei jedem Build neu. Die Box gestaltet deshalb nur eigene Klassen, die
+ * ueber die Optionen moreLinkClass bzw. ueber eigenes Markup gesetzt werden.
+ */
+.calendar .calendarbox-title {
+    padding: 10px 0;
     font-size: 20px;
+    text-align: center;
 }
-.calendar #calendar .fc-view-container .fc-scroller {
-    min-height: 250px;
-    height: 100% !important;
+.calendar .calendarbox-title a {
+    color: inherit;
+    text-decoration: none;
 }
-.calendar #calendar .fc-toolbar button:focus {
-    outline: none;
+.calendar .calendarbox-title a:hover,
+.calendar .calendarbox-title a:focus {
+    text-decoration: underline;
 }
-.calendar #calendar .fc-toolbar .fc-head .fc-button-group {
-    margin-bottom: 10px;
-}
-.calendar #calendar .fc-toolbar .fc-head .fc-button-group.fc-right {
-    float: right;
-}
-.calendar #calendar .fc-more-cell div {
+.calendar .calendarbox-event-count {
+    display: inline-block;
     margin: 1px 2px 0;
+    padding: 0 4px;
     background-color: #f89406;
     border-radius: 3px;
+    color: #000;
+    font-size: 14px;
+    line-height: 1.3;
+    text-decoration: none;
     cursor: pointer;
 }
-@media (min-width: 768px) {
-    .calendar #calendar .fc-more-cell div {
-        margin: 1px 2px;
-        position: relative;
-        font-size: 14px;
-        line-height: 1.3;
-    }
-}
-.calendar #calendar .fc-more-cell div a {
+.calendar .calendarbox-event-count:hover,
+.calendar .calendarbox-event-count:focus {
     color: #000;
     text-decoration: none;
-    pointer-events: none;
-}
-.calendar #calendar .fc-event {
-    font-size: 14px;
-    cursor: pointer;
-}
-.calendar #calendar .fc-agendaDay-view .fc-event {
-    cursor: auto;
-}
-.calendar #calendar .fc-agendaDay-view .fc-time-grid-event .fc-time {
-    margin-top: 2px;
-    float: left;
-    padding-right: 10px;
-}
-.calendar #calendar .fc-agendaDay-view .fc-more-cell div a {
-    pointer-events: none;
-}
-@media (min-width: 768px) {
-    .calendar #calendar .fc-agendaDay-view .fc-more-cell div a {
-        pointer-events: inherit;
-    }
-}
-@media (max-width: 767px) {
-    .calendar #calendar .fc-month-view .fc-week td.fc-event-container a {
-        top: 0;
-        margin-top: 2px;
-        margin-left: 1px;
-        padding: 0;
-        position: absolute;
-        border-style: solid;
-        border-width: 20px 20px 0 0;
-        border-color: #f89306 transparent transparent transparent !important;
-        border-radius: 0;
-        background-color: transparent !important;
-        pointer-events: none;
-    }
-}
-.calendar #calendar .fc-month-view .fc-week td.fc-event-container .fc-content {
-    display: none;
-    cursor: pointer;
-}
-@media (min-width: 768px) {
-    .calendar #calendar .fc-month-view .fc-week td.fc-event-container .fc-content {
-        display: block;
-    }
 }


### PR DESCRIPTION
# Description
Die Kalender-Box (Sidebar-Box) verlinkte den Titel und fasste ueberzaehlige Termine eines Tages zu einem "+N"-Zaehler zusammen. Beides wurde per DOM-Hack (loading-Callback + jQuery) nachtraeglich in FullCalendar hineingebastelt und verliess sich dabei auf die Klassen `.fc-toolbar-title` und `.fc-more-cell`. Seit dem Update auf FullCalendar 7 (#1437) vergibt FullCalendar diese Klassen ueber CSS-Module und damit nicht mehr stabil - der Hack griff dadurch nicht mehr zuverlaessig (Titel unverlinkt, Zaehler fehlerhaft/unformatiert).

Der Fix nutzt stattdessen offizielle FullCalendar-7-APIs:
- Titel wird ueber den `datesSet`-Callback in ein eigenes Element gerendert und verlinkt (kein Abhaengen an internen Klassen mehr).
- Der Ueberlauf-Zaehler nutzt `dayMaxEvents: 0` zusammen mit `moreLinkClass`/`moreLinkContent`/`moreLinkClick`, statt Events nachtraeglich per jQuery zu zaehlen und zu verstecken.
- CSS entsprechend auf die neuen eigenen Klassen (`calendarbox-title`, `calendarbox-event-count`) umgestellt.

Fixes # (kein verlinktes Issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [x] AI-assisted

- Tools used: Claude Code (Claude Sonnet 5)
- What was generated by the tool: Code-Aenderungen in calendar.php (Box-View) und calendar.css, sowie dieser PR-Text
- Extent of AI use: gesamter Fix (2 Dateien)
- Verification steps performed: manuelle Sichtpruefung des Diffs, PHP-Lint, manueller Test im Browser (Titel-Link und +N-Zaehler-Klick funktionieren)
- License/IP check performed: ja, keine Fremdcode-Uebernahme, nur Nutzung dokumentierter FullCalendar-7-Optionen

# This PR has been tested in the following browsers:
- [x] Chrome