### PR TITLE
Downloads: Handle no access selection and add info text

### DIFF
--- a/application/modules/downloads/controllers/Index.php
+++ b/application/modules/downloads/controllers/Index.php
@@ -55,8 +55,8 @@ class Index extends Frontend
 
         // Handle the case when downloadsItems is a single item.
         if (!is_array($downloadsItems)) {
-            // Early return if the user is an admin.
-            if ($isAdmin) {
+            // Early return if the user is an admin or if empty as it is visible for everyone then.
+            if ($isAdmin || empty($downloadsItems->getAccess())) {
                 return [$downloadsItems];
             }
 

--- a/application/modules/downloads/translations/de.php
+++ b/application/modules/downloads/translations/de.php
@@ -29,6 +29,7 @@ return [
     'downloadsedit' => 'Downloads bearbeiten',
     'title' => 'Name',
     'type' => 'Art',
+    'accessEmptyHelp' => 'Keine Auswahl bedeutet sichtbar für alle.',
     'downloadsItemAdd' => 'Hinzufügen',
     'menuDownloadsOverview' => 'Downloads Übersicht',
     'files' => 'Dateien',

--- a/application/modules/downloads/translations/en.php
+++ b/application/modules/downloads/translations/en.php
@@ -29,6 +29,7 @@ return [
     'downloadsedit' => 'Edit downloads',
     'title' => 'Title',
     'type' => 'Type',
+    'accessEmptyHelp' => 'No selection means visible to everyone.',
     'downloadsItemAdd' => 'Append',
     'menuDownloadsOverview' => 'Downloads Overview',
     'file' => 'File',

--- a/application/modules/downloads/views/admin/file/treatfile.php
+++ b/application/modules/downloads/views/admin/file/treatfile.php
@@ -64,7 +64,12 @@ if ($file->getFileImage() != '') {
                         </div>
                     </div>
                     <div class="row mb-3">
-                        <label for="access" class="col-xl-2 col-form-label"><?=$this->getTrans('access') ?></label>
+                        <label for="access" class="col-xl-2 col-form-label">
+                            <?=$this->getTrans('access') ?><br>
+                            <span id="accessHelp" class="form-text">
+                                <?=$this->getTrans('accessEmptyHelp') ?>
+                            </span>
+                        </label>
                         <div class="col-xl-8">
                             <select class="choices-select form-control"
                                     id="access"

--- a/application/modules/downloads/views/admin/index/index.php
+++ b/application/modules/downloads/views/admin/index/index.php
@@ -120,7 +120,7 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj): vo
                 <label for="access" class="col-xl-3 col-form-label">
                     <?=$this->getTrans('access') ?><br>
                     <span id="accessHelp" class="form-text">
-                      <?=$this->getTrans('accessEmptyHelp') ?>
+                        <?=$this->getTrans('accessEmptyHelp') ?>
                     </span>
                 </label>
                 <div class="col-xl-6">

--- a/application/modules/downloads/views/admin/index/index.php
+++ b/application/modules/downloads/views/admin/index/index.php
@@ -117,7 +117,12 @@ function rec(\Modules\Downloads\Models\DownloadsItem $item, \Ilch\View $obj): vo
             </div>
             <div class="dyn"></div>
             <div class="row mb-3">
-                <label for="access" class="col-xl-3 col-form-label"><?=$this->getTrans('access') ?></label>
+                <label for="access" class="col-xl-3 col-form-label">
+                    <?=$this->getTrans('access') ?><br>
+                    <span id="accessHelp" class="form-text">
+                      <?=$this->getTrans('accessEmptyHelp') ?>
+                    </span>
+                </label>
                 <div class="col-xl-6">
                     <select class="choices-select form-control"
                             id="access"


### PR DESCRIPTION
# Description
- Handle no access selection -> means visible to everyone
- Add an info text regarding this to the access selection

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [X] Firefox
- [ ] Opera
- [ ] Edge
