### PR TITLE
Add build-release and update existing build files

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,10 +1,11 @@
-name: Build
+name: Build release
 
 on:
   workflow_dispatch:
   push:
-    branches:
-      - master
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   build:
@@ -28,8 +29,8 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-php${{ matrix.php-versions }}
       - name: Install dependencies
         run: composer install --prefer-dist --no-dev --optimize-autoloader --no-interaction
-      - name: Optimize vendor and static/js
-        run: php build/optimize_build.php
+      - name: Optimize vendor and static/js. Remove additional optional modules and layouts.
+        run: php build/optimize_build.php release
       - name: Create archive
         run: |
           git archive --format=zip HEAD > Ilch-2.zip
@@ -41,14 +42,25 @@ jobs:
           name: ilch2-zip
           path: |
             Ilch-2.zip
-      - name: Upload archive to ilch.de
-        if: ${{ github.ref_name == 'master' }}
-        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+
+  create-draft:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: ${{ github.ref_type == 'tag' }}
+    steps:
+      - name: Download a single artifact
+        uses: actions/download-artifact@v8
         with:
-          username: 'ilch2'
-          server: 'ilch.de'
-          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
-          local_path: './Ilch-2.zip'
-          sftp_only: true
-          remote_path: '/versions/master.zip'
-          sftpArgs: '-o ConnectTimeout=5'
+          name: ilch2-zip
+      - name: Prepare release
+        id: prepare-release
+        run: |
+          mv Ilch-2.zip Ilch-${{ github.ref_name }}.zip
+          echo "VERSION=${GITHUB_REF_NAME/v/}" >> $GITHUB_OUTPUT
+      - name: Create release draft
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ format('Ilch-{0}.zip', github.ref_name) }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          name: ${{ format('Version {0}', steps.prepare-release.outputs.VERSION) }}

--- a/build/optimize_build.php
+++ b/build/optimize_build.php
@@ -2,11 +2,11 @@
 <?php
 
 /**
- * Script to remove not needed files from the vendor and static/js directory, when creating a build (just --no-dev dependencies).
+ * Script to remove not needed files from the vendor, static/js and application directory, when creating a build (just --no-dev dependencies).
  *
  * Configuration of files/directories to remove or keep.
  * Directories must be given with a trailing /
- * Only the provided directories in vendor will be processes, all other directories in vendor will be kept untouched.
+ * Only the provided directories in for example vendor will be processes, all other directories in vendor will be kept untouched.
  *
  * Select files that should be kept, all other files/dirs in dir-in-vendor will be removed
  * 'dir-in-vendor' => [
@@ -136,6 +136,19 @@ $directoriesStaticJs = [
     ],
 ];
 
+$directoriesModulesLayouts = [
+    'modules' => [
+        'remove' => [
+            'sample/',
+            'checkout/'
+        ]
+    ],
+    'layouts' => [
+        'remove' => [
+        ]
+    ],
+];
+
 /**
  * Returns an array with all files in the directory and all its subdirectories
  * @param string $dirname
@@ -199,7 +212,6 @@ function removeEmptySubFolders(string $path): bool
     return false;
 }
 
-
 /**
  * Quote the file for the regular expression pattern
  * @param string $fileOrDir
@@ -216,7 +228,7 @@ function quoteForPattern(string $fileOrDir): string
 }
 
 /**
- * Optimize spezific directory
+ * Optimize specific directory
  * @param string $pathString
  * @param array $directories
  * @return string
@@ -270,3 +282,8 @@ echo optimizeDirectory('vendor', $directories);
 
 // Optimize static/js directory
 echo optimizeDirectory('static/js', $directoriesStaticJs);
+
+if ($argc == 2 && $argv[1] === 'release') {
+    // Remove additional optional modules and layouts that are not supposed to be part of the release.
+    echo optimizeDirectory('application', $directoriesModulesLayouts);
+}


### PR DESCRIPTION
# Description
- Add build-release.yaml to run when we create a new release (or a tag) to remove additional optional modules and layouts.
- Update build.yaml to only run when master gets changed. Move creating a draft release to build-release.yaml.
- Update optimize_build.php to remove additional optional modules and layouts.

Previously build.yaml ran when master changed or a tag was created. It gets all files from GitHub, runs composer and optimize_build.php, creates a Ilch-2.zip, an artifact for the build and uploads the Ilch-2.zip as master.zip (this is the current state of development for users to test) to ilch.de.

For a release we simply ran the same. This had the disadvantage that the "sample" module was part of the release. We don't want it in the release, but in the current development state.

build-release.yaml now runs when we create a new release (or a tag) to remove additional optional modules and layouts. It doesn't upload a file to ilch.de as the state of the tag should be equal to master.
build.yaml now only runs when master gets changed, but with the same output as previously.
optimze_build got updated to optionally ("release" argument) remove additional optional modules and layouts. This is used to remove the sample module for now.

This should allow us to add more modules and layouts to the main repository without these modules and layouts all be added to the release. Ilch 2.2.18 is for example 9.76 MB and we try to not further increase the file size if possible.
Having the modules and layouts (for example the checkout module) in the main repository makes sure that the CI and PHP Quality Checks workflows run on these.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## AI usage disclosure
- [X] No AI assistance used

