### PR TITLE
Calendar: Fix "Calling is_a() with a string when $allow_string is false"

### DIFF
--- a/application/modules/calendar/mappers/Calendar.php
+++ b/application/modules/calendar/mappers/Calendar.php
@@ -94,7 +94,7 @@ class Calendar extends \Ilch\Mapper
      */
     public function getCalendarById($id): ?EntryModel
     {
-        if (is_a($id, EntryModel::class)) {
+        if ($id instanceof EntryModel) {
             $id = $id->getId();
         }
 
@@ -235,7 +235,7 @@ class Calendar extends \Ilch\Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, EntryModel::class)) {
+        if ($id instanceof EntryModel) {
             $id = $id->getId();
         }
 

--- a/application/modules/calendar/mappers/Events.php
+++ b/application/modules/calendar/mappers/Events.php
@@ -84,7 +84,7 @@ class Events extends \Ilch\Mapper
      */
     public function getEntryById(int $id): ?EntryModel
     {
-        if (is_a($id, EntryModel::class)) {
+        if ($id instanceof EntryModel) {
             $id = $id->getId();
         }
 
@@ -128,7 +128,7 @@ class Events extends \Ilch\Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, EntryModel::class)) {
+        if ($id instanceof EntryModel) {
             $id = $id->getId();
         }
 


### PR DESCRIPTION
# Description
- Fix "Calling is_a() with a string when $allow_string is false"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
