### PR TITLE
Shoutbox: Deckkraft-Regler für transparente Hintergründe

### DIFF
--- a/application/modules/shoutbox/config/config.php
+++ b/application/modules/shoutbox/config/config.php
@@ -37,7 +37,7 @@ class Config extends \Ilch\Config\Install
 
     public $config = [
         'key' => 'shoutbox',
-        'version' => '1.8.1',
+        'version' => '1.8.2',
         'icon_small' => 'fa-solid fa-bullhorn',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',
@@ -130,6 +130,7 @@ class Config extends \Ilch\Config\Install
             case "1.7.1":
             case "1.7.2":
             case "1.8.0":
+            case "1.8.1":
                 // Add default values for settings added in later versions.
                 // Only adds missing settings without overwriting existing values.
                 $databaseConfig = new \Ilch\Config\Database($this->db());

--- a/application/modules/shoutbox/controllers/admin/Settings.php
+++ b/application/modules/shoutbox/controllers/admin/Settings.php
@@ -79,13 +79,13 @@ class Settings extends \Ilch\Controller\Admin
                     ->set('shoutbox_floodInterval', $this->getRequest()->getPost('floodInterval'))
                     ->set('shoutbox_autoRefreshInterval', $this->getRequest()->getPost('autoRefreshInterval'))
                     ->set('shoutbox_writeaccess', $writeAccess)
-                    ->set('shoutbox_designBackgroundColor', $this->getColorFromPost('designBackgroundColor'))
+                    ->set('shoutbox_designBackgroundColor', $this->getColorFromPost('designBackgroundColor', true))
                     ->set('shoutbox_designTextColor', $this->getColorFromPost('designTextColor'))
                     ->set('shoutbox_designNameColor', $this->getColorFromPost('designNameColor'))
-                    ->set('shoutbox_designBoxBackgroundColor', $this->getColorFromPost('designBoxBackgroundColor'))
-                    ->set('shoutbox_designButtonColor', $this->getColorFromPost('designButtonColor'))
+                    ->set('shoutbox_designBoxBackgroundColor', $this->getColorFromPost('designBoxBackgroundColor', true))
+                    ->set('shoutbox_designButtonColor', $this->getColorFromPost('designButtonColor', true))
                     ->set('shoutbox_designButtonTextColor', $this->getColorFromPost('designButtonTextColor'))
-                    ->set('shoutbox_designInputBackgroundColor', $this->getColorFromPost('designInputBackgroundColor'))
+                    ->set('shoutbox_designInputBackgroundColor', $this->getColorFromPost('designInputBackgroundColor', true))
                     ->set('shoutbox_designInputTextColor', $this->getColorFromPost('designInputTextColor'))
                     ->set('shoutbox_designFontSize', $this->getRequest()->getPost('designFontSize'))
                     ->set('shoutbox_showAvatars', $this->getRequest()->getPost('showAvatars') ? '1' : '0')
@@ -139,15 +139,25 @@ class Settings extends \Ilch\Controller\Admin
      * Gets a design color from the post data. Returns an empty string (theme default)
      * if the corresponding default checkbox is set or the color is invalid.
      *
+     * Background colors additionally carry an opacity slider, its value gets
+     * merged into the color as an alpha channel (0 percent = transparent).
+     *
      * @param string $field
+     * @param bool $withOpacity
      * @return string
      */
-    private function getColorFromPost(string $field): string
+    private function getColorFromPost(string $field, bool $withOpacity = false): string
     {
         if ($this->getRequest()->getPost($field . 'Default')) {
             return '';
         }
 
-        return DesignCss::sanitizeColor((string)$this->getRequest()->getPost($field));
+        $color = (string)$this->getRequest()->getPost($field);
+
+        if ($withOpacity) {
+            return DesignCss::composeColor($color, (string)$this->getRequest()->getPost($field . 'Opacity'));
+        }
+
+        return DesignCss::sanitizeColor($color);
     }
 }

--- a/application/modules/shoutbox/libs/DesignCss.php
+++ b/application/modules/shoutbox/libs/DesignCss.php
@@ -120,13 +120,64 @@ class DesignCss
     }
 
     /**
-     * Returns the color if it is a valid hex color like #aabbcc, otherwise an empty string.
+     * Returns the color if it is a valid hex color like #aabbcc or #aabbccdd
+     * (with alpha channel), otherwise an empty string.
+     *
+     * This is the boundary that keeps the rendered style block free of injected
+     * CSS, so it stays strict on purpose: no color names, no rgba() notation.
      *
      * @param string $color
      * @return string
      */
     public static function sanitizeColor(string $color): string
     {
-        return preg_match('/^#[0-9a-f]{6}$/i', $color) ? $color : '';
+        return preg_match('/^#([0-9a-f]{6}|[0-9a-f]{8})$/i', $color) ? $color : '';
+    }
+
+    /**
+     * Combines a color from the color picker with an opacity in percent into a
+     * hex color. 100 percent keeps the six digit notation so existing values
+     * stay untouched, everything below adds the alpha channel (0 = transparent).
+     *
+     * @param string $color color like #aabbcc, an alpha channel gets replaced
+     * @param string $opacity opacity in percent (0-100)
+     * @return string
+     * @since 1.8.2
+     */
+    public static function composeColor(string $color, string $opacity): string
+    {
+        if (self::sanitizeColor($color) === '') {
+            return '';
+        }
+        // The color input only ever submits #rrggbb, drop a manually added alpha channel.
+        $color = substr($color, 0, 7);
+
+        if (!preg_match('/^\d{1,3}$/', trim($opacity))) {
+            return $color;
+        }
+
+        $opacity = min(100, (int)$opacity);
+        if ($opacity === 100) {
+            return $color;
+        }
+
+        return $color . sprintf('%02x', (int)round($opacity * 255 / 100));
+    }
+
+    /**
+     * Returns the opacity of a hex color in percent. Colors without an alpha
+     * channel are fully opaque.
+     *
+     * @param string $color
+     * @return int
+     * @since 1.8.2
+     */
+    public static function getOpacity(string $color): int
+    {
+        if (strlen(self::sanitizeColor($color)) !== 9) {
+            return 100;
+        }
+
+        return (int)round(hexdec(substr($color, 7, 2)) * 100 / 255);
     }
 }

--- a/application/modules/shoutbox/translations/de.php
+++ b/application/modules/shoutbox/translations/de.php
@@ -50,6 +50,7 @@ return [
     'designInputBackgroundColor' => 'Eingabefelder',
     'designInputTextColor' => 'Eingabefelder-Text',
     'designFontSize' => 'Schriftgröße in Pixel (0 = Theme-Standard)',
+    'designOpacity' => 'Deckkraft',
     'guest' => 'Gast',
     'showAvatars' => 'Avatare anzeigen',
     'customCss' => 'Eigenes CSS (wirkt auf Box und Seite)',

--- a/application/modules/shoutbox/translations/en.php
+++ b/application/modules/shoutbox/translations/en.php
@@ -50,6 +50,7 @@ return [
     'designInputBackgroundColor' => 'Input fields',
     'designInputTextColor' => 'Input field text',
     'designFontSize' => 'Font size in pixels (0 = theme default)',
+    'designOpacity' => 'Opacity',
     'guest' => 'Guest',
     'showAvatars' => 'Show avatars',
     'customCss' => 'Custom CSS (applies to box and page)',

--- a/application/modules/shoutbox/views/admin/settings/index.php
+++ b/application/modules/shoutbox/views/admin/settings/index.php
@@ -2,6 +2,55 @@
 
 /** @var \Ilch\View $this */
 ?>
+<style>
+    .shoutbox-color-field {
+        background-color: var(--bs-body-bg);
+    }
+
+    .shoutbox-color-field.is-theme-default .shoutbox-color-preview-value {
+        display: none;
+    }
+
+    .shoutbox-color-field.is-theme-default label {
+        opacity: .65;
+    }
+
+    /* Checkerboard behind the color so a low opacity is actually visible. */
+    .shoutbox-color-preview {
+        position: relative;
+        display: inline-block;
+        flex: 0 0 auto;
+        width: 2.25rem;
+        height: 2.25rem;
+        overflow: hidden;
+        border: 1px solid var(--bs-border-color);
+        border-radius: var(--bs-border-radius);
+        background-color: #fff;
+        background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
+                          linear-gradient(-45deg, #ccc 25%, transparent 25%),
+                          linear-gradient(45deg, transparent 75%, #ccc 75%),
+                          linear-gradient(-45deg, transparent 75%, #ccc 75%);
+        background-size: 12px 12px;
+        background-position: 0 0, 0 6px, 6px -6px, -6px 0;
+    }
+
+    .shoutbox-color-preview-value {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+    }
+
+    .shoutbox-color-field .form-range {
+        min-width: 4rem;
+    }
+
+    .shoutbox-opacity-output {
+        min-width: 2.75rem;
+        text-align: right;
+    }
+</style>
 <h1><?=$this->getTrans('settings') ?></h1>
 <form method="POST" action="<?=$this->getUrl(['action' => $this->getRequest()->getActionName()]) ?>">
     <?=$this->getTokenField() ?>
@@ -125,26 +174,58 @@
                 <div class="card-body">
                     <?php
                     $view = $this;
-                    $renderColorField = function (string $colorField, string $colorFallback) use ($view) {
-                        $colorValue = $view->get($colorField); ?>
-                        <div class="mb-3">
-                            <label for="<?=$colorField ?>" class="form-label mb-1">
-                                <?=$view->getTrans($colorField) ?>
-                            </label>
-                            <div class="d-flex align-items-center gap-3">
-                                <input type="color"
-                                       class="form-control form-control-color"
-                                       id="<?=$colorField ?>"
-                                       name="<?=$colorField ?>"
-                                       value="<?=$view->escape($colorValue !== '' ? $colorValue : $colorFallback) ?>">
-                                <div class="form-check mb-0">
+                    /**
+                     * Renders one color setting as a self contained block: preview, color
+                     * picker, optional opacity slider and the theme default switch.
+                     */
+                    $renderColorField = function (string $colorField, string $colorFallback, bool $withOpacity = false) use ($view) {
+                        $colorValue = (string)$view->get($colorField);
+                        $isDefault = $colorValue === '';
+                        $opacity = \Modules\Shoutbox\Libs\DesignCss::getOpacity($colorValue);
+                        // <input type="color"> only knows #rrggbb, the alpha channel is set by the range below.
+                        $pickerValue = $colorValue !== '' ? substr($colorValue, 0, 7) : $colorFallback; ?>
+                        <div class="col">
+                            <div class="shoutbox-color-field h-100 p-3 border rounded<?=$isDefault ? ' is-theme-default' : '' ?>">
+                                <div class="d-flex align-items-center gap-2 mb-3">
+                                    <span class="shoutbox-color-preview">
+                                        <span class="shoutbox-color-preview-value"
+                                              style="background-color: <?=$view->escape($pickerValue) ?>; opacity: <?=sprintf('%.2F', $opacity / 100) ?>"></span>
+                                    </span>
+                                    <label for="<?=$colorField ?>" class="form-label mb-0 flex-grow-1">
+                                        <?=$view->getTrans($colorField) ?>
+                                    </label>
+                                </div>
+                                <div class="d-flex align-items-center gap-2 mb-2">
+                                    <input type="color"
+                                           class="form-control form-control-color"
+                                           id="<?=$colorField ?>"
+                                           name="<?=$colorField ?>"
+                                           value="<?=$view->escape($pickerValue) ?>"
+                                           <?=$isDefault ? 'disabled' : '' ?>>
+                                    <?php if ($withOpacity) : ?>
+                                        <label for="<?=$colorField ?>Opacity" class="form-label mb-0 small text-body-secondary text-nowrap">
+                                            <?=$view->getTrans('designOpacity') ?>
+                                        </label>
+                                        <input type="range"
+                                               class="form-range"
+                                               id="<?=$colorField ?>Opacity"
+                                               name="<?=$colorField ?>Opacity"
+                                               min="0"
+                                               max="100"
+                                               step="1"
+                                               value="<?=$opacity ?>"
+                                               <?=$isDefault ? 'disabled' : '' ?>>
+                                        <span class="small text-body-secondary text-nowrap shoutbox-opacity-output"><?=$opacity ?> %</span>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="form-check form-switch mb-0">
                                     <input type="checkbox"
                                            class="form-check-input"
                                            id="<?=$colorField ?>Default"
                                            name="<?=$colorField ?>Default"
                                            value="1"
-                                           <?=$colorValue === '' ? 'checked' : '' ?>>
-                                    <label class="form-check-label" for="<?=$colorField ?>Default">
+                                           <?=$isDefault ? 'checked' : '' ?>>
+                                    <label class="form-check-label small" for="<?=$colorField ?>Default">
                                         <?=$view->getTrans('useThemeDefault') ?>
                                     </label>
                                 </div>
@@ -152,27 +233,27 @@
                         </div>
                     <?php };
                     ?>
+                    <h6 class="border-bottom pb-2 mb-3"><?=$this->getTrans('designMessagesSection') ?></h6>
+                    <div class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 g-3 mb-4">
+                        <?php
+                        $renderColorField('designBackgroundColor', '#ffffff', true);
+                        $renderColorField('designTextColor', '#212529');
+                        $renderColorField('designNameColor', '#0d6efd');
+                        ?>
+                    </div>
+                    <h6 class="border-bottom pb-2 mb-3"><?=$this->getTrans('designBoxSection') ?></h6>
+                    <div class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 g-3 mb-4">
+                        <?php
+                        $renderColorField('designBoxBackgroundColor', '#ffffff', true);
+                        $renderColorField('designInputBackgroundColor', '#ffffff', true);
+                        $renderColorField('designInputTextColor', '#212529');
+                        $renderColorField('designButtonColor', '#6c757d', true);
+                        $renderColorField('designButtonTextColor', '#ffffff');
+                        ?>
+                    </div>
+                    <h6 class="border-bottom pb-2 mb-3"><?=$this->getTrans('designMiscSection') ?></h6>
                     <div class="row g-4">
-                        <div class="col-xl-4">
-                            <h6 class="border-bottom pb-2 mb-3"><?=$this->getTrans('designMessagesSection') ?></h6>
-                            <?php
-                            $renderColorField('designBackgroundColor', '#ffffff');
-                            $renderColorField('designTextColor', '#212529');
-                            $renderColorField('designNameColor', '#0d6efd');
-                            ?>
-                        </div>
-                        <div class="col-xl-4">
-                            <h6 class="border-bottom pb-2 mb-3"><?=$this->getTrans('designBoxSection') ?></h6>
-                            <?php
-                            $renderColorField('designBoxBackgroundColor', '#ffffff');
-                            $renderColorField('designButtonColor', '#6c757d');
-                            $renderColorField('designButtonTextColor', '#ffffff');
-                            $renderColorField('designInputBackgroundColor', '#ffffff');
-                            $renderColorField('designInputTextColor', '#212529');
-                            ?>
-                        </div>
-                        <div class="col-xl-4">
-                            <h6 class="border-bottom pb-2 mb-3"><?=$this->getTrans('designMiscSection') ?></h6>
+                        <div class="col-lg-4">
                             <div class="mb-3<?=$this->validation()->hasError('designFontSize') ? ' has-error' : '' ?>">
                                 <label for="designFontSize" class="form-label mb-1">
                                     <?=$this->getTrans('designFontSize') ?>
@@ -186,30 +267,28 @@
                                        style="max-width: 8rem"
                                        value="<?=$this->originalInput('designFontSize', $this->get('designFontSize')) ?>">
                             </div>
-                            <div class="mb-3">
-                                <div class="form-check form-switch">
-                                    <input type="checkbox"
-                                           class="form-check-input"
-                                           id="showAvatars"
-                                           name="showAvatars"
-                                           value="1"
-                                           <?=$this->get('showAvatars') ? 'checked' : '' ?>>
-                                    <label class="form-check-label" for="showAvatars">
-                                        <?=$this->getTrans('showAvatars') ?>
-                                    </label>
-                                </div>
-                            </div>
-                            <div class="mb-0">
-                                <label for="customCss" class="form-label mb-1">
-                                    <?=$this->getTrans('customCss') ?>
+                            <div class="form-check form-switch mb-0">
+                                <input type="checkbox"
+                                       class="form-check-input"
+                                       id="showAvatars"
+                                       name="showAvatars"
+                                       value="1"
+                                       <?=$this->get('showAvatars') ? 'checked' : '' ?>>
+                                <label class="form-check-label" for="showAvatars">
+                                    <?=$this->getTrans('showAvatars') ?>
                                 </label>
-                                <textarea class="form-control font-monospace"
-                                          style="resize: vertical"
-                                          id="customCss"
-                                          name="customCss"
-                                          rows="6"
-                                          placeholder=".shoutbox-messages td { }"><?=$this->escape($this->originalInput('customCss', $this->get('customCss'))) ?></textarea>
                             </div>
+                        </div>
+                        <div class="col-lg-8">
+                            <label for="customCss" class="form-label mb-1">
+                                <?=$this->getTrans('customCss') ?>
+                            </label>
+                            <textarea class="form-control font-monospace"
+                                      style="resize: vertical"
+                                      id="customCss"
+                                      name="customCss"
+                                      rows="6"
+                                      placeholder=".shoutbox-messages td { }"><?=$this->escape($this->originalInput('customCss', $this->get('customCss'))) ?></textarea>
                         </div>
                     </div>
                 </div>
@@ -225,5 +304,34 @@
             ...choicesOptions,
             searchEnabled: true
         })
+
+        // Keep preview, percentage and the disabled state of each color field in sync.
+        document.querySelectorAll('.shoutbox-color-field').forEach(function (field) {
+            var picker = field.querySelector('input[type="color"]');
+            var range = field.querySelector('input[type="range"]');
+            var themeDefault = field.querySelector('input[type="checkbox"]');
+            var preview = field.querySelector('.shoutbox-color-preview-value');
+            var output = field.querySelector('.shoutbox-opacity-output');
+
+            var update = function () {
+                var opacity = range ? Number(range.value) : 100;
+
+                preview.style.backgroundColor = picker.value;
+                preview.style.opacity = opacity / 100;
+                field.classList.toggle('is-theme-default', themeDefault.checked);
+                picker.disabled = themeDefault.checked;
+
+                if (range) {
+                    range.disabled = themeDefault.checked;
+                    output.textContent = opacity + ' %';
+                }
+            };
+
+            picker.addEventListener('input', update);
+            themeDefault.addEventListener('change', update);
+            if (range) {
+                range.addEventListener('input', update);
+            }
+        });
     });
 </script>


### PR DESCRIPTION
# Beschreibung

Baut auf #1443 auf und erweitert die dort eingeführten Design-Einstellungen der Shoutbox; #1447 war die Nachbesserung dazu. Betroffen sind dieselben beiden Dateien, die mit #1443 entstanden sind: `libs/DesignCss.php` und `views/admin/settings/index.php`.

Die Hintergrundfarben der Shoutbox ließen sich bisher nicht auf transparent stellen: `<input type="color">` kennt laut Spezifikation nur `#rrggbb`, und `DesignCss::sanitizeColor()` ließ ausschließlich sechsstellige Hex-Werte durch. Ein leerer Wert bedeutet „Theme-Standard" und gibt gar keine CSS-Regel aus, ist also kein Ersatz für Transparenz.

Neben den Hintergrundfarben (Nachrichten, Box, Eingabefelder, Buttons) gibt es jetzt einen Regler für die Deckkraft von 0–100 %. Farbe und Prozentwert werden serverseitig zu einem achtstelligen Hex-Wert verbunden, 0 % ergibt einen transparenten Hintergrund.

* Bei 100 % bleibt die sechsstellige Schreibweise erhalten. Bestehende Werte ändern sich dadurch nicht, neue Konfigurationsschlüssel sind nicht nötig.
* `sanitizeColor()` akzeptiert nun sechs- **oder** achtstellige Hex-Werte, bleibt sonst aber bewusst streng (keine Farbnamen, kein `rgba()`), da sie die Grenze gegen eingeschleustes CSS im ausgegebenen `<style>`-Block ist.
* Der Design-Bereich der Einstellungen wurde dafür neu geordnet: Abschnitte über die volle Breite, je Farbe ein Block mit Vorschaukachel, die die eingestellte Deckkraft über einem Schachbrettmuster zeigt. „Theme-Standard" ist ein Schalter geworden, der Farbwähler und Regler deaktiviert.
* Modulversion 1.8.1 → 1.8.2 inklusive `case "1.8.1":` in `getUpdate()`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## AI usage disclosure

- [x] AI-assisted

* **Tools used:** Claude (Claude Code)
* **What was generated:** Code, Admin-View und Commit-Nachricht
* **Extent of AI use:** das gesamte Feature, nach meinen Vorgaben zu Variante, Umfang, Versionsnummer und Layout
* **Verification steps:** `php -l` über alle geänderten Dateien, Logiktests der Farb-/Deckkraftumrechnung (Roundtrip 0–100 % verlustfrei, Abweisen ungültiger Eingaben wie `red`, `-5`, `5)}</style`), Prüfung des gerenderten Markups, manuelle Durchsicht des Diffs
* **License/IP check:** ja, keine fremden Code-Fragmente übernommen, GPL-3.0-kompatibel

# This PR has been tested in the following browsers:
- [x] Chrome
- [x] Firefox
- [ ] Opera
- [ ] Edge

