### PR TITLE
War: Fix "Calling is_a() with a string when $allow_string is false"

### DIFF
--- a/application/modules/war/mappers/Accept.php
+++ b/application/modules/war/mappers/Accept.php
@@ -144,7 +144,7 @@ class Accept extends Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 

--- a/application/modules/war/mappers/Enemy.php
+++ b/application/modules/war/mappers/Enemy.php
@@ -98,7 +98,7 @@ class Enemy extends Mapper
      */
     public function getEnemyById($id): ?EntriesModel
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 
@@ -144,7 +144,7 @@ class Enemy extends Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 

--- a/application/modules/war/mappers/Games.php
+++ b/application/modules/war/mappers/Games.php
@@ -121,7 +121,7 @@ class Games extends Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 

--- a/application/modules/war/mappers/Group.php
+++ b/application/modules/war/mappers/Group.php
@@ -98,7 +98,7 @@ class Group extends Mapper
      */
     public function getGroupById($id): ?EntriesModel
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 
@@ -144,7 +144,7 @@ class Group extends Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 

--- a/application/modules/war/mappers/Maps.php
+++ b/application/modules/war/mappers/Maps.php
@@ -98,7 +98,7 @@ class Maps extends Mapper
      */
     public function getEntryById(int $id): ?EntriesModel
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 
@@ -144,7 +144,7 @@ class Maps extends Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 

--- a/application/modules/war/mappers/War.php
+++ b/application/modules/war/mappers/War.php
@@ -257,7 +257,7 @@ class War extends Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 
@@ -391,18 +391,16 @@ class War extends Mapper
     /**
      * Returns the Countdown
      *
-     * @param Date|string $datum
+     * @param Date|string $date
      * @return string
      */
-    public function countdown($datum): string
+    public function countdown($date): string
     {
         $datenow = new Date();
         $datenow = $datenow->format(null, true);
 
-        if (is_a($datum, Date::class)) {
-            $date = $datum;
-        } else {
-            $date = new Date($datum);
+        if (!$date instanceof Date) {
+            $date = new Date($date);
         }
 
         // make a unix timestamp for the given date
@@ -459,7 +457,7 @@ class War extends Mapper
         if ($status !== -1) {
             $statusNow = $status;
         } else {
-            if (is_a($id, EntriesModel::class)) {
+            if ($id instanceof EntriesModel) {
                 $status = $id->getWarStatus();
             } else {
                 $status = (int) $this->db()->select('status')
@@ -475,7 +473,7 @@ class War extends Mapper
                 $statusNow = 1;
             }
         }
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 
@@ -497,7 +495,7 @@ class War extends Mapper
         if ($show !== -1) {
             $showNow = $show;
         } else {
-            if (is_a($id, EntriesModel::class)) {
+            if ($id instanceof EntriesModel) {
                 $show = $id->getShow();
             } else {
                 $show = (int) $this->db()->select('show')
@@ -513,7 +511,7 @@ class War extends Mapper
                 $showNow = 1;
             }
         }
-        if (is_a($id, EntriesModel::class)) {
+        if ($id instanceof EntriesModel) {
             $id = $id->getId();
         }
 


### PR DESCRIPTION
# Description
- War: Fix "Calling is_a() with a string when $allow_string is false" by using instanceof (PHP 8.6).

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

Optionally add a `Co-authored-by:` trailer if an AI tool substantially contributed. The contributor remains fully responsible for the content.

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
