### PR TITLE
Teams: Fix "Calling is_a() with a string when $allow_string is false"

### DIFF
--- a/application/modules/teams/config/config.php
+++ b/application/modules/teams/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'teams',
-        'version' => '1.25.2',
+        'version' => '1.25.3',
         'icon_small' => 'fa-solid fa-users',
         'author' => 'Veldscholten, Kevin',
         'link' => 'https://ilch.de',

--- a/application/modules/teams/mappers/Joins.php
+++ b/application/modules/teams/mappers/Joins.php
@@ -7,6 +7,7 @@
 
 namespace Modules\Teams\Mappers;
 
+use Ilch\Date;
 use Modules\Teams\Models\Joins as JoinsModel;
 
 class Joins extends \Ilch\Mapper
@@ -80,7 +81,7 @@ class Joins extends \Ilch\Mapper
      */
     public function getEntryById($id): ?JoinsModel
     {
-        if (is_a($id, JoinsModel::class)) {
+        if ($id instanceof JoinsModel) {
             $id = $id->getId();
         }
 
@@ -148,7 +149,7 @@ class Joins extends \Ilch\Mapper
      */
     public function getJoinInHistoryById($id): ?JoinsModel
     {
-        if (is_a($id, JoinsModel::class)) {
+        if ($id instanceof JoinsModel) {
             $id = $id->getId();
         }
 
@@ -181,8 +182,8 @@ class Joins extends \Ilch\Mapper
      */
     public function getAge($date): int
     {
-        if (!is_a($date, \ilch\Date::class)) {
-            $date = new \ilch\Date($date);
+        if (!$date instanceof Date) {
+            $date = new Date($date);
         }
 
         return (int)(substr(date('Ymd') - date('Ymd', strtotime($date)), 0, -4));
@@ -198,7 +199,7 @@ class Joins extends \Ilch\Mapper
      */
     public function updateDecision($id, int $decision): bool
     {
-        if (is_a($id, JoinsModel::class)) {
+        if ($id instanceof JoinsModel) {
             $id = $id->getId();
         }
 
@@ -239,7 +240,7 @@ class Joins extends \Ilch\Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, JoinsModel::class)) {
+        if ($id instanceof JoinsModel) {
             $id = $id->getId();
         }
 

--- a/application/modules/teams/mappers/Teams.php
+++ b/application/modules/teams/mappers/Teams.php
@@ -80,7 +80,7 @@ class Teams extends \Ilch\Mapper
      */
     public function getEntryById($id): ?TeamsModel
     {
-        if (is_a($id, TeamsModel::class)) {
+        if ($id instanceof TeamsModel) {
             $id = $id->getId();
         }
 
@@ -123,7 +123,7 @@ class Teams extends \Ilch\Mapper
      */
     public function getTeamByGroupId($groupId): ?TeamsModel
     {
-        if (is_a($groupId, TeamsModel::class)) {
+        if ($groupId instanceof TeamsModel) {
             $groupId = $groupId->getGroupId();
         }
 
@@ -145,7 +145,7 @@ class Teams extends \Ilch\Mapper
      */
     public function delImageById($id, bool $noUpdate = false): bool
     {
-        if (is_a($id, TeamsModel::class)) {
+        if ($id instanceof TeamsModel) {
             $entry = $id;
         } else {
             $entry = $this->getTeamById($id);
@@ -176,7 +176,7 @@ class Teams extends \Ilch\Mapper
      */
     public function sort($id, int $pos): bool
     {
-        if (is_a($id, TeamsModel::class)) {
+        if ($id instanceof TeamsModel) {
             $id = $id->getId();
         }
 
@@ -196,7 +196,7 @@ class Teams extends \Ilch\Mapper
         if ($show !== -1) {
             $showNow = $show;
         } else {
-            if (is_a($id, TeamsModel::class)) {
+            if ($id instanceof TeamsModel) {
                 $show = $id->getOptShow();
             } else {
                 $show = (int) $this->db()->select('a.optShow')
@@ -212,7 +212,7 @@ class Teams extends \Ilch\Mapper
                 $showNow = 1;
             }
         }
-        if (is_a($id, TeamsModel::class)) {
+        if ($id instanceof TeamsModel) {
             $id = $id->getId();
         }
 
@@ -253,7 +253,7 @@ class Teams extends \Ilch\Mapper
      */
     public function delete($id): bool
     {
-        if (is_a($id, TeamsModel::class)) {
+        if ($id instanceof TeamsModel) {
             $entry = $id;
         } else {
             $entry = $this->getTeamById($id);


### PR DESCRIPTION
# Description
- Fix "Calling is_a() with a string when $allow_string is false"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
