### PR TITLE
Downloads: Fix download not being visible for guests and more

### DIFF
--- a/application/modules/downloads/config/config.php
+++ b/application/modules/downloads/config/config.php
@@ -11,7 +11,7 @@ use Modules\Comment\Mappers\Comment as CommentMapper;
 
 class Config extends \Ilch\Config\Install
 {
-    public $config = [
+    public array $config = [
         'key' => 'downloads',
         'version' => '1.15.1',
         'icon_small' => 'fa-regular fa-circle-down',
@@ -28,15 +28,15 @@ class Config extends \Ilch\Config\Install
             ],
         ],
         'ilchCore' => '2.2.7',
-        'phpVersion' => '7.4'
+        'phpVersion' => '8.1'
     ];
 
-    public function install()
+    public function install(): void
     {
         $this->db()->queryMulti($this->getInstallSql());
     }
 
-    public function uninstall()
+    public function uninstall(): void
     {
         $this->db()->drop('downloads_access', true);
         $this->db()->drop('downloads_files_access', true);

--- a/application/modules/downloads/config/config.php
+++ b/application/modules/downloads/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'downloads',
-        'version' => '1.15.0',
+        'version' => '1.15.1',
         'icon_small' => 'fa-regular fa-circle-down',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/downloads/controllers/Index.php
+++ b/application/modules/downloads/controllers/Index.php
@@ -17,19 +17,19 @@ use Modules\Downloads\Models\File as FileModel;
 
 class Index extends Frontend
 {
-    public function indexAction()
+    public function indexAction(): void
     {
         $downloadsMapper = new DownloadsMapper();
         $fileMapper = new FileMapper();
 
         $downloadsItems = $downloadsMapper->getDownloadsItemsByParent(0);
 
-        $downloadsItems = $this->checkAccess($downloadsItems);
+        $downloadsItems = $downloadsItems ? $this->checkAccess($downloadsItems) : [];
         $subItems = [];
         foreach ($downloadsItems as $downloadItem) {
             $subItems[$downloadItem->getId()] = $downloadsMapper->getDownloadsItemsByParent($downloadItem->getId());
         }
-        $subItems = $this->checkAccess($subItems);
+        $subItems = $subItems ? $this->checkAccess($subItems) : [];
 
         $this->getLayout()->getTitle()
                 ->add($this->getTranslator()->trans('downloads'));
@@ -45,10 +45,10 @@ class Index extends Frontend
     /**
      *  Check if the user or guest has access to the downloadsItems.
      *
-     * @param DownloadsItem[]|DownloadsItem|FileModel $downloadsItems
-     * @return array
+     * @param DownloadsItem|DownloadsItem[]|FileModel $downloadsItems
+     * @return FileModel|array|DownloadsItem
      */
-    private function checkAccess($downloadsItems)
+    private function checkAccess(FileModel|DownloadsItem|array $downloadsItems): FileModel|array|DownloadsItem
     {
         $downloadsItemsVisible = [];
         $isAdmin = $this->getUser() && $this->getUser()->isAdmin();
@@ -71,7 +71,7 @@ class Index extends Frontend
         }
 
         // Check which downloadsItems should be visible for the user or guest.
-        foreach ($downloadsItems ?? [] as $key => $downloadsItem) {
+        foreach ($downloadsItems as $key => $downloadsItem) {
             if (!is_array($downloadsItem)) {
                 if (empty($downloadsItem->getAccess())) {
                     // Visible for everyone.
@@ -101,7 +101,7 @@ class Index extends Frontend
         return $downloadsItemsVisible;
     }
 
-    public function showAction()
+    public function showAction(): void
     {
         $fileMapper = new FileMapper();
         $pagination = new Pagination();
@@ -115,7 +115,7 @@ class Index extends Frontend
             $this->redirect(['controller' => 'index', 'action' => 'index']);
         }
 
-        $downloads = $this->checkAccess($downloads);
+        $downloads = $downloads ? $this->checkAccess($downloads) : null;
         $downloads = $downloads ? $downloads[0] : null;
 
         $this->getLayout()->getTitle()
@@ -138,14 +138,14 @@ class Index extends Frontend
         $files = [];
         if ($downloads) {
             $files = $fileMapper->getFilesByItemId($id, $pagination);
-            $files = $this->checkAccess($files);
+            $files = $files ? $this->checkAccess($files) : [];
         }
 
         $this->getView()->set('files', $files);
         $this->getView()->set('pagination', $pagination);
     }
 
-    public function showFileAction()
+    public function showFileAction(): void
     {
         $downloadsMapper = new DownloadsMapper();
         $fileMapper = new FileMapper();
@@ -158,7 +158,7 @@ class Index extends Frontend
             $this->redirect(['controller' => 'index', 'action' => 'index']);
         }
 
-        $file = $this->checkAccess($file);
+        $file = $file ? $this->checkAccess($file) : null;
         $file = $file ? $file[0] : null;
 
         $this->getLayout()->getTitle()

--- a/application/modules/downloads/controllers/Index.php
+++ b/application/modules/downloads/controllers/Index.php
@@ -50,40 +50,55 @@ class Index extends Frontend
      */
     private function checkAccess($downloadsItems)
     {
-        if (!($this->getUser() && $this->getUser()->isAdmin())) {
-            // Check which downloadsItems should be visible for the user or guest.
-            $downloadsItemsVisible = [];
-            foreach ($downloadsItems ?? [] as $key => $downloadsItem) {
-                if (!is_array($downloadsItem)) {
-                    if (empty($downloadsItem->getAccess())) {
+        $downloadsItemsVisible = [];
+        $isAdmin = $this->getUser() && $this->getUser()->isAdmin();
+
+        // Handle the case when downloadsItems is a single item.
+        if (!is_array($downloadsItems)) {
+            // Early return if the user is an admin.
+            if ($isAdmin) {
+                return [$downloadsItems];
+            }
+
+            if (is_in_array(explode(',', $downloadsItems->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ? $this->getUser()->getGroups() : [3])) {
+                return [$downloadsItems];
+            }
+        }
+
+        // Early return if the user is an admin.
+        if ($isAdmin) {
+            return $downloadsItems;
+        }
+
+        // Check which downloadsItems should be visible for the user or guest.
+        foreach ($downloadsItems ?? [] as $key => $downloadsItem) {
+            if (!is_array($downloadsItem)) {
+                if (empty($downloadsItem->getAccess())) {
+                    // Visible for everyone.
+                    $downloadsItemsVisible[$key] = $downloadsItem;
+                    continue;
+                }
+
+                if (is_in_array(explode(',', $downloadsItem->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ? $this->getUser()->getGroups() : [3])) {
+                    $downloadsItemsVisible[$key] = $downloadsItem;
+                }
+            } else {
+                // Subitems
+                foreach ($downloadsItem as $downloadItem) {
+                    if (empty($downloadItem->getAccess())) {
                         // Visible for everyone.
-                        $downloadsItemsVisible[$key] = $downloadsItem;
+                        $downloadsItemsVisible[$key][] = $downloadItem;
                         continue;
                     }
 
-                    if (is_in_array(explode(',', $downloadsItem->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ?: [3])) {
-                        $downloadsItemsVisible[$key] = $downloadsItem;
-                    }
-                } else {
-                    // Subitems
-                    foreach ($downloadsItem as $downloadItem) {
-                        if (empty($downloadItem->getAccess())) {
-                            // Visible for everyone.
-                            $downloadsItemsVisible[$key][] = $downloadItem;
-                            continue;
-                        }
-
-                        if (is_in_array(explode(',', $downloadItem->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ?: [3])) {
-                            $downloadsItemsVisible[$key][] = $downloadItem;
-                        }
+                    if (is_in_array(explode(',', $downloadItem->getAccess()) ? : [], $this->getUser() && $this->getUser()->getGroups() ? $this->getUser()->getGroups() : [3])) {
+                        $downloadsItemsVisible[$key][] = $downloadItem;
                     }
                 }
             }
-
-            $downloadsItems = $downloadsItemsVisible;
         }
 
-        return $downloadsItems;
+        return $downloadsItemsVisible;
     }
 
     public function showAction()
@@ -101,6 +116,7 @@ class Index extends Frontend
         }
 
         $downloads = $this->checkAccess($downloads);
+        $downloads = $downloads ? $downloads[0] : null;
 
         $this->getLayout()->getTitle()
                 ->add($this->getTranslator()->trans('downloads'));
@@ -137,6 +153,7 @@ class Index extends Frontend
         }
 
         $file = $this->checkAccess($file);
+        $file = $file ? $file[0] : null;
 
         $this->getLayout()->getTitle()
                 ->add($this->getTranslator()->trans('downloads'));

--- a/application/modules/downloads/controllers/Index.php
+++ b/application/modules/downloads/controllers/Index.php
@@ -135,7 +135,13 @@ class Index extends Frontend
         $pagination->setRowsPerPage(!$this->getConfig()->get('downloads_downloadsPerPage') ? $this->getConfig()->get('defaultPaginationObjects') : $this->getConfig()->get('downloads_downloadsPerPage'));
         $pagination->setPage($this->getRequest()->getParam('page'));
 
-        $this->getView()->set('files', ($downloads) ? $fileMapper->getFilesByItemId($id, $pagination) : []);
+        $files = [];
+        if ($downloads) {
+            $files = $fileMapper->getFilesByItemId($id, $pagination);
+            $files = $this->checkAccess($files);
+        }
+
+        $this->getView()->set('files', $files);
         $this->getView()->set('pagination', $pagination);
     }
 

--- a/application/modules/downloads/controllers/admin/Downloads.php
+++ b/application/modules/downloads/controllers/admin/Downloads.php
@@ -16,7 +16,7 @@ use Modules\Downloads\Models\File as FileModel;
 
 class Downloads extends Admin
 {
-    public function init()
+    public function init(): void
     {
         $items = [
             [
@@ -45,7 +45,7 @@ class Downloads extends Admin
         );
     }
 
-    public function treatDownloadsAction()
+    public function treatDownloadsAction(): void
     {
         $fileMapper = new FileMapper();
         $pagination = new Pagination();
@@ -90,7 +90,7 @@ class Downloads extends Admin
         $this->getView()->set('downloadsTitle', $downloadsTitle->getTitle());
     }
 
-    public function delAction()
+    public function delAction(): void
     {
         if ($this->getRequest()->isSecure()) {
             $fileMapper = new FileMapper();

--- a/application/modules/downloads/controllers/admin/File.php
+++ b/application/modules/downloads/controllers/admin/File.php
@@ -15,7 +15,7 @@ use Modules\User\Mappers\Group as UserGroupMapper;
 
 class File extends Admin
 {
-    public function init()
+    public function init(): void
     {
         $items = [
             [
@@ -50,7 +50,7 @@ class File extends Admin
         );
     }
 
-    public function treatFileAction()
+    public function treatFileAction(): void
     {
         $fileMapper = new FileMapper();
         $userGroupMapper = new UserGroupMapper();

--- a/application/modules/downloads/controllers/admin/Index.php
+++ b/application/modules/downloads/controllers/admin/Index.php
@@ -15,7 +15,7 @@ use Modules\User\Mappers\Group as UserGroupMapper;
 
 class Index extends Admin
 {
-    public function init()
+    public function init(): void
     {
         $items = [
             [
@@ -38,7 +38,7 @@ class Index extends Admin
         );
     }
 
-    public function indexAction()
+    public function indexAction(): void
     {
         $this->getLayout()->getAdminHmenu()
                 ->add($this->getTranslator()->trans('downloads'), ['action' => 'index']);
@@ -75,7 +75,7 @@ class Index extends Admin
                     foreach ($items as $item) {
                         $downloadsItem = new DownloadsItem();
 
-                        if (strpos($item['id'], 'tmp_') !== false) {
+                        if (str_contains($item['id'], 'tmp_')) {
                             $tmpId = str_replace('tmp_', '', $item['id']);
                         } else {
                             $downloadsItem->setId($item['id']);

--- a/application/modules/downloads/controllers/admin/Settings.php
+++ b/application/modules/downloads/controllers/admin/Settings.php
@@ -11,7 +11,7 @@ use Ilch\Controller\Admin;
 
 class Settings extends Admin
 {
-    public function init()
+    public function init(): void
     {
         $items = [
             [
@@ -34,7 +34,7 @@ class Settings extends Admin
         );
     }
 
-    public function indexAction()
+    public function indexAction(): void
     {
         $this->getLayout()->getAdminHmenu()
                 ->add($this->getTranslator()->trans('downloads'), ['action' => 'index'])

--- a/application/modules/downloads/mappers/Access.php
+++ b/application/modules/downloads/mappers/Access.php
@@ -34,7 +34,7 @@ class Access extends Mapper
      * @return void
      * @since 1.15.0
      */
-    public function save(int $itemId, ?string $access)
+    public function save(int $itemId, ?string $access): void
     {
         $this->saveAccess($itemId, $access);
     }
@@ -47,7 +47,7 @@ class Access extends Mapper
      * @return void
      * @since 1.15.0
      */
-    public function saveFileAccess(int $fileId, ?string $access)
+    public function saveFileAccess(int $fileId, ?string $access): void
     {
         $this->saveAccess($fileId, $access, true);
     }
@@ -61,7 +61,7 @@ class Access extends Mapper
      * @return void
      * @since 1.15.0
      */
-    private function saveAccess(int $id, ?string $access, bool $isFileId = false)
+    private function saveAccess(int $id, ?string $access, bool $isFileId = false): void
     {
         if ($access === null) {
             return;

--- a/application/modules/downloads/mappers/Downloads.php
+++ b/application/modules/downloads/mappers/Downloads.php
@@ -166,7 +166,7 @@ class Downloads extends Mapper
      *
      * @param DownloadsItem $downloadsItem
      */
-    public function deleteItem(DownloadsItem $downloadsItem)
+    public function deleteItem(DownloadsItem $downloadsItem): void
     {
         $this->db()->delete('downloads_items')
             ->where(['id' => $downloadsItem->getId()])

--- a/application/modules/downloads/mappers/Downloads.php
+++ b/application/modules/downloads/mappers/Downloads.php
@@ -91,7 +91,7 @@ class Downloads extends Mapper
      */
     public function getDownloadsById(int $id): ?DownloadsItem
     {
-        $itemRows = $this->db()->select(['di.id', 'di.type', 'di.title', 'di.description', 'di.parent_id'])
+        $itemRow = $this->db()->select(['di.id', 'di.type', 'di.title', 'di.description', 'di.parent_id'])
             ->from(['di' => 'downloads_items'])
             ->join(['da' => 'downloads_access'], 'da.item_id = di.id', 'LEFT', ['access' => 'GROUP_CONCAT(DISTINCT da.group_id)'])
             ->where(['id' => $id])
@@ -100,16 +100,16 @@ class Downloads extends Mapper
             ->execute()
             ->fetchAssoc();
 
-        if (empty($itemRows)) {
+        if (empty($itemRow)) {
             return null;
         }
 
         $itemModel = new DownloadsItem();
-        $itemModel->setId($itemRows['id']);
-        $itemModel->setType($itemRows['type']);
-        $itemModel->setTitle($itemRows['title']);
-        $itemModel->setDesc($itemRows['description']);
-        $itemModel->setParentId($itemRows['parent_id']);
+        $itemModel->setId($itemRow['id']);
+        $itemModel->setType($itemRow['type']);
+        $itemModel->setTitle($itemRow['title']);
+        $itemModel->setDesc($itemRow['description']);
+        $itemModel->setParentId($itemRow['parent_id']);
         $itemModel->setAccess($itemRow['access'] ?? '');
 
         return $itemModel;

--- a/application/modules/downloads/mappers/File.php
+++ b/application/modules/downloads/mappers/File.php
@@ -151,7 +151,7 @@ class File extends Mapper
      *
      * @param FileModel $model
      */
-    public function save(FileModel $model)
+    public function save(FileModel $model): void
     {
         if ($model->getId()) {
             $this->db()->update('downloads_files')
@@ -166,12 +166,12 @@ class File extends Mapper
     }
 
     /**
-     * Delete a file by it's id.
+     * Delete a file by its id.
      *
      * @param int $id the id of the file
      * @return Result|int
      */
-    public function deleteById(int $id)
+    public function deleteById(int $id): Result|int
     {
         return $this->db()->delete('downloads_files')
             ->where(['id' => $id])
@@ -183,7 +183,7 @@ class File extends Mapper
      *
      * @param FileModel $model
      */
-    public function saveVisits(FileModel $model)
+    public function saveVisits(FileModel $model): void
     {
         if ($model->getVisits()) {
             $this->db()->update('downloads_files')
@@ -198,7 +198,7 @@ class File extends Mapper
      *
      * @param FileModel $model
      */
-    public function saveFileTreat(FileModel $model)
+    public function saveFileTreat(FileModel $model): void
     {
         $this->db()->update('downloads_files')
             ->values(['file_title' => $model->getFileTitle(), 'file_image' => $model->getFileImage(), 'file_description' => $model->getFileDesc()])

--- a/application/modules/downloads/models/DownloadsItem.php
+++ b/application/modules/downloads/models/DownloadsItem.php
@@ -80,7 +80,7 @@ class DownloadsItem extends Model
      *
      * @param int $id
      */
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -100,7 +100,7 @@ class DownloadsItem extends Model
      *
      * @param int $sort
      */
-    public function setSort(int $sort)
+    public function setSort(int $sort): void
     {
         $this->sort = $sort;
     }
@@ -120,7 +120,7 @@ class DownloadsItem extends Model
      *
      * @param int $type
      */
-    public function setType(int $type)
+    public function setType(int $type): void
     {
         $this->type = $type;
     }
@@ -140,7 +140,7 @@ class DownloadsItem extends Model
      *
      * @param int $id
      */
-    public function setParentId(int $id)
+    public function setParentId(int $id): void
     {
         $this->parentId = $id;
     }
@@ -160,7 +160,7 @@ class DownloadsItem extends Model
      *
      * @param string $title
      */
-    public function setTitle(string $title)
+    public function setTitle(string $title): void
     {
         $this->title = $title;
     }
@@ -180,7 +180,7 @@ class DownloadsItem extends Model
      *
      * @param string $desc
      */
-    public function setDesc(string $desc)
+    public function setDesc(string $desc): void
     {
         $this->desc = $desc;
     }

--- a/application/modules/downloads/models/File.php
+++ b/application/modules/downloads/models/File.php
@@ -94,7 +94,7 @@ class File extends Model
      *
      * @param int $id
      */
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -114,7 +114,7 @@ class File extends Model
      *
      * @param string $file_id
      */
-    public function setFileId(string $file_id)
+    public function setFileId(string $file_id): void
     {
         $this->file_id = $file_id;
     }
@@ -134,7 +134,7 @@ class File extends Model
      *
      * @param string $fileThumb
      */
-    public function setFileThumb(string $fileThumb)
+    public function setFileThumb(string $fileThumb): void
     {
         $this->filethumb = $fileThumb;
     }
@@ -154,7 +154,7 @@ class File extends Model
      *
      * @param string $fileTitle
      */
-    public function setFileTitle(string $fileTitle)
+    public function setFileTitle(string $fileTitle): void
     {
         $this->file_title = $fileTitle;
     }
@@ -174,7 +174,7 @@ class File extends Model
      *
      * @param string $fileDesc
      */
-    public function setFileDesc(string $fileDesc)
+    public function setFileDesc(string $fileDesc): void
     {
         $this->file_desc = $fileDesc;
     }
@@ -194,7 +194,7 @@ class File extends Model
      *
      * @param string $fileImage
      */
-    public function setFileImage(string $fileImage)
+    public function setFileImage(string $fileImage): void
     {
         $this->file_image = $fileImage;
     }
@@ -214,7 +214,7 @@ class File extends Model
      *
      * @param int $itemId
      */
-    public function setItemId(int $itemId)
+    public function setItemId(int $itemId): void
     {
         $this->item_id = $itemId;
     }
@@ -234,7 +234,7 @@ class File extends Model
      *
      * @param int $visits
      */
-    public function setVisits(int $visits)
+    public function setVisits(int $visits): void
     {
         $this->visits = $visits;
     }
@@ -254,7 +254,7 @@ class File extends Model
      *
      * @param string $fileUrl
      */
-    public function setFileUrl(string $fileUrl)
+    public function setFileUrl(string $fileUrl): void
     {
         $this->file_url = $fileUrl;
     }

--- a/application/modules/downloads/views/admin/index/index.php
+++ b/application/modules/downloads/views/admin/index/index.php
@@ -9,7 +9,7 @@ $downloadsItems = $this->get('downloadsItems');
  * @param \Modules\Downloads\Models\DownloadsItem $item
  * @param \Ilch\View $obj
  */
-function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
+function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj): void
 {
     /** @var \Modules\Downloads\Mappers\Downloads $downloadsMapper */
     $downloadsMapper = $obj->get('downloadsMapper');

--- a/application/modules/downloads/views/index/index.php
+++ b/application/modules/downloads/views/index/index.php
@@ -66,7 +66,7 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
             if (!empty($downloadsItems)) {
                 foreach ($downloadsItems as $item) {
                     rec($item, $this);
-                    foreach($subItems[$item->getId()] as $subItem) {
+                    foreach($subItems[$item->getId()] ?? [] as $subItem) {
                         rec($subItem, $this);
                     }
                 }

--- a/application/modules/downloads/views/index/index.php
+++ b/application/modules/downloads/views/index/index.php
@@ -15,7 +15,7 @@ $subItems = $this->get('subItems');
  * @param \Modules\Downloads\Models\DownloadsItem $item
  * @param \Ilch\View $obj
  */
-function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj)
+function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj): void
 {
     /** @var \Modules\Downloads\Mappers\File $fileMapper */
     $fileMapper = $obj->get('fileMapper');


### PR DESCRIPTION
# Description
- Fix getDownloadsById returns no access rights.
- Fix issues in checkAccess and it's callers.
- Don't show the filenames and a few details about them if the visitor has no access rights.
- Fix an error in the frontend index view.
- Code style improvements and adjustments for it.

https://www.ilch.de/forum-showposts-58929.html

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
