### PR TITLE
Gallery: Fix "Calling is_a() with a string when $allow_string is false"

### DIFF
--- a/application/modules/gallery/mappers/Gallery.php
+++ b/application/modules/gallery/mappers/Gallery.php
@@ -148,7 +148,7 @@ class Gallery extends Mapper
      */
     public function sort($id, int $pos, int $parent): bool
     {
-        if (is_a($id, GalleryItem::class)) {
+        if ($id instanceof GalleryItem) {
             $id = $id->getId();
         }
 
@@ -166,7 +166,7 @@ class Gallery extends Mapper
      */
     public function deleteItem($id): bool
     {
-        if (is_a($id, GalleryItem::class)) {
+        if ($id instanceof GalleryItem) {
             $id = $id->getId();
         }
 


### PR DESCRIPTION
# Description
- Fix "Calling is_a() with a string when $allow_string is false"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
