### PR TITLE
Calendar: Remove old fullcalendar on update

### DIFF
--- a/application/modules/calendar/config/config.php
+++ b/application/modules/calendar/config/config.php
@@ -267,6 +267,9 @@ class Config extends \Ilch\Config\Install
                 removeDir(APPLICATION_PATH . '/modules/calendar/static/js/fullcalendar-6.1.17/');
                 // no break
             case "1.11.7":
+                // Remove old version of fullcalendar as this version comes with version 7.1.0.
+                removeDir(APPLICATION_PATH . '/modules/calendar/static/js/fullcalendar-7.0.0/');
+                // no break
         }
 
         return '"' . $this->config['key'] . '" Update-function executed.';


### PR DESCRIPTION
# Description
- Remove old fullcalendar on update

#1477 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## AI usage disclosure
- [X] No AI assistance used

