### PR TITLE
Update ci.yaml to run on PHP 8.6 and fix deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.5']
+        php-versions: ['8.1', '8.6']
         mysql-versions: ['5.7', 'latest']
 
     services:
@@ -74,7 +74,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.5']
+        php-versions: ['8.6']
         mariadb-versions: ['10.5', 'latest']
 
     services:

--- a/application/libraries/Captcha/DefaultCaptcha.php
+++ b/application/libraries/Captcha/DefaultCaptcha.php
@@ -16,16 +16,13 @@ class DefaultCaptcha
      *
      * @var string
      */
-    protected $form = '';
+    protected string $form = '';
 
     /**
      * Start Default Captcha.
-     *
-     * @return $this
      */
     public function __construct()
     {
-        return $this;
     }
 
     /**

--- a/application/modules/calendar/mappers/Calendar.php
+++ b/application/modules/calendar/mappers/Calendar.php
@@ -122,10 +122,10 @@ class Calendar extends \Ilch\Mapper
         }
 
         if ($start && $end) {
-            if (!is_a($start, Date::class)) {
+            if (!$start instanceof Date) {
                 $start = new Date($start);
             }
-            if (!is_a($end, Date::class)) {
+            if (!$end instanceof Date) {
                 $end = new Date($end);
             }
             $select = $this->db()->select();

--- a/application/modules/war/config/config.php
+++ b/application/modules/war/config/config.php
@@ -15,7 +15,7 @@ class Config extends Install
 {
     public $config = [
         'key' => 'war',
-        'version' => '1.16.6',
+        'version' => '1.16.7',
         'icon_small' => 'fa-solid fa-shield',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/war/mappers/War.php
+++ b/application/modules/war/mappers/War.php
@@ -117,14 +117,14 @@ class War extends Mapper
      */
     public function getWarById($id): ?EntriesModel
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 
-        $entrys = $this->getEntriesBy(['w.id' => (int)$id], []);
+        $entries = $this->getEntriesBy(['w.id' => (int)$id], []);
 
-        if (!empty($entrys)) {
-            return reset($entrys);
+        if (!empty($entries)) {
+            return reset($entries);
         }
 
         return null;
@@ -145,10 +145,10 @@ class War extends Mapper
         }
 
         if ($start && $end) {
-            if (!is_a($start, Date::class)) {
+            if (!$start instanceof Date) {
                 $start = new Date($start);
             }
-            if (!is_a($end, Date::class)) {
+            if (!$end instanceof Date) {
                 $end = new Date($end);
             }
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="bootstrap.php">
-	<php>
-		<const name="PHPUNIT_TEST" value="true"/>
-	</php>
+<phpunit bootstrap="bootstrap.php"
+         displayDetailsOnAllIssues="true">
+
+    <php>
+        <const name="PHPUNIT_TEST" value="true"/>
+    </php>
 
     <testsuites>
         <testsuite name="libraries">
@@ -12,5 +14,5 @@
             <directory>modules</directory>
         </testsuite>
     </testsuites>
-    
+
 </phpunit>


### PR DESCRIPTION
# Description
- Update ci.yaml to run on PHP 8.6.
- Update phpunit.xml to display all issues (displaydetailsonallissues-attribute).
- Fix "Returning a value from a constructor is deprecated" in DefaultCaptcha.php.
- Fix "Calling is_a() with a string when $allow_string is false" in Calendar Mapper by using instanceof.
- Fix "Calling is_a() with a string when $allow_string is false" in War Mapper by using instanceof.

> PHP 8.6 is the active development branch, expected to be released towards the end of the 2026.

https://www.php.net/manual/en/function.is-a.php
https://www.php.net/manual/en/language.operators.type.php

https://wiki.php.net/rfc/deprecate-return-value-from-construct

https://docs.phpunit.de/en/10.5/configuration.html#the-displaydetailsonallissues-attribute

#1334

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used
