### PR TITLE
QueryBuilder: Fix "Calling is_a() with a string when $allow_string is false"

### DIFF
--- a/application/libraries/Ilch/Database/Mysql/QueryBuilder.php
+++ b/application/libraries/Ilch/Database/Mysql/QueryBuilder.php
@@ -176,7 +176,7 @@ abstract class QueryBuilder
     {
         $oppositeType = $type === 'and' ? 'or' : 'and';
         // add to existing or
-        if (is_a($this->where, __NAMESPACE__ . '\Expression\\' . ucfirst($type) . 'X')) {
+        if (is_a($this->where, __NAMESPACE__ . '\Expression\\' . ucfirst($type) . 'X', true)) {
             if (\is_array($where)) {
                 $this->where->addParts($this->createCompositePartArray($where));
             } elseif ($where instanceof Expression\CompositePart) {
@@ -188,7 +188,7 @@ abstract class QueryBuilder
         }
 
         // new or insert existing where into condition
-        if (is_a($this->where, __NAMESPACE__ . '\Expression\\' . ucfirst($oppositeType) . 'X')) {
+        if (is_a($this->where, __NAMESPACE__ . '\Expression\\' . ucfirst($oppositeType) . 'X', true)) {
             if (!\is_array($where)) {
                 $where = [$where];
             }


### PR DESCRIPTION
# Description
- QueryBuilder: Fix "Calling is_a() with a string when $allow_string is false" by passing true for $allow_string

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
