### PR TITLE
User: Fix "Calling is_a() with a string when $allow_string is false"

### DIFF
--- a/application/modules/user/mappers/Group.php
+++ b/application/modules/user/mappers/Group.php
@@ -190,7 +190,7 @@ class Group extends \Ilch\Mapper
      */
     public function delete($groupId): bool
     {
-        if (is_a($groupId, GroupModel::class)) {
+        if ($groupId instanceof GroupModel) {
             $groupId = $groupId->getId();
         }
 

--- a/application/modules/user/mappers/User.php
+++ b/application/modules/user/mappers/User.php
@@ -530,7 +530,7 @@ class User extends \Ilch\Mapper
      */
     public function selectsdelete($userId, $deletedate = '1000-01-01 00:00:00'): int
     {
-        if (is_a($userId, UserModel::class)) {
+        if ($userId instanceof UserModel) {
             $userId = $userId->getId();
         }
 
@@ -575,7 +575,7 @@ class User extends \Ilch\Mapper
      */
     public function delete($userId): bool
     {
-        if (is_a($userId, UserModel::class)) {
+        if ($userId instanceof UserModel) {
             $userId = $userId->getId();
         }
 


### PR DESCRIPTION
# Description
- Fix "Calling is_a() with a string when $allow_string is false"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
