### PR TITLE
Captcha: Ressourcen-Pfad absolut aufloesen

### DIFF
--- a/application/libraries/Captcha/Captcha.php
+++ b/application/libraries/Captcha/Captcha.php
@@ -45,11 +45,13 @@ class Captcha
     /**
      * Path for resource files (fonts, words, etc.)
      *
-     * "resources" by default. For security reasons, is better move this
-     * directory to another location outise the web server
+     * The "resources" folder next to this file by default. Resolved absolutely
+     * so it does not depend on the current working directory. For security
+     * reasons, is better move this directory to another location outise the
+     * web server
      *
      */
-    public $resourcesPath = 'resources';
+    public $resourcesPath = __DIR__ . '/resources';
 
     /** Min word length (for non-dictionary random text generation) */
     public $minWordLength = 5;


### PR DESCRIPTION
# Description

`Captcha::$resourcesPath` ist relativ vorbelegt (`'resources'`). Das geht bisher nur gut, weil `Captcha.php` ausschließlich direkt per URL aufgerufen wird und das Arbeitsverzeichnis dadurch im Ordner der Datei selbst liegt. Aus jedem anderen Kontext (Autoloader, CLI, Tests) laufen Wortliste und Fonts ins Leere.

Der Pfad wird jetzt im Property-Default über `__DIR__` aufgelöst; ein Überschreiben von außen bleibt möglich.

```php
public $resourcesPath = __DIR__ . '/resources';
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure

- [x] AI-assisted
