### PR TITLE
Guestbook: Fix "Calling is_a() with a string when $allow_string is false"

### DIFF
--- a/application/modules/guestbook/config/config.php
+++ b/application/modules/guestbook/config/config.php
@@ -13,7 +13,7 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'guestbook',
-        'version' => '1.14.4',
+        'version' => '1.14.5',
         'icon_small' => 'fa-solid fa-book',
         'author' => 'Stantin, Thomas',
         'link' => 'https://ilch.de',

--- a/application/modules/guestbook/mappers/Guestbook.php
+++ b/application/modules/guestbook/mappers/Guestbook.php
@@ -85,7 +85,7 @@ class Guestbook extends \Ilch\Mapper
         if ($setfree !== -1) {
             $setfreeNow = $setfree;
         } else {
-            if (is_a($id, GuestbookModel::class)) {
+            if ($id instanceof GuestbookModel) {
                 $setfree = $id->getFree();
             } else {
                 $setfree = (int) $this->db()->select('setfree')
@@ -101,7 +101,7 @@ class Guestbook extends \Ilch\Mapper
                 $setfreeNow = 1;
             }
         }
-        if (is_a($id, GuestbookModel::class)) {
+        if ($id instanceof GuestbookModel) {
             $id = $id->getId();
         }
 


### PR DESCRIPTION
# Description
- Fix "Calling is_a() with a string when $allow_string is fa…lse"

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

# This PR has been tested in the following browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Opera
- [ ] Edge
