### PR TITLE
Shoutbox: Unerreichbare case-Zweige aus getUpdate() entfernt

### DIFF
--- a/application/modules/shoutbox/config/config.php
+++ b/application/modules/shoutbox/config/config.php
@@ -129,8 +129,6 @@ class Config extends \Ilch\Config\Install
             case "1.7.0":
             case "1.7.1":
             case "1.7.2":
-            case "1.8.0":
-            case "1.8.1":
                 // Add default values for settings added in later versions.
                 // Only adds missing settings without overwriting existing values.
                 $databaseConfig = new \Ilch\Config\Database($this->db());


### PR DESCRIPTION
# Description

Entfernt zwei unerreichbare `case`-Zweige aus `getUpdate()` des Shoutbox-Moduls. Reines Aufräumen, kein Funktionsunterschied für bestehende Installationen.

Nach #1454 steht die Modulversion auf `1.8.0`. Damit sind zwei Zweige im `switch` von `getUpdate()` tot:

- **`case "1.8.0"`** entspricht der aktuellen Config-Version. Der Update-Button im Admincenter wird nur gerendert, wenn `version_compare(installiert, config, '<')` zutrifft (`application/modules/admin/views/admin/modules/index.php:85`) — bei Gleichstand also nie.
- **`case "1.8.1"`** verweist auf eine Version, die es in dieser Linie nicht mehr gibt.

Die Versionen `1.7.1` bis `1.8.2` existierten ausschließlich im unveröffentlichten 2.2.18-Entwicklungsstand; `v2.2.17` liefert Shoutbox `1.7.0` aus. Es gibt daher keine Installation im Umlauf, die einen der beiden Zweige treffen könnte.

Der relevante Update-Pfad bleibt unverändert: Eine Installation mit `1.7.0` trifft `case "1.7.0"` und fällt durch bis zum Block, der fehlende Einstellungen aus `SETTINGS_DEFAULTS` ergänzt.

Ein Hinweis zur Vollständigkeit: Ein direkter Aufruf von `admin/modules/localupdate/key/shoutbox` hätte über `case "1.8.0"` auch bei Versionsgleichstand noch die generische „fehlende Einstellungen ergänzen“-Reparatur aus #1447 ausgelöst. Diese manuelle Route entfällt mit diesem PR. Im Normalbetrieb ist das folgenlos, da der Settings-Controller fehlende Keys ohnehin über `getConfigOrDefault()` abfängt. Falls dieser Reparaturpfad erhalten bleiben soll, kann `case "1.8.0"` gerne stehenbleiben — dann bitte kurz Bescheid geben.

Fixes # (kein Issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure

- [x] AI-assisted

- **Tools used:** Claude Code (Claude Opus 5)
- **What was generated by the tool:** Die Code-Änderung (Entfernen der beiden `case`-Zeilen), die Analyse der Versionshistorie, die Commit-Message sowie dieser PR-Text.
- **Extent of AI use:** Einzelner Snippet — zwei gelöschte Zeilen in einer Datei.
- **Verification steps performed:** `php -l` ohne Fehler; Update-Pfad ab `1.7.0` manuell durch den `switch` nachvollzogen; ausgelieferte Modulversionen in den Tags `v2.2.17` (1.7.0) und `v2.2.16` (1.6.3) geprüft; beide Aufrufer von `getUpdate()` (`Ilch/Transfer.php:545`, `admin/controllers/admin/Modules.php:311`) gegengelesen.
- **License/IP check performed:** Ja — kein übernommener Fremdcode, die Änderung besteht ausschließlich aus einer Löschung.

# This PR has been tested in the following browsers:

Nicht zutreffend — die Änderung betrifft ausschließlich serverseitige Update-Logik ohne Frontend-Anteil.
